### PR TITLE
ci: use concurrency to cancel workflow

### DIFF
--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -25,6 +25,12 @@ on:
   pull_request:
     branches:
       - master
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -26,7 +26,6 @@ on:
     branches:
       - master
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-[submodule ".github/actions/cancel-workflow-runs"]
-	path = .github/actions/cancel-workflow-runs
-	url = https://github.com/potiuk/cancel-workflow-runs
 [submodule ".github/actions/paths-filter"]
 	path = .github/actions/paths-filter
 	url = https://github.com/dorny/paths-filter.git


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

Ref: https://github.com/apache/apisix/issues/4341

Use github official argument to cancel duplicate workflows, to replace deprecated `cancel-workflow-runs`.

Tested for push and PR from [original repo](https://github.com/Yiyiyimu/GithubActionsTest/pull/8) and [forked repo](https://github.com/Yiyiyimu/GithubActionsTest/pull/9)