### PR TITLE
fix: broken e2e test case

### DIFF
--- a/test/e2e/endpoints/endpoints.go
+++ b/test/e2e/endpoints/endpoints.go
@@ -69,6 +69,6 @@ spec:
 		// Now delete the backend httpbin service resource.
 		assert.Nil(ginkgo.GinkgoT(), s.DeleteHTTPBINService())
 		time.Sleep(3 * time.Second)
-		s.NewAPISIXClient().GET("/ip").WithHeader("Host", "httpbin.com").Expect().Status(http.StatusBadGateway)
+		s.NewAPISIXClient().GET("/ip").WithHeader("Host", "httpbin.com").Expect().Status(http.StatusServiceUnavailable)
 	})
 })


### PR DESCRIPTION
The image apache/apisix:dev was updated these two days, the status code when upstream is not available was changed from 502 to 503, so the e2e case should also be adjusted.