### PR TITLE
fix: unmarshal apisix/upstream field nodes be null

### DIFF
--- a/pkg/types/apisix/v1/types.go
+++ b/pkg/types/apisix/v1/types.go
@@ -208,6 +208,7 @@ func (n *UpstreamNodes) UnmarshalJSON(p []byte) error {
 		if len(p) != 2 {
 			return errors.New("unexpected non-empty object")
 		}
+		*n = UpstreamNodes{}
 		return nil
 	}
 	var data []UpstreamNode


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
![image](https://user-images.githubusercontent.com/10919124/139024175-ee48548b-a9e0-4ea3-8e43-d4325a6e087f.png)
I found this error in apisix-ingress-controller log

Controller sync the upstream from APISIX will set the `v1.Upstream.Nodes = nil ` when the  APISIX upstream json like `"nodes": {}`  


we can repeat this:
```golang
package main

import (
	"encoding/json"
	"fmt"

	v1 "github.com/apache/apisix-ingress-controller/pkg/types/apisix/v1"
)

func main() {
	data := `{"node":{}}`
	var ups v1.Upstream

	err := json.Unmarshal([]byte(data), &ups)
	if err != nil {
		panic(err)
	}
	fmt.Println(ups.Nodes == nil) // output: true
}
```
Output should be `false`, but is `true`
