### PR TITLE
chore: optimize log message when the endpoint does not have a corresponding service

### DIFF
--- a/pkg/ingress/endpoint.go
+++ b/pkg/ingress/endpoint.go
@@ -90,7 +90,7 @@ func (c *endpointsController) sync(ctx context.Context, ev *types.Event) error {
 	svc, err := c.controller.svcLister.Services(ep.Namespace).Get(ep.Name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.Warnf("service %s/%s was deleted", ep.Namespace, ep.Name)
+			log.Infof("service %s/%s not found", ep.Namespace, ep.Name)
 			return nil
 		}
 		log.Errorf("failed to get service %s/%s: %s", ep.Namespace, ep.Name, err)


### PR DESCRIPTION
- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Some endpoints doesn't have corresponding services, currently endpoint controller will log massive warning continuously
