### PR TITLE
docs: ApisixRoute v2alpha1 is deprecated

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -35,8 +35,10 @@
       "items": [
         "references/apisix_route_v1",
         "references/apisix_route_v2alpha1",
+        "references/apisix_route_v2beta1",
         "references/apisix_upstream",
-        "references/apisix_tls"
+        "references/apisix_tls",
+        "references/apisix_apisix_cluster_config"
       ]
     },
     {

--- a/docs/en/latest/practices/mtls/route.yaml
+++ b/docs/en/latest/practices/mtls/route.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apisix.apache.org/v2alpha1
+apiVersion: apisix.apache.org/v2beta1
 kind: ApisixRoute
 metadata:
   name: httpserver-route

--- a/docs/en/latest/practices/the-hard-way.md
+++ b/docs/en/latest/practices/the-hard-way.md
@@ -615,6 +615,9 @@ spec:
       storage: false
     - name: v2alpha1
       served: true
+      storage: false
+    - name: v2beta1
+      served: true
       storage: true
   scope: Namespaced
   names:
@@ -681,7 +684,7 @@ data:
       - "*"
       ingress_class: "apisix"
       ingress_version: "networking/v1"
-      apisix_route_version: "apisix.apache.org/v2alpha1"
+      apisix_route_version: "apisix.apache.org/v2beta1"
     apisix:
       default_cluster_base_url: "http://apisix-admin.apisix:9180/apisix/admin"
       default_cluster_admin_key: "edd1c9f034335f136f87ad84b625c8f1"

--- a/docs/en/latest/references/apisix_cluster_config.md
+++ b/docs/en/latest/references/apisix_cluster_config.md
@@ -1,5 +1,5 @@
 ---
-title: ApisixRoute/v2alpha1 Reference
+title: ApisixClusterConfig/v2alpha1 Reference
 ---
 
 <!--

--- a/docs/en/latest/references/apisix_route_v1.md
+++ b/docs/en/latest/references/apisix_route_v1.md
@@ -21,7 +21,7 @@ title: ApisixRoute/v1 (Deprecated) Reference
 #
 -->
 
-**WARNINIG**: `ApisixRoute/v1` is obsolete and will be unsupported in the future, please use `ApisixRoute/v2alpha1`!
+**WARNINIG**: `ApisixRoute/v1` is obsolete and will be unsupported in the future, please use `ApisixRoute/v2beta1`!
 
 |     Field     |  Type    |                    Description                     |
 |---------------|----------|----------------------------------------------------|


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

Please answer these questions before submitting a pull request



- Related issues

    #597 

