### PR TITLE
fix: use the temporary image

### DIFF
--- a/samples/deploy/deployment/ingress-controller.yaml
+++ b/samples/deploy/deployment/ingress-controller.yaml
@@ -43,7 +43,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: apisix-config
-        image: ???/???/ingress-controller:???
+        image: viewking/apisix-ingress-controller:dev
         imagePullPolicy: IfNotPresent
         name: ingress-controller
         ports:


### PR DESCRIPTION
Closing https://github.com/apache/apisix-ingress-controller/issues/55.

We will use this image until we release the 0.1.0 version.