### PR TITLE
fix: exprs field escapes to other route rules defined in the same ApisixRoute object

### DIFF
--- a/pkg/kube/translation/apisix_route.go
+++ b/pkg/kube/translation/apisix_route.go
@@ -95,7 +95,6 @@ func (t *translator) TranslateRouteV1(ar *configv1.ApisixRoute) ([]*apisixv1.Rou
 
 func (t *translator) TranslateRouteV2alpha1(ar *configv2alpha1.ApisixRoute) ([]*apisixv1.Route, []*apisixv1.Upstream, error) {
 	var (
-		vars      [][]apisixv1.StringOrSlice
 		routes    []*apisixv1.Route
 		upstreams []*apisixv1.Upstream
 	)
@@ -146,8 +145,9 @@ func (t *translator) TranslateRouteV2alpha1(ar *configv2alpha1.ApisixRoute) ([]*
 				pluginMap[plugin.Name] = make(map[string]interface{})
 			}
 		}
+		var exprs [][]apisixv1.StringOrSlice
 		if part.Match.NginxVars != nil {
-			vars, err = t.translateRouteMatchExprs(part.Match.NginxVars)
+			exprs, err = t.translateRouteMatchExprs(part.Match.NginxVars)
 			if err != nil {
 				log.Errorw("ApisixRoute with bad nginxVars",
 					zap.Error(err),
@@ -167,7 +167,7 @@ func (t *translator) TranslateRouteV2alpha1(ar *configv2alpha1.ApisixRoute) ([]*
 				ID:              id.GenID(routeName),
 				ResourceVersion: ar.ResourceVersion,
 			},
-			Vars:         vars,
+			Vars:         exprs,
 			Hosts:        part.Match.Hosts,
 			Uris:         part.Match.Paths,
 			Methods:      part.Match.Methods,


### PR DESCRIPTION

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
https://github.com/apache/apisix-ingress-controller/issues/322

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

___
### Backport patches
- Why need to backport?

- Source branch

- Related commits and pull requests

- Target branch
