### PR TITLE
chore: update default version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #
 default: help
 
-VERSION ?= 0.6.0
+VERSION ?= 1.0.0
 RELEASE_SRC = apache-apisix-ingress-controller-${VERSION}-src
 LOCAL_REGISTRY="localhost:5000"
 IMAGE_TAG ?= dev


### PR DESCRIPTION
* Why submit this pull request?
To keep the default version of apisix-ingress-controller in Makefile up-to-date (1.0.0).

* Related issues
#553