### PR TITLE
ci: cancel duplicate workflow to reduce CI queue time

### DIFF
--- a/.github/workflows/cancel-workflow.yml
+++ b/.github/workflows/cancel-workflow.yml
@@ -1,0 +1,24 @@
+name: Cancelling Duplicates
+on:
+  workflow_run:
+    workflows:
+      - 'e2e-test-ci'
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/cancel-workflow-runs
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          skipEventTypes: '["push"]'

--- a/.github/workflows/cancel-workflow.yml
+++ b/.github/workflows/cancel-workflow.yml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 name: Cancelling Duplicates
 on:
   workflow_run:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 [submodule ".github/actions/gitleaks-action"]
 	path = .github/actions/gitleaks-action
 	url = https://github.com/zricethezav/gitleaks-action

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".github/actions/gitleaks-action"]
+	path = .github/actions/gitleaks-action
+	url = https://github.com/zricethezav/gitleaks-action


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

The Github Actions - cancel workflow have already been applied in apisix and dashboard, and it works well, so try to also import it here.

> We always wait for CI queue time, and we always trying to reduce waiting time. Here is another method to achieve it.
> 
> The method is that whenever a new commit added to PR, the previous running CI could be canceled since it is of no use. This could be achieved by using Github API, find the workflow on the same branch but with different SHA. And we could achieve this with [potiuk/cancel-workflow-runs](https://github.com/potiuk/cancel-workflow-runs) which is also [used in Apache Airflow](https://github.com/apache/airflow/blob/master/.github/workflows/build-images-workflow-run.yml).
> 
> To bypass the limit of third party Actions, [the recommendation provided by Apache Infra](https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+status#GitHubActionsstatus-Security) is to use submodules.
> 
> Since the "cancel" workflow could only be triggered after merged, so I could not test it in this PR. Thus I duplicate the same situation in my own repo, and it works as expect. See https://github.com/Yiyiyimu/GithubActionsTest/pull/5 you could find previous running workflow got cancelled when a new one coming in. Also see https://github.com/Yiyiyimu/GithubActionsTest/runs/2344066993?check_suite_focus=true for cancellation detail.check_suite_focus=true for cancellation detail.