### PR TITLE
Bugfix: add tag omitempty for the fields in this data structure ApisixRouteHTTPMatchExpr

### DIFF
--- a/pkg/kube/apisix/apis/config/v2alpha1/types.go
+++ b/pkg/kube/apisix/apis/config/v2alpha1/types.go
@@ -143,12 +143,12 @@ type ApisixRouteHTTPMatchExpr struct {
 	Op string `json:"op" yaml:"op"`
 	// Set is an array type object of the expression.
 	// It should be used when the Op is "in" or "not_in";
-	Set []string `json:"set" yaml:"set"`
+	Set []string `json:"set,omitempty" yaml:"set,omitempty"`
 	// Value is the normal type object for the expression,
 	// it should be used when the Op is not "in" and "not_in".
 	// Set and Value are exclusive so only of them can be set
 	// in the same time.
-	Value *string `json:"value" yaml:"value"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // ApisixRouteHTTPMatchExprSubject describes the route match expression subject.


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
In the ApisixRoute CRD: 
![image](https://user-images.githubusercontent.com/10919124/139011884-e45bc91e-f578-4fe1-8c7e-bf1367f6336d.png)
So the field `value` and `set` can't appear at the same time
But the golang data structure will be marshal to `value: null` or `set: null`, this will cause CRD checking error

- How to fix?
 Adding tag `omitempty` to this field 
