### PR TITLE
fix: update config of installation by Kustomize

### DIFF
--- a/samples/deploy/configmap/apisix-ingress-cm.yaml
+++ b/samples/deploy/configmap/apisix-ingress-cm.yaml
@@ -46,8 +46,9 @@ data:
 
    # APISIX related configurations.
    apisix:
-     base_url: "http://127.0.0.1:9080/apisix/admin" # the APISIX admin api / manager api
+     base_url: "http://apisix-admin:9180/apisix/admin" # the APISIX admin api / manager api
                                               # base url, it's required.
+     admin_key: "edd1c9f034335f136f87ad84b625c8f1"
 kind: ConfigMap
 metadata:
   name: apisix-ingress-cm

--- a/samples/deploy/deployment/ingress-controller.yaml
+++ b/samples/deploy/deployment/ingress-controller.yaml
@@ -41,7 +41,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-      - image: apache/apisix-ingress-controller:0.1.0
+      - image: apache/apisix-ingress-controller:1.0.0
         imagePullPolicy: IfNotPresent
         name: ingress-controller
         ports:


### PR DESCRIPTION
- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
Installation by Kustomize is not working unless correct configuration of several parameters. The default value of `apisix.base_url` is not a correct APISIX Admin adress. Also, `apisix.admin_key` is missing so that one would get _401 Authorization Required_ error when invoking APISIX Admin API.

- How to fix?
Update default values in config file to make the installation of apisix-ingress-controller by Kustomize ready to use.
    * update the default version of apisix-ingress-controller container image to keep it up-to-date
    * update `apisix.base_url` to send requests to the correct APISIX address
    * add `apisix.admin_key` to configure APISIX Admin API access token. This avoids _401 Authenticaion Required_ error when invoking APISIX Admin API