### PR TITLE
docs: update index of practices docs for website

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -10,6 +10,8 @@
       "label": "Practices",
       "items": [
         "practices/index",
+        "practices/check-crd-status",
+        "practices/mtls",
         "practices/the-hard-way",
         "practices/proxy-the-httpbin-service-with-ingress",
         "practices/proxy-the-httpbin-service"


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [X] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
currently these two articles have not been indexed in our [ingress controller docs](https://apisix.apache.org/docs/ingress-controller/practices/index)
  * https://apisix.apache.org/docs/ingress-controller/practices/check-crd-status/
  * https://apisix.apache.org/docs/ingress-controller/practices/mtls/


- How to fix?
update config.json in docs dir to include these two articles.
