### PR TITLE
fix: ApisixClusterConfig e2e test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ endif
 .PHONY: push-images-to-kind
 push-images-to-kind: kind-up
 ifeq ($(E2E_SKIP_BUILD), 0)
-	docker pull apache/apisix:dev
-	docker tag apache/apisix:dev $(LOCAL_REGISTRY)/apache/apisix:dev
+	docker pull apache/apisix:2.12.0-alpine
+	docker tag apache/apisix:2.12.0-alpine $(LOCAL_REGISTRY)/apache/apisix:dev
 	docker push $(LOCAL_REGISTRY)/apache/apisix:dev
 
 	docker pull bitnami/etcd:3.4.14-debian-10-r0

--- a/pkg/apisix/plugin.go
+++ b/pkg/apisix/plugin.go
@@ -41,7 +41,7 @@ func (p *pluginClient) List(ctx context.Context) ([]string, error) {
 		zap.String("cluster", "default"),
 		zap.String("url", p.url),
 	)
-	pluginList, err := p.cluster.getList(ctx, p.url+"/list", "plugin")
+	pluginList, err := p.cluster.getList(ctx, p.url+"?all=true", "plugin")
 	if err != nil {
 		log.Errorf("failed to list plugins' names: %s", err)
 		return nil, err

--- a/pkg/ingress/status.go
+++ b/pkg/ingress/status.go
@@ -190,6 +190,22 @@ func (c *Controller) recordStatus(at interface{}, reason string, err error, stat
 				)
 			}
 		}
+	case *configv2beta3.ApisixClusterConfig:
+		// set to status
+		if v.Status.Conditions == nil {
+			conditions := make([]metav1.Condition, 0)
+			v.Status.Conditions = conditions
+		}
+		if c.verifyGeneration(&v.Status.Conditions, condition) {
+			meta.SetStatusCondition(&v.Status.Conditions, condition)
+			if _, errRecord := client.ApisixV2beta3().ApisixClusterConfigs().
+				UpdateStatus(context.TODO(), v, metav1.UpdateOptions{}); errRecord != nil {
+				log.Errorw("failed to record status change for ApisixClusterConfig",
+					zap.Error(errRecord),
+					zap.String("name", v.Name),
+				)
+			}
+		}
 	case *networkingv1.Ingress:
 		// set to status
 		lbips, err := c.ingressLBStatusIPs()


### PR DESCRIPTION
* pin the image of APISIX to stable version
* using the new plugin list API
* fix ApisixClusterConfig status logic

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix: #857 
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
