### PR TITLE
feat: add metric 'check_cluster_health_total' and 'sync_operation_total'

### DIFF
--- a/pkg/ingress/apisix_consumer.go
+++ b/pkg/ingress/apisix_consumer.go
@@ -131,9 +131,11 @@ func (c *apisixConsumerController) sync(ctx context.Context, ev *types.Event) er
 		)
 		c.controller.recorderEvent(ac, corev1.EventTypeWarning, _resourceSyncAborted, err)
 		c.controller.recordStatus(ac, _resourceSyncAborted, err, metav1.ConditionFalse)
+		c.controller.metricsCollector.IncrSyncOperation("consumer", "failure")
 		return err
 	}
 
+	c.controller.metricsCollector.IncrSyncOperation("consumer", "success")
 	c.controller.recorderEvent(ac, corev1.EventTypeNormal, _resourceSynced, nil)
 	return nil
 }

--- a/pkg/ingress/apisix_tls.go
+++ b/pkg/ingress/apisix_tls.go
@@ -146,7 +146,6 @@ func (c *apisixTlsController) sync(ctx context.Context, ev *types.Event) error {
 		c.controller.recordStatus(tls, _resourceSyncAborted, err, metav1.ConditionFalse)
 		return err
 	}
-
 	c.controller.recorderEvent(tls, corev1.EventTypeNormal, _resourceSynced, nil)
 	c.controller.recordStatus(tls, _resourceSynced, nil, metav1.ConditionTrue)
 	return err
@@ -173,6 +172,7 @@ func (c *apisixTlsController) syncSecretSSL(secretKey string, apisixTlsKey strin
 func (c *apisixTlsController) handleSyncErr(obj interface{}, err error) {
 	if err == nil {
 		c.workqueue.Forget(obj)
+		c.controller.metricsCollector.IncrSyncOperation("ssl", "success")
 		return
 	}
 	log.Warnw("sync ApisixTls failed, will retry",
@@ -180,6 +180,7 @@ func (c *apisixTlsController) handleSyncErr(obj interface{}, err error) {
 		zap.Error(err),
 	)
 	c.workqueue.AddRateLimited(obj)
+	c.controller.metricsCollector.IncrSyncOperation("ssl", "failure")
 }
 
 func (c *apisixTlsController) onAdd(obj interface{}) {

--- a/pkg/ingress/controller.go
+++ b/pkg/ingress/controller.go
@@ -166,7 +166,7 @@ func NewController(cfg *config.Config) (*Controller, error) {
 		cfg:               cfg,
 		apiServer:         apiSrv,
 		apisix:            client,
-		metricsCollector:  metrics.NewPrometheusCollector(podName, podNamespace),
+		metricsCollector:  metrics.NewPrometheusCollector(),
 		kubeClient:        kubeClient,
 		watchingNamespace: watchingNamespace,
 		secretSSLMap:      new(sync.Map),
@@ -617,5 +617,6 @@ func (c *Controller) checkClusterHealth(ctx context.Context, cancelFunc context.
 			return
 		}
 		log.Debugf("success check health for default cluster")
+		c.metricsCollector.IncrCheckClusterHealth(c.name)
 	}
 }

--- a/pkg/ingress/endpoint.go
+++ b/pkg/ingress/endpoint.go
@@ -90,12 +90,14 @@ func (c *endpointsController) sync(ctx context.Context, ev *types.Event) error {
 func (c *endpointsController) handleSyncErr(obj interface{}, err error) {
 	if err == nil {
 		c.workqueue.Forget(obj)
+		c.controller.metricsCollector.IncrSyncOperation("endpoint", "success")
 		return
 	}
 	log.Warnw("sync endpoints failed, will retry",
 		zap.Any("object", obj),
 	)
 	c.workqueue.AddRateLimited(obj)
+	c.controller.metricsCollector.IncrSyncOperation("endpoint", "failure")
 }
 
 func (c *endpointsController) onAdd(obj interface{}) {

--- a/pkg/ingress/endpointslice.go
+++ b/pkg/ingress/endpointslice.go
@@ -109,12 +109,14 @@ func (c *endpointSliceController) sync(ctx context.Context, ev *types.Event) err
 func (c *endpointSliceController) handleSyncErr(obj interface{}, err error) {
 	if err == nil {
 		c.workqueue.Forget(obj)
+		c.controller.metricsCollector.IncrSyncOperation("endpointSlices", "success")
 		return
 	}
 	log.Warnw("sync endpointSlice failed, will retry",
 		zap.Any("object", obj),
 	)
 	c.workqueue.AddRateLimited(obj)
+	c.controller.metricsCollector.IncrSyncOperation("endpointSlices", "failure")
 }
 
 func (c *endpointSliceController) onAdd(obj interface{}) {

--- a/pkg/ingress/secret.go
+++ b/pkg/ingress/secret.go
@@ -215,6 +215,7 @@ func (c *secretController) sync(ctx context.Context, ev *types.Event) error {
 func (c *secretController) handleSyncErr(obj interface{}, err error) {
 	if err == nil {
 		c.workqueue.Forget(obj)
+		c.controller.metricsCollector.IncrSyncOperation("secret", "success")
 		return
 	}
 	log.Warnw("sync ApisixTls failed, will retry",
@@ -222,6 +223,7 @@ func (c *secretController) handleSyncErr(obj interface{}, err error) {
 		zap.Error(err),
 	)
 	c.workqueue.AddRateLimited(obj)
+	c.controller.metricsCollector.IncrSyncOperation("secret", "failure")
 }
 
 func (c *secretController) onAdd(obj interface{}) {

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -30,11 +30,12 @@ func apisixBadStatusCodesTestHandler(t *testing.T, metrics []*io_prometheus_clie
 		assert.Equal(t, metric.Type.String(), "GAUGE")
 		m := metric.GetMetric()
 		assert.Len(t, m, 2)
+
 		assert.Equal(t, *m[0].Gauge.Value, float64(1))
 		assert.Equal(t, *m[0].Label[0].Name, "controller_namespace")
 		assert.Equal(t, *m[0].Label[0].Value, "default")
 		assert.Equal(t, *m[0].Label[1].Name, "controller_pod")
-		assert.Equal(t, *m[0].Label[1].Value, "test")
+		assert.Equal(t, *m[0].Label[1].Value, "")
 		assert.Equal(t, *m[0].Label[2].Name, "resource")
 		assert.Equal(t, *m[0].Label[2].Value, "route")
 		assert.Equal(t, *m[0].Label[3].Name, "status_code")
@@ -44,7 +45,7 @@ func apisixBadStatusCodesTestHandler(t *testing.T, metrics []*io_prometheus_clie
 		assert.Equal(t, *m[1].Label[0].Name, "controller_namespace")
 		assert.Equal(t, *m[1].Label[0].Value, "default")
 		assert.Equal(t, *m[1].Label[1].Name, "controller_pod")
-		assert.Equal(t, *m[1].Label[1].Value, "test")
+		assert.Equal(t, *m[1].Label[1].Value, "")
 		assert.Equal(t, *m[1].Label[2].Name, "resource")
 		assert.Equal(t, *m[1].Label[2].Value, "upstream")
 		assert.Equal(t, *m[1].Label[3].Name, "status_code")
@@ -64,7 +65,7 @@ func isLeaderTestHandler(t *testing.T, metrics []*io_prometheus_client.MetricFam
 		assert.Equal(t, *m[0].Label[0].Name, "controller_namespace")
 		assert.Equal(t, *m[0].Label[0].Value, "default")
 		assert.Equal(t, *m[0].Label[1].Name, "controller_pod")
-		assert.Equal(t, *m[0].Label[1].Value, "test")
+		assert.Equal(t, *m[0].Label[1].Value, "")
 	}
 }
 
@@ -81,7 +82,7 @@ func apisixLatencyTestHandler(t *testing.T, metrics []*io_prometheus_client.Metr
 		assert.Equal(t, *m[0].Label[0].Name, "controller_namespace")
 		assert.Equal(t, *m[0].Label[0].Value, "default")
 		assert.Equal(t, *m[0].Label[1].Name, "controller_pod")
-		assert.Equal(t, *m[0].Label[1].Value, "test")
+		assert.Equal(t, *m[0].Label[1].Value, "")
 	}
 }
 
@@ -97,7 +98,7 @@ func apisixRequestTestHandler(t *testing.T, metrics []*io_prometheus_client.Metr
 		assert.Equal(t, *m[0].Label[0].Name, "controller_namespace")
 		assert.Equal(t, *m[0].Label[0].Value, "default")
 		assert.Equal(t, *m[0].Label[1].Name, "controller_pod")
-		assert.Equal(t, *m[0].Label[1].Value, "test")
+		assert.Equal(t, *m[0].Label[1].Value, "")
 		assert.Equal(t, *m[0].Label[2].Name, "resource")
 		assert.Equal(t, *m[0].Label[2].Value, "route")
 
@@ -105,14 +106,62 @@ func apisixRequestTestHandler(t *testing.T, metrics []*io_prometheus_client.Metr
 		assert.Equal(t, *m[1].Label[0].Name, "controller_namespace")
 		assert.Equal(t, *m[1].Label[0].Value, "default")
 		assert.Equal(t, *m[1].Label[1].Name, "controller_pod")
-		assert.Equal(t, *m[1].Label[1].Value, "test")
+		assert.Equal(t, *m[1].Label[1].Value, "")
 		assert.Equal(t, *m[1].Label[2].Name, "resource")
 		assert.Equal(t, *m[1].Label[2].Value, "upstream")
 	}
 }
 
+func checkClusterHealthTestHandler(t *testing.T, metrics []*io_prometheus_client.MetricFamily) func(t *testing.T) {
+	return func(t *testing.T) {
+		metric := findMetric("apisix_ingress_controller_check_cluster_health_total", metrics)
+		assert.NotNil(t, metric)
+		assert.Equal(t, metric.Type.String(), "COUNTER")
+		m := metric.GetMetric()
+		assert.Len(t, m, 1)
+
+		assert.Equal(t, *m[0].Counter.Value, float64(1))
+		assert.Equal(t, *m[0].Label[0].Name, "controller_namespace")
+		assert.Equal(t, *m[0].Label[0].Value, "default")
+		assert.Equal(t, *m[0].Label[1].Name, "controller_pod")
+		assert.Equal(t, *m[0].Label[1].Value, "")
+		assert.Equal(t, *m[0].Label[2].Name, "name")
+		assert.Equal(t, *m[0].Label[2].Value, "test")
+	}
+}
+
+func syncOperationTestHandler(t *testing.T, metrics []*io_prometheus_client.MetricFamily) func(t *testing.T) {
+	return func(t *testing.T) {
+		metric := findMetric("apisix_ingress_controller_sync_operation_total", metrics)
+		assert.NotNil(t, metric)
+		assert.Equal(t, metric.Type.String(), "COUNTER")
+		m := metric.GetMetric()
+		assert.Len(t, m, 2)
+
+		assert.Equal(t, *m[0].Counter.Value, float64(1))
+		assert.Equal(t, *m[0].Label[0].Name, "controller_namespace")
+		assert.Equal(t, *m[0].Label[0].Value, "default")
+		assert.Equal(t, *m[0].Label[1].Name, "controller_pod")
+		assert.Equal(t, *m[0].Label[1].Value, "")
+		assert.Equal(t, *m[0].Label[2].Name, "resource")
+		assert.Equal(t, *m[0].Label[2].Value, "endpoint")
+		assert.Equal(t, *m[0].Label[3].Name, "result")
+		assert.Equal(t, *m[0].Label[3].Value, "success")
+
+		assert.Equal(t, *m[1].Counter.Value, float64(1))
+		assert.Equal(t, *m[1].Label[0].Name, "controller_namespace")
+		assert.Equal(t, *m[1].Label[0].Value, "default")
+		assert.Equal(t, *m[1].Label[1].Name, "controller_pod")
+		assert.Equal(t, *m[1].Label[1].Value, "")
+		assert.Equal(t, *m[1].Label[2].Name, "resource")
+		assert.Equal(t, *m[1].Label[2].Value, "schema")
+		assert.Equal(t, *m[1].Label[3].Name, "result")
+		assert.Equal(t, *m[1].Label[3].Value, "failure")
+	}
+}
+
 func TestPrometheusCollector(t *testing.T) {
-	c := NewPrometheusCollector("test", "default")
+	c := NewPrometheusCollector()
 	c.ResetLeader(true)
 	c.RecordAPISIXCode(404, "route")
 	c.RecordAPISIXCode(500, "upstream")
@@ -120,6 +169,9 @@ func TestPrometheusCollector(t *testing.T) {
 	c.IncrAPISIXRequest("route")
 	c.IncrAPISIXRequest("route")
 	c.IncrAPISIXRequest("upstream")
+	c.IncrCheckClusterHealth("test")
+	c.IncrSyncOperation("schema", "failure")
+	c.IncrSyncOperation("endpoint", "success")
 
 	metrics, err := prometheus.DefaultGatherer.Gather()
 	assert.Nil(t, err)
@@ -128,6 +180,8 @@ func TestPrometheusCollector(t *testing.T) {
 	t.Run("is_leader", isLeaderTestHandler(t, metrics))
 	t.Run("apisix_request_latencies", apisixLatencyTestHandler(t, metrics))
 	t.Run("apisix_requests", apisixRequestTestHandler(t, metrics))
+	t.Run("check_cluster_health_total", checkClusterHealthTestHandler(t, metrics))
+	t.Run("sync_operation_total", syncOperationTestHandler(t, metrics))
 }
 
 func findMetric(name string, metrics []*io_prometheus_client.MetricFamily) *io_prometheus_client.MetricFamily {


### PR DESCRIPTION
- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
___
### New feature or improvement
- Describe the details and related test reports.
add two Promethues metrics for apisix-ingress-controller:
***
HELP apisix_ingress_controller_check_cluster_health_success Number of cluster health check operations
TYPE apisix_ingress_controller_check_cluster_health_success counter
Label:

* controller_class
* controller_namespace
* controller_pod
* name (cluster name)

***
HELP apisix_ingress_controller_sync_success Number of success sync operations 
TYPE apisix_ingress_controller_sync_success counter  
Labels:

* controller_class
* controller_namespace
* controller_pod
* resource ( cache, schema, ssl, endpoint, consumer)
* result (success, failure)
***
Show in Prometheus:
```
# HELP apisix_ingress_controller_check_cluster_health_total Number of cluster health check operations
# TYPE apisix_ingress_controller_check_cluster_health_total counter
apisix_ingress_controller_check_cluster_health{controller_namespace="default",controller_pod="",name="default"} 1
# HELP apisix_ingress_controller_sync_operation_total Number of sync operations
# TYPE apisix_ingress_controller_sync_operation_total counter
apisix_ingress_controller_sync_success_total{controller_namespace="default",controller_pod="",resource="schema",result="success"} 1
```
___
