### PR TITLE
feat: ensure that the lease can be actively released before program shutdown to reduce the time required for failover

### DIFF
--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -124,13 +125,17 @@ the apisix cluster and others are created`,
 			if err != nil {
 				dief("failed to create ingress controller: %s", err)
 			}
+			wg := sync.WaitGroup{}
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				if err := ingress.Run(stop); err != nil {
 					dief("failed to run ingress controller: %s", err)
 				}
 			}()
 
 			waitForSignal(stop)
+			wg.Wait()
 			log.Info("apisix ingress controller exited")
 		},
 	}

--- a/pkg/ingress/controller.go
+++ b/pkg/ingress/controller.go
@@ -380,10 +380,7 @@ func (c *Controller) Run(stop chan struct{}) error {
 				c.apisix.DeleteCluster(c.cfg.APISIX.DefaultClusterName)
 			},
 		},
-		// Set it to false as current leaderelection implementation will report
-		// "Failed to release lock: resource name may not be empty" error when
-		// ReleaseOnCancel is true and the Run context is cancelled.
-		ReleaseOnCancel: false,
+		ReleaseOnCancel: true,
 		Name:            "ingress-apisix",
 	}
 

--- a/test/e2e/ingress/sanity.go
+++ b/test/e2e/ingress/sanity.go
@@ -167,8 +167,8 @@ var _ = ginkgo.Describe("leader election", func() {
 		ginkgo.GinkgoT().Logf("lease is %s", *lease.Spec.HolderIdentity)
 		assert.Nil(ginkgo.GinkgoT(), s.KillPod(pods[leaderIdx].Name))
 
-		// Wait the old lease expire and new leader was elected.
-		time.Sleep(25 * time.Second)
+		// Wait the old leader given up lease and new leader was elected.
+		time.Sleep(3 * time.Second)
 
 		newLease, err := s.WaitGetLeaderLease()
 		assert.Nil(ginkgo.GinkgoT(), err)


### PR DESCRIPTION
Ensure that the lease can be actively released before program shutdown to reduce the time required for failover
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->
- [x] Improve performance