### PR TITLE
chore: change default resync period to 6 hours

### DIFF
--- a/conf/config-default.json
+++ b/conf/config-default.json
@@ -5,7 +5,7 @@
   "enable_profiling": true,
   "kubernetes": {
     "kubeconfig": "",
-    "resync_interval": "60s"
+    "resync_interval": "6h"
   },
   "apisix": {
     "base_url": "http://127.0.0.1:9080/apisix/admin"

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -35,8 +35,8 @@ enable_profiling: true # enable profileing via web interfaces
 kubernetes:
   kubeconfig: ""         # the Kubernetes configuration file path, default is
                          # "", so the in-cluster configuration will be used.
-  resync_interval: "60s" # how long should apisix-ingress-controller
-                         # re-synchronizes with Kubernetes, default is 60s,
+  resync_interval: "6h" # how long should apisix-ingress-controller
+                         # re-synchronizes with Kubernetes, default is 6h,
                          # and the minimal resync interval is 30s.
 
 # APISIX related configurations.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/api7/ingress-controller/pkg/types"
 	"gopkg.in/yaml.v2"
+
+	"github.com/api7/ingress-controller/pkg/types"
 )
 
 const (
@@ -63,7 +64,7 @@ func NewDefaultConfig() *Config {
 		EnableProfiling: true,
 		Kubernetes: KubernetesConfig{
 			Kubeconfig:     "", // Use in-cluster configurations.
-			ResyncInterval: types.TimeDuration{time.Minute},
+			ResyncInterval: types.TimeDuration{6 * time.Hour},
 		},
 	}
 }

--- a/samples/deploy/configmap/apisix-ingress-cm.yaml
+++ b/samples/deploy/configmap/apisix-ingress-cm.yaml
@@ -40,8 +40,8 @@ data:
    kubernetes:
      kubeconfig: ""         # the Kubernetes configuration file path, default is
                             # "", so the in-cluster configuration will be used.
-     resync_interval: "60s" # how long should apisix-ingress-controller
-                            # re-synchronizes with Kubernetes, default is 60s,
+     resync_interval: "6h" # how long should apisix-ingress-controller
+                            # re-synchronizes with Kubernetes, default is 6h,
                             # and the minimal resync interval is 30s.
 
    # APISIX related configurations.


### PR DESCRIPTION
As Resync has been set, change the default value to 6 hours.