### PR TITLE
chore: namespaces filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ e2e-test:
 	export APISIX_UPSTREAM_DEF=$(PWD)/samples/deploy/crd/v1beta1/ApisixUpstream.yaml && \
 	export APISIX_SERVICE_DEF=$(PWD)/samples/deploy/crd/v1beta1/ApisixService.yaml && \
 	export APISIX_TLS_DEF=$(PWD)/samples/deploy/crd/v1beta1/ApisixTls.yaml && \
-	cd test/e2e && ginkgo -cover -coverprofile=coverage.txt -r --randomizeSuites --randomizeAllSpecs --trace -p --nodes=1
+	cd test/e2e && ginkgo -cover -coverprofile=coverage.txt -r --randomizeSuites --randomizeAllSpecs --trace -p
 
 ### license-check:    Do Apache License Header check
 license-check:

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,10 @@ e2e-test: build-image-to-minikube
 	export APISIX_UPSTREAM_DEF=$(PWD)/samples/deploy/crd/v1beta1/ApisixUpstream.yaml && \
 	export APISIX_SERVICE_DEF=$(PWD)/samples/deploy/crd/v1beta1/ApisixService.yaml && \
 	export APISIX_TLS_DEF=$(PWD)/samples/deploy/crd/v1beta1/ApisixTls.yaml && \
-	cd test/e2e && ginkgo -cover -coverprofile=coverage.txt -r --randomizeSuites --randomizeAllSpecs --trace -p --nodes=4
+	cd test/e2e && ginkgo -cover -coverprofile=coverage.txt -r --randomizeSuites --randomizeAllSpecs --trace -p --nodes=1
 
+# build images to minikube node directly, it's an internal directive, so don't
+# expose it's help message.
 build-image-to-minikube:
 	@minikube version > /dev/null 2>&1 || (echo "ERROR: minikube is required."; exit 1)
 	@eval $$(minikube docker-env);\

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -82,6 +82,10 @@ the apisix cluster and others are created`,
 				}
 				cfg = c
 			}
+			if err := cfg.Validate(); err != nil {
+				dief("bad configuration: %s", err)
+			}
+
 			logger, err := log.NewLogger(
 				log.WithLogLevel(cfg.LogLevel),
 				log.WithOutputFile(cfg.LogOutput),
@@ -121,6 +125,7 @@ the apisix cluster and others are created`,
 	cmd.PersistentFlags().BoolVar(&cfg.EnableProfiling, "enable-profiling", true, "enable profiling via web interface host:port/debug/pprof")
 	cmd.PersistentFlags().StringVar(&cfg.Kubernetes.Kubeconfig, "kubeconfig", "", "Kubernetes configuration file (by default in-cluster configuration will be used)")
 	cmd.PersistentFlags().DurationVar(&cfg.Kubernetes.ResyncInterval.Duration, "resync-interval", time.Minute, "the controller resync (with Kubernetes) interval, the minimum resync interval is 30s")
+	cmd.PersistentFlags().StringSliceVar(&cfg.Kubernetes.AppNamespaces, "app-namespace", []string{config.NamespaceAll}, "namespaces that controller will watch for resources")
 	cmd.PersistentFlags().StringVar(&cfg.APISIX.BaseURL, "apisix-base-url", "", "the base URL for APISIX admin api / manager api")
 	cmd.PersistentFlags().StringVar(&cfg.APISIX.AdminKey, "apisix-admin-key", "", "admin key used for the authorization of APISIX admin api / manager api")
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -38,6 +38,8 @@ kubernetes:
   resync_interval: "6h" # how long should apisix-ingress-controller
                          # re-synchronizes with Kubernetes, default is 6h,
                          # and the minimal resync interval is 30s.
+  app_namespaces: ["*"]  # namespace list that controller will watch for resources,
+                         # by default all namespaces (represented by "*") are watched.
 
 # APISIX related configurations.
 apisix:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -35,6 +35,7 @@ func TestNewConfigFromFile(t *testing.T) {
 		Kubernetes: KubernetesConfig{
 			ResyncInterval: types.TimeDuration{time.Hour},
 			Kubeconfig:     "/path/to/foo/baz",
+			AppNamespaces:  []string{""},
 		},
 		APISIX: APISIXConfig{
 			BaseURL:  "http://127.0.0.1:8080/apisix",

--- a/test/e2e/ingress/namespace.go
+++ b/test/e2e/ingress/namespace.go
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/api7/ingress-controller/test/e2e/scaffold"
+	"github.com/onsi/ginkgo"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ = ginkgo.Describe("namespacing filtering", func() {
+	s := scaffold.NewDefaultScaffold()
+	ginkgo.It("resources in other namespaces should be ignored", func() {
+		backendSvc, backendSvcPort := s.DefaultHTTPBackend()
+		route := fmt.Sprintf(`
+apiVersion: apisix.apache.org/v1
+kind: ApisixRoute
+metadata:
+  name: httpbin-route
+spec:
+  rules:
+  - host: httpbin.com
+    http:
+      paths:
+      - backend:
+          serviceName: %s
+          servicePort: %d
+        path: /ip
+`, backendSvc, backendSvcPort[0])
+
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(route), "creating ApisixRoute")
+		assert.Nil(ginkgo.GinkgoT(), s.EnsureNumApisixRoutesCreated(1), "checking number of routes")
+		assert.Nil(ginkgo.GinkgoT(), s.EnsureNumApisixUpstreamsCreated(1), "checking number of upstreams")
+
+		body := s.NewAPISIXClient().GET("/ip").WithHeader("Host", "httpbin.com").Expect().Status(http.StatusOK).Body().Raw()
+		var placeholder ip
+		err := json.Unmarshal([]byte(body), &placeholder)
+		assert.Nil(ginkgo.GinkgoT(), err, "unmarshalling IP")
+
+		// Now create another ApisixRoute in default namespace.
+		route = fmt.Sprintf(`
+apiVersion: apisix.apache.org/v1
+kind: ApisixRoute
+metadata:
+ name: httpbin-route
+spec:
+ rules:
+ - host: httpbin.com
+   http:
+     paths:
+     - backend:
+         serviceName: %s
+         servicePort: %d
+       path: /headers
+`, backendSvc, backendSvcPort[0])
+
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(route, "default"), "creating ApisixRoute")
+		_ = s.NewAPISIXClient().GET("/headers").WithHeader("Host", "httpbin.com").Expect().Status(http.StatusNotFound)
+	})
+})

--- a/test/e2e/ingress/resourcepushing.go
+++ b/test/e2e/ingress/resourcepushing.go
@@ -39,8 +39,8 @@ spec:
    http:
      paths:
      - backend:
-         serviceName: httpbin-service-e2e-test
-         servicePort: 80
+         serviceName: %s
+         servicePort: %d
        path: /ip
 `, backendSvc, backendSvcPort[0])
 		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(apisixRoute))
@@ -52,7 +52,7 @@ spec:
 		scale := 2
 		err = s.ScaleHTTPBIN(scale)
 		assert.Nil(ginkgo.GinkgoT(), err)
-		time.Sleep(10 * time.Second) // wait for ingress to sync
+		time.Sleep(5 * time.Second) // wait for ingress to sync
 		ups, err := s.ListApisixUpstreams()
 		assert.Nil(ginkgo.GinkgoT(), err, "list upstreams error")
 		assert.Len(ginkgo.GinkgoT(), ups[0].Nodes, 2, "upstreams nodes not expect")
@@ -83,10 +83,10 @@ spec:
 		assert.Nil(ginkgo.GinkgoT(), err, "Checking number of upstreams")
 
 		// remove
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(apisixRoute))
-		time.Sleep(5 * time.Second) // wait for ingress to sync
+		assert.Nil(ginkgo.GinkgoT(), s.RemoveResourceByString(apisixRoute))
+		time.Sleep(10 * time.Second) // wait for ingress to sync
 		ups, err := s.ListApisixUpstreams()
 		assert.Nil(ginkgo.GinkgoT(), err, "list upstreams error")
-		assert.Len(ginkgo.GinkgoT(), len(ups), 0, "upstreams nodes not expect")
+		assert.Len(ginkgo.GinkgoT(), ups, 0, "upstreams nodes not expect")
 	})
 })

--- a/test/e2e/ingress/resourcepushing.go
+++ b/test/e2e/ingress/resourcepushing.go
@@ -15,6 +15,7 @@
 package ingress
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -26,7 +27,8 @@ import (
 var _ = ginkgo.Describe("ApisixRoute Testing", func() {
 	s := scaffold.NewDefaultScaffold()
 	ginkgo.It("create and then scale upstream pods to 2 ", func() {
-		apisixRoute := `
+		backendSvc, backendSvcPort := s.DefaultHTTPBackend()
+		apisixRoute := fmt.Sprintf(`
 apiVersion: apisix.apache.org/v1
 kind: ApisixRoute
 metadata:
@@ -40,8 +42,8 @@ spec:
          serviceName: httpbin-service-e2e-test
          servicePort: 80
        path: /ip
-`
-		s.CreateApisixRouteByString(apisixRoute)
+`, backendSvc, backendSvcPort[0])
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(apisixRoute))
 
 		err := s.EnsureNumApisixRoutesCreated(1)
 		assert.Nil(ginkgo.GinkgoT(), err, "Checking number of routes")
@@ -56,8 +58,9 @@ spec:
 		assert.Len(ginkgo.GinkgoT(), ups[0].Nodes, 2, "upstreams nodes not expect")
 	})
 
-	ginkgo.It("create and then remove ", func() {
-		apisixRoute := `
+	ginkgo.It("create and then remove", func() {
+		backendSvc, backendSvcPort := s.DefaultHTTPBackend()
+		apisixRoute := fmt.Sprintf(`
 apiVersion: apisix.apache.org/v1
 kind: ApisixRoute
 metadata:
@@ -68,24 +71,21 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: httpbin-service-e2e-test
-          servicePort: 80
+          serviceName: %s
+          servicePort: %d
         path: /ip
-`
-		s.CreateApisixRouteByString(apisixRoute)
+`, backendSvc, backendSvcPort[0])
 
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(apisixRoute), "creating ApisixRoute")
 		err := s.EnsureNumApisixRoutesCreated(1)
 		assert.Nil(ginkgo.GinkgoT(), err, "Checking number of routes")
 		err = s.EnsureNumApisixUpstreamsCreated(1)
 		assert.Nil(ginkgo.GinkgoT(), err, "Checking number of upstreams")
-		ups, err := s.ListApisixUpstreams()
-		assert.Nil(ginkgo.GinkgoT(), err, "list upstreams error")
-		assert.Len(ginkgo.GinkgoT(), ups[0].Nodes, 1, "upstreams nodes not expect")
 
 		// remove
-		s.CreateApisixRouteByString(apisixRoute)
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(apisixRoute))
 		time.Sleep(5 * time.Second) // wait for ingress to sync
-		ups, err = s.ListApisixUpstreams()
+		ups, err := s.ListApisixUpstreams()
 		assert.Nil(ginkgo.GinkgoT(), err, "list upstreams error")
 		assert.Len(ginkgo.GinkgoT(), len(ups), 0, "upstreams nodes not expect")
 	})

--- a/test/e2e/scaffold/ingress.go
+++ b/test/e2e/scaffold/ingress.go
@@ -78,7 +78,7 @@ spec:
               port: 8080
             timeoutSeconds: 2
           image: "apache/apisix-ingress-controller:dev"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           name: ingress-apisix-controller-deployment-e2e-test
           ports:
             - containerPort: 8080

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -133,14 +133,6 @@ func (s *Scaffold) NewAPISIXClient() *httpexpect.Expect {
 	})
 }
 
-func (s *Scaffold) BeforeEach() {
-	s.beforeEach()
-}
-
-func (s *Scaffold) AfterEach() {
-	s.afterEach()
-}
-
 func (s *Scaffold) beforeEach() {
 	var err error
 	s.namespace = fmt.Sprintf("ingress-apisix-e2e-tests-%s-%d", s.opts.Name, time.Now().Nanosecond())
@@ -157,7 +149,6 @@ func (s *Scaffold) beforeEach() {
 	assert.Nil(s.t, err, "initializing etcd")
 
 	// We don't use k8s.WaitUntilServiceAvailable since it hacks for Minikube.
-	//err = s.waitAllEtcdPodsAvailable()
 	err = k8s.WaitUntilNumPodsCreatedE(s.t, s.kubectlOptions, s.labelSelector("app=etcd-deployment-e2e-test"), 1, 5, 2*time.Second)
 	assert.Nil(s.t, err, "waiting for etcd ready")
 


### PR DESCRIPTION
Support to filter namespaces by specifying `--app-namespace` (multiple times if necessary) or adding `app_namespace` in configuration file. By default all namespaces will be watched.

What's more, after this PR is merged, e2e test cases can be run in parallel.

Closing #139 