### PR TITLE
fix: skip ErrDuplicatedCluster when rebecame leader

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -281,7 +281,7 @@ func (c *Controller) run(ctx context.Context) {
 		AdminKey: c.cfg.APISIX.AdminKey,
 		BaseURL:  c.cfg.APISIX.BaseURL,
 	})
-	if err != nil {
+	if err != nil && err != apisix.ErrDuplicatedCluster {
 		// TODO give up the leader role.
 		log.Errorf("failed to add default cluster: %s", err)
 		return


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
  - [x] Bugfix

- Related issues

___
### Bugfix
- Description

Start two controller, A first became leader and add cluster, and B later became leader,
then B stop and A became leader again, this time A will can not working because of add duplicated cluster.

- How to fix?

Skip ErrDuplicatedCluster when rebecame leader.

