### PR TITLE
fix: correctly handle ingress in extensions/v1beta1 version

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -16,6 +16,7 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -91,10 +92,16 @@ func (c *ingressController) sync(ctx context.Context, ev *types.Event) error {
 	}
 
 	var ing kube.Ingress
-	if ingEv.GroupVersion == kube.IngressV1 {
+	switch ingEv.GroupVersion {
+	case kube.IngressV1:
 		ing, err = c.controller.ingressLister.V1(namespace, name)
-	} else {
+	case kube.IngressV1beta1:
 		ing, err = c.controller.ingressLister.V1beta1(namespace, name)
+	case kube.IngressExtensionsV1beta1:
+		ing, err = c.controller.ingressLister.ExtensionsV1beta1(namespace, name)
+	default:
+		err = fmt.Errorf("unsupported group version %s, one of (%s/%s/%s) is expected", ingEv.GroupVersion,
+			kube.IngressV1, kube.IngressV1beta1, kube.IngressExtensionsV1beta1)
 	}
 
 	if err != nil {


### PR DESCRIPTION
get extensions/v1beta1 object when group version is extensions/v1beta1

fix: #365

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix

- Related issues

#365 
___
### Bugfix
- Description

get extensions/v1beta1 object via networking/v1beta1 interface, it's of course not found

- How to fix?

handle ingress in extensions/v1beta1 correctly
