### PR TITLE
bugfix: add tag omitempty for the fields in some data structures

### DIFF
--- a/pkg/kube/apisix/apis/config/v2alpha1/types.go
+++ b/pkg/kube/apisix/apis/config/v2alpha1/types.go
@@ -92,11 +92,11 @@ type ApisixRouteHTTP struct {
 	Priority int                   `json:"priority,omitempty" yaml:"priority,omitempty"`
 	Match    *ApisixRouteHTTPMatch `json:"match,omitempty" yaml:"match,omitempty"`
 	// Deprecated: Backend will be removed in the future, use Backends instead.
-	Backend *ApisixRouteHTTPBackend `json:"backend" yaml:"backend"`
+	Backend *ApisixRouteHTTPBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
 	// Backends represents potential backends to proxy after the route
 	// rule matched. When number of backends are more than one, traffic-split
 	// plugin in APISIX will be used to split traffic based on the backend weight.
-	Backends       []*ApisixRouteHTTPBackend  `json:"backends" yaml:"backends"`
+	Backends       []*ApisixRouteHTTPBackend  `json:"backends,omitempty" yaml:"backends,omitempty"`
 	Websocket      bool                       `json:"websocket" yaml:"websocket"`
 	Plugins        []*ApisixRouteHTTPPlugin   `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 	Authentication *ApisixRouteAuthentication `json:"authentication,omitempty" yaml:"authentication,omitempty"`
@@ -172,12 +172,12 @@ type ApisixRouteHTTPBackend struct {
 	// when set to "endpoints", the pod ips will be used; other
 	// wise, the service ClusterIP or ExternalIP will be used,
 	// default is endpoints.
-	ResolveGranularity string `json:"resolveGranularity" yaml:"resolveGranularity"`
+	ResolveGranularity string `json:"resolveGranularity,omitempty" yaml:"resolveGranularity,omitempty"`
 	// Weight of this backend.
 	Weight *int `json:"weight" yaml:"weight"`
 	// Subset specifies a subset for the target Service. The subset should be pre-defined
 	// in ApisixUpstream about this service.
-	Subset string `json:"subset" yaml:"subset"`
+	Subset string `json:"subset,omitempty" yaml:"subset,omitempty"`
 }
 
 // ApisixRouteHTTPPlugin represents an APISIX plugin.

--- a/pkg/kube/apisix/apis/config/v2beta1/types.go
+++ b/pkg/kube/apisix/apis/config/v2beta1/types.go
@@ -55,11 +55,11 @@ type ApisixRouteHTTP struct {
 	Priority int                  `json:"priority,omitempty" yaml:"priority,omitempty"`
 	Match    ApisixRouteHTTPMatch `json:"match,omitempty" yaml:"match,omitempty"`
 	// Deprecated: Backend will be removed in the future, use Backends instead.
-	Backend v2alpha1.ApisixRouteHTTPBackend `json:"backend" yaml:"backend"`
+	Backend v2alpha1.ApisixRouteHTTPBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
 	// Backends represents potential backends to proxy after the route
 	// rule matched. When number of backends are more than one, traffic-split
 	// plugin in APISIX will be used to split traffic based on the backend weight.
-	Backends       []v2alpha1.ApisixRouteHTTPBackend `json:"backends" yaml:"backends"`
+	Backends       []v2alpha1.ApisixRouteHTTPBackend `json:"backends,omitempty" yaml:"backends,omitempty"`
 	Websocket      bool                              `json:"websocket" yaml:"websocket"`
 	Plugins        []ApisixRouteHTTPPlugin           `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 	Authentication ApisixRouteAuthentication         `json:"authentication,omitempty" yaml:"authentication,omitempty"`
@@ -175,10 +175,10 @@ type ApisixRouteStreamBackend struct {
 	// when set to "endpoints", the pod ips will be used; other
 	// wise, the service ClusterIP or ExternalIP will be used,
 	// default is endpoints.
-	ResolveGranularity string `json:"resolveGranularity" yaml:"resolveGranularity"`
+	ResolveGranularity string `json:"resolveGranularity,omitempty" yaml:"resolveGranularity,omitempty"`
 	// Subset specifies a subset for the target Service. The subset should be pre-defined
 	// in ApisixUpstream about this service.
-	Subset string `json:"subset" yaml:"subset"`
+	Subset string `json:"subset,omitempty" yaml:"subset,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
### Bugfix
- Description
 Using `clientset` to create `ApisixRoute` will get error `spec.http.backend: Invalid value: "null"` when only set `backends`
- Related issues:
   #621
- How to fix?
  adding `omitempty` to `not-required` field