### PR TITLE
bug: Remove route timeout default value

### DIFF
--- a/pkg/kube/translation/apisix_route.go
+++ b/pkg/kube/translation/apisix_route.go
@@ -446,12 +446,13 @@ func (t *translator) translateHTTPRoute(ctx *TranslateContext, ar *configv2alpha
 			return err
 		}
 
-		timeout := &apisixv1.UpstreamTimeout{
-			Connect: apisixv1.DefaultUpstreamTimeout,
-			Read:    apisixv1.DefaultUpstreamTimeout,
-			Send:    apisixv1.DefaultUpstreamTimeout,
-		}
+		var timeout *apisixv1.UpstreamTimeout
 		if part.Timeout != nil {
+			timeout = &apisixv1.UpstreamTimeout{
+				Connect: apisixv1.DefaultUpstreamTimeout,
+				Read:    apisixv1.DefaultUpstreamTimeout,
+				Send:    apisixv1.DefaultUpstreamTimeout,
+			}
 			if part.Timeout.Connect.Duration > 0 {
 				timeout.Connect = int(part.Timeout.Connect.Seconds())
 			}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues

___
### Bugfix
- Description
The controller will set default timeout 60s to the Apisix Route if not assigned `timeout` in the ApisixRoute CRD
And The Apisix Route timeout  will overwrite the timeout option which set in Upstream configuration.
![image](https://user-images.githubusercontent.com/10919124/139779178-8ad10f10-9205-4b67-ba94-7520d6e746cc.png)


- How to fix?
Keeping the original logic， not assign default timeout to the Apisix Route

