### PR TITLE
fix: Fix response error rate expression on grafana

### DIFF
--- a/docs/assets/other/json/apisix-ingress-controller-grafana.json
+++ b/docs/assets/other/json/apisix-ingress-controller-grafana.json
@@ -414,7 +414,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(apisix_ingress_controller_apisix_bad_status_codes{status_code =~ \"[4-5].*\"}) / sum(apisix_ingress_controller_apisix_requests)",
+          "expr": "sum(increase(apisix_ingress_controller_apisix_bad_status_codes{status_code =~ \"[4-5].*\"}[$__range])) / sum(increase(apisix_ingress_controller_apisix_bad_status_codes[$__range]))",
           "hide": false,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
### Type of change:

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
If we check the metrics available, we have:
* apisix_ingress_controller_apisix_bad_status_codes
* apisix_ingress_controller_apisix_requests

First, I think the `apisix_ingress_controller_apisix_bad_status_codes` is not a good name since it counts all the requests including the good ones.
The `apisix_ingress_controller_apisix_requests` seems to only have the number of successful requests.

Currently, the response error rate is calculated using the `apisix_ingress_controller_apisix_requests`, which I believe is not correct since it doesn't have the total requests made.

So, I changed the expression to use only the `apisix_ingress_controller_apisix_bad_status_codes` and put also the possibility to define a time range.


### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
