### PR TITLE
fix: If resource synchronization retry occurs, other events of the same resource will be blocked.

### DIFF
--- a/pkg/ingress/apisix_cluster_config.go
+++ b/pkg/ingress/apisix_cluster_config.go
@@ -207,7 +207,7 @@ func (c *apisixClusterConfigController) onAdd(obj interface{}) {
 		zap.Any("object", obj),
 	)
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventAdd,
 		Object: key,
 	})
@@ -229,7 +229,7 @@ func (c *apisixClusterConfigController) onUpdate(oldObj, newObj interface{}) {
 		zap.Any("old object", prev),
 	)
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventUpdate,
 		Object: key,
 	})
@@ -253,7 +253,7 @@ func (c *apisixClusterConfigController) onDelete(obj interface{}) {
 	log.Debugw("ApisixClusterConfig delete event arrived",
 		zap.Any("final state", acc),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:      types.EventDelete,
 		Object:    key,
 		Tombstone: acc,

--- a/pkg/ingress/apisix_consumer.go
+++ b/pkg/ingress/apisix_consumer.go
@@ -165,7 +165,7 @@ func (c *apisixConsumerController) onAdd(obj interface{}) {
 		zap.Any("object", obj),
 	)
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventAdd,
 		Object: key,
 	})
@@ -190,7 +190,7 @@ func (c *apisixConsumerController) onUpdate(oldObj, newObj interface{}) {
 		zap.Any("old object", prev),
 	)
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventUpdate,
 		Object: key,
 	})
@@ -217,7 +217,7 @@ func (c *apisixConsumerController) onDelete(obj interface{}) {
 	log.Debugw("ApisixConsumer delete event arrived",
 		zap.Any("final state", ac),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:      types.EventDelete,
 		Object:    key,
 		Tombstone: ac,

--- a/pkg/ingress/apisix_route.go
+++ b/pkg/ingress/apisix_route.go
@@ -330,7 +330,7 @@ func (c *apisixRouteController) onAdd(obj interface{}) {
 		zap.Any("object", obj))
 
 	ar := kube.MustNewApisixRoute(obj)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventAdd,
 		Object: kube.ApisixRouteEvent{
 			Key:          key,
@@ -357,7 +357,7 @@ func (c *apisixRouteController) onUpdate(oldObj, newObj interface{}) {
 		zap.Any("new object", curr),
 		zap.Any("old object", prev),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventUpdate,
 		Object: kube.ApisixRouteEvent{
 			Key:          key,
@@ -387,7 +387,7 @@ func (c *apisixRouteController) onDelete(obj interface{}) {
 	log.Debugw("ApisixRoute delete event arrived",
 		zap.Any("final state", ar),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventDelete,
 		Object: kube.ApisixRouteEvent{
 			Key:          key,

--- a/pkg/ingress/apisix_tls.go
+++ b/pkg/ingress/apisix_tls.go
@@ -195,7 +195,7 @@ func (c *apisixTlsController) onAdd(obj interface{}) {
 	log.Debugw("ApisixTls add event arrived",
 		zap.Any("object", obj),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventAdd,
 		Object: key,
 	})
@@ -219,7 +219,7 @@ func (c *apisixTlsController) onUpdate(prev, curr interface{}) {
 		zap.Any("new object", curr),
 		zap.Any("old object", prev),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventUpdate,
 		Object: key,
 	})
@@ -248,7 +248,7 @@ func (c *apisixTlsController) onDelete(obj interface{}) {
 	log.Debugw("ApisixTls delete event arrived",
 		zap.Any("final state", obj),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:      types.EventDelete,
 		Object:    key,
 		Tombstone: tls,

--- a/pkg/ingress/apisix_upstream.go
+++ b/pkg/ingress/apisix_upstream.go
@@ -225,7 +225,7 @@ func (c *apisixUpstreamController) onAdd(obj interface{}) {
 	log.Debugw("ApisixUpstream add event arrived",
 		zap.Any("object", obj))
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventAdd,
 		Object: key,
 	})
@@ -250,7 +250,7 @@ func (c *apisixUpstreamController) onUpdate(oldObj, newObj interface{}) {
 		zap.Any("old object", prev),
 	)
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventUpdate,
 		Object: key,
 	})
@@ -277,7 +277,7 @@ func (c *apisixUpstreamController) onDelete(obj interface{}) {
 	log.Debugw("ApisixUpstream delete event arrived",
 		zap.Any("final state", au),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:      types.EventDelete,
 		Object:    key,
 		Tombstone: au,

--- a/pkg/ingress/endpoint.go
+++ b/pkg/ingress/endpoint.go
@@ -112,7 +112,7 @@ func (c *endpointsController) onAdd(obj interface{}) {
 	log.Debugw("endpoints add event arrived",
 		zap.String("object-key", key))
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventAdd,
 		// TODO pass key.
 		Object: kube.NewEndpoint(obj.(*corev1.Endpoints)),
@@ -138,7 +138,7 @@ func (c *endpointsController) onUpdate(prev, curr interface{}) {
 		zap.Any("new object", currEp),
 		zap.Any("old object", prevEp),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventUpdate,
 		// TODO pass key.
 		Object: kube.NewEndpoint(currEp),
@@ -165,7 +165,7 @@ func (c *endpointsController) onDelete(obj interface{}) {
 	log.Debugw("endpoints delete event arrived",
 		zap.Any("final state", ep),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventDelete,
 		Object: kube.NewEndpoint(ep),
 	})

--- a/pkg/ingress/endpointslice.go
+++ b/pkg/ingress/endpointslice.go
@@ -142,7 +142,7 @@ func (c *endpointSliceController) onAdd(obj interface{}) {
 		zap.String("object-key", key),
 	)
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventAdd,
 		Object: endpointSliceEvent{
 			Key:         key,
@@ -180,7 +180,7 @@ func (c *endpointSliceController) onUpdate(prev, curr interface{}) {
 		zap.Any("new object", currEp),
 		zap.Any("old object", prevEp),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventUpdate,
 		// TODO pass key.
 		Object: endpointSliceEvent{
@@ -217,7 +217,7 @@ func (c *endpointSliceController) onDelete(obj interface{}) {
 	log.Debugw("endpoints delete event arrived",
 		zap.Any("object-key", key),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventDelete,
 		Object: endpointSliceEvent{
 			Key:         key,

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -218,7 +218,7 @@ func (c *ingressController) onAdd(obj interface{}) {
 		return
 	}
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventAdd,
 		Object: kube.IngressEvent{
 			Key:          key,
@@ -253,7 +253,7 @@ func (c *ingressController) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventUpdate,
 		Object: kube.IngressEvent{
 			Key:          key,
@@ -292,7 +292,7 @@ func (c *ingressController) OnDelete(obj interface{}) {
 		)
 		return
 	}
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type: types.EventDelete,
 		Object: kube.IngressEvent{
 			Key:          key,

--- a/pkg/ingress/namespace.go
+++ b/pkg/ingress/namespace.go
@@ -133,7 +133,7 @@ func (c *namespaceController) onAdd(obj interface{}) {
 	if err == nil {
 		log.Debugw(key)
 	}
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventAdd,
 		Object: key,
 	})
@@ -150,7 +150,7 @@ func (c *namespaceController) onUpdate(pre, cur interface{}) {
 		log.Errorf("found Namespace resource with error: %s", err)
 		return
 	}
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventUpdate,
 		Object: key,
 	})
@@ -158,7 +158,7 @@ func (c *namespaceController) onUpdate(pre, cur interface{}) {
 
 func (c *namespaceController) onDelete(obj interface{}) {
 	namespace := obj.(*corev1.Namespace)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:      types.EventDelete,
 		Object:    namespace.Name,
 		Tombstone: namespace,

--- a/pkg/ingress/secret.go
+++ b/pkg/ingress/secret.go
@@ -242,7 +242,7 @@ func (c *secretController) onAdd(obj interface{}) {
 	log.Debugw("secret add event arrived",
 		zap.String("object-key", key),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventAdd,
 		Object: key,
 	})
@@ -267,7 +267,7 @@ func (c *secretController) onUpdate(prev, curr interface{}) {
 		zap.Any("new object", curr),
 		zap.Any("old object", prev),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:   types.EventUpdate,
 		Object: key,
 	})
@@ -298,7 +298,7 @@ func (c *secretController) onDelete(obj interface{}) {
 	log.Debugw("secret delete event arrived",
 		zap.Any("final state", sec),
 	)
-	c.workqueue.AddRateLimited(&types.Event{
+	c.workqueue.Add(&types.Event{
 		Type:      types.EventDelete,
 		Object:    key,
 		Tombstone: sec,


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

- Related issues
#759 
___
### Bugfix

- How to fix?

This bug is due to a `workqueue` shared under the same resource, and a `ratelimit` mechanism is added to this `workqueue`, but we only need to add the `ratelimit` when retrying fails, and when normal resource changes, we should immediately add the `workqueue` to be processed .

The new k8s event does not need to use the rate limit.
