### PR TITLE
chore: specify the K8S cluster version used for the test

### DIFF
--- a/docs/en/latest/development.md
+++ b/docs/en/latest/development.md
@@ -26,7 +26,7 @@ This document explains how to get started with developing for Apache APISIX Ingr
 ## Prerequisites
 
 * Install [Go 1.13](https://golang.org/dl/) or later, and we use go module to manage the go package dependencies.
-* Prepare an available Kubernetes cluster in your workstation, we recommend you to use [Kind](https://kind.sigs.k8s.io/).
+* Prepare an available Kubernetes cluster in your workstation, we recommend you to use [KIND](https://kind.sigs.k8s.io/).
 * Install Apache APISIX in Kubernetes by [Helm Chart](https://github.com/apache/apisix-helm-chart).
 
 ## Fork and Clone
@@ -53,6 +53,9 @@ make unit-test
 ```
 
 ### Run e2e test cases
+
+We using [KIND](https://kind.sigs.k8s.io/) for running e2e test cases. Please ensure `kind` CLI has been installed.
+Currently we using KIND latest version v0.11.1 and using Kubernetes v1.21.1 for testing.
 
 ```shell
 cd /path/to/apisix-ingress-controller

--- a/utils/kind-with-registry.sh
+++ b/utils/kind-with-registry.sh
@@ -54,7 +54,8 @@ fi
 echo "Registry Host: ${reg_host}"
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind_node_image='kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6'
+cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --image ${kind_node_image} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

  - [x] CI

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

    Specify the K8S cluster version used for the test. To avoid CI failure due to inconsistent local environment version.
