### PR TITLE
fix: export apisix type for encoding/json package

### DIFF
--- a/pkg/ingress/apisix_pluginconfig.go
+++ b/pkg/ingress/apisix_pluginconfig.go
@@ -131,9 +131,9 @@ func (c *apisixPluginConfigController) sync(ctx context.Context, ev *types.Event
 	switch obj.GroupVersion {
 	case kube.ApisixPluginConfigV2beta3:
 		if ev.Type != types.EventDelete {
-			tctx, err = c.controller.translator.TranslatePluginConfigV2beta3(apc.V2beta3())
+			tctx, err = c.controller.translator.TranslatePluginConfigV2beta3(apc.GetV2beta3())
 		} else {
-			tctx, err = c.controller.translator.TranslatePluginConfigV2beta3NotStrictly(apc.V2beta3())
+			tctx, err = c.controller.translator.TranslatePluginConfigV2beta3NotStrictly(apc.GetV2beta3())
 		}
 		if err != nil {
 			log.Errorw("failed to translate ApisixPluginConfig v2beta3",
@@ -166,7 +166,7 @@ func (c *apisixPluginConfigController) sync(ctx context.Context, ev *types.Event
 		var oldCtx *translation.TranslateContext
 		switch obj.GroupVersion {
 		case kube.ApisixPluginConfigV2beta3:
-			oldCtx, err = c.controller.translator.TranslatePluginConfigV2beta3(obj.OldObject.V2beta3())
+			oldCtx, err = c.controller.translator.TranslatePluginConfigV2beta3(obj.OldObject.GetV2beta3())
 		}
 		if err != nil {
 			log.Errorw("failed to translate old ApisixPluginConfig",
@@ -212,10 +212,10 @@ func (c *apisixPluginConfigController) handleSyncErr(obj interface{}, errOrigin 
 	if errOrigin == nil {
 		if ev.Type != types.EventDelete {
 			if errLocal == nil {
-				switch apc.GroupVersion() {
+				switch apc.GetGroupVersion() {
 				case kube.ApisixPluginConfigV2beta3:
-					c.controller.recorderEvent(apc.V2beta3(), v1.EventTypeNormal, _resourceSynced, nil)
-					c.controller.recordStatus(apc.V2beta3(), _resourceSynced, nil, metav1.ConditionTrue, apc.V2beta3().GetGeneration())
+					c.controller.recorderEvent(apc.GetV2beta3(), v1.EventTypeNormal, _resourceSynced, nil)
+					c.controller.recordStatus(apc.GetV2beta3(), _resourceSynced, nil, metav1.ConditionTrue, apc.GetV2beta3().GetGeneration())
 				}
 			} else {
 				log.Errorw("failed list ApisixPluginConfig",
@@ -234,10 +234,10 @@ func (c *apisixPluginConfigController) handleSyncErr(obj interface{}, errOrigin 
 		zap.Error(errOrigin),
 	)
 	if errLocal == nil {
-		switch apc.GroupVersion() {
+		switch apc.GetGroupVersion() {
 		case kube.ApisixPluginConfigV2beta3:
-			c.controller.recorderEvent(apc.V2beta3(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
-			c.controller.recordStatus(apc.V2beta3(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, apc.V2beta3().GetGeneration())
+			c.controller.recorderEvent(apc.GetV2beta3(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
+			c.controller.recordStatus(apc.GetV2beta3(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, apc.GetV2beta3().GetGeneration())
 		}
 	} else {
 		log.Errorw("failed list ApisixPluginConfig",
@@ -267,7 +267,7 @@ func (c *apisixPluginConfigController) onAdd(obj interface{}) {
 		Type: types.EventAdd,
 		Object: kube.ApisixPluginConfigEvent{
 			Key:          key,
-			GroupVersion: apc.GroupVersion(),
+			GroupVersion: apc.GetGroupVersion(),
 		},
 	})
 
@@ -277,7 +277,7 @@ func (c *apisixPluginConfigController) onAdd(obj interface{}) {
 func (c *apisixPluginConfigController) onUpdate(oldObj, newObj interface{}) {
 	prev := kube.MustNewApisixPluginConfig(oldObj)
 	curr := kube.MustNewApisixPluginConfig(newObj)
-	if prev.ResourceVersion() >= curr.ResourceVersion() {
+	if prev.GetResourceVersion() >= curr.GetResourceVersion() {
 		return
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)
@@ -296,7 +296,7 @@ func (c *apisixPluginConfigController) onUpdate(oldObj, newObj interface{}) {
 		Type: types.EventUpdate,
 		Object: kube.ApisixPluginConfigEvent{
 			Key:          key,
-			GroupVersion: curr.GroupVersion(),
+			GroupVersion: curr.GetGroupVersion(),
 			OldObject:    prev,
 		},
 	})
@@ -328,7 +328,7 @@ func (c *apisixPluginConfigController) onDelete(obj interface{}) {
 		Type: types.EventDelete,
 		Object: kube.ApisixPluginConfigEvent{
 			Key:          key,
-			GroupVersion: apc.GroupVersion(),
+			GroupVersion: apc.GetGroupVersion(),
 		},
 		Tombstone: apc,
 	})

--- a/pkg/ingress/apisix_route.go
+++ b/pkg/ingress/apisix_route.go
@@ -138,9 +138,9 @@ func (c *apisixRouteController) sync(ctx context.Context, ev *types.Event) error
 	switch obj.GroupVersion {
 	case kube.ApisixRouteV2beta1:
 		if ev.Type != types.EventDelete {
-			tctx, err = c.controller.translator.TranslateRouteV2beta1(ar.V2beta1())
+			tctx, err = c.controller.translator.TranslateRouteV2beta1(ar.GetV2beta1())
 		} else {
-			tctx, err = c.controller.translator.TranslateRouteV2beta1NotStrictly(ar.V2beta1())
+			tctx, err = c.controller.translator.TranslateRouteV2beta1NotStrictly(ar.GetV2beta1())
 		}
 		if err != nil {
 			log.Errorw("failed to translate ApisixRoute v2beta1",
@@ -151,9 +151,9 @@ func (c *apisixRouteController) sync(ctx context.Context, ev *types.Event) error
 		}
 	case kube.ApisixRouteV2beta2:
 		if ev.Type != types.EventDelete {
-			tctx, err = c.controller.translator.TranslateRouteV2beta2(ar.V2beta2())
+			tctx, err = c.controller.translator.TranslateRouteV2beta2(ar.GetV2beta2())
 		} else {
-			tctx, err = c.controller.translator.TranslateRouteV2beta2NotStrictly(ar.V2beta2())
+			tctx, err = c.controller.translator.TranslateRouteV2beta2NotStrictly(ar.GetV2beta2())
 		}
 		if err != nil {
 			log.Errorw("failed to translate ApisixRoute v2beta2",
@@ -164,11 +164,11 @@ func (c *apisixRouteController) sync(ctx context.Context, ev *types.Event) error
 		}
 	case kube.ApisixRouteV2beta3:
 		if ev.Type != types.EventDelete {
-			if err = c.checkPluginNameIfNotEmptyV2beta3(ctx, ar.V2beta3()); err == nil {
-				tctx, err = c.controller.translator.TranslateRouteV2beta3(ar.V2beta3())
+			if err = c.checkPluginNameIfNotEmptyV2beta3(ctx, ar.GetV2beta3()); err == nil {
+				tctx, err = c.controller.translator.TranslateRouteV2beta3(ar.GetV2beta3())
 			}
 		} else {
-			tctx, err = c.controller.translator.TranslateRouteV2beta3NotStrictly(ar.V2beta3())
+			tctx, err = c.controller.translator.TranslateRouteV2beta3NotStrictly(ar.GetV2beta3())
 		}
 		if err != nil {
 			log.Errorw("failed to translate ApisixRoute v2beta3",
@@ -207,11 +207,11 @@ func (c *apisixRouteController) sync(ctx context.Context, ev *types.Event) error
 		var oldCtx *translation.TranslateContext
 		switch obj.GroupVersion {
 		case kube.ApisixRouteV2beta1:
-			oldCtx, err = c.controller.translator.TranslateRouteV2beta1(obj.OldObject.V2beta1())
+			oldCtx, err = c.controller.translator.TranslateRouteV2beta1(obj.OldObject.GetV2beta1())
 		case kube.ApisixRouteV2beta2:
-			oldCtx, err = c.controller.translator.TranslateRouteV2beta2(obj.OldObject.V2beta2())
+			oldCtx, err = c.controller.translator.TranslateRouteV2beta2(obj.OldObject.GetV2beta2())
 		case kube.ApisixRouteV2beta3:
-			oldCtx, err = c.controller.translator.TranslateRouteV2beta3(obj.OldObject.V2beta3())
+			oldCtx, err = c.controller.translator.TranslateRouteV2beta3(obj.OldObject.GetV2beta3())
 		}
 		if err != nil {
 			log.Errorw("failed to translate old ApisixRoute",
@@ -287,16 +287,16 @@ func (c *apisixRouteController) handleSyncErr(obj interface{}, errOrigin error) 
 	if errOrigin == nil {
 		if ev.Type != types.EventDelete {
 			if errLocal == nil {
-				switch ar.GroupVersion() {
+				switch ar.GetGroupVersion() {
 				case kube.ApisixRouteV2beta1:
-					c.controller.recorderEvent(ar.V2beta1(), v1.EventTypeNormal, _resourceSynced, nil)
-					c.controller.recordStatus(ar.V2beta1(), _resourceSynced, nil, metav1.ConditionTrue, ar.V2beta1().GetGeneration())
+					c.controller.recorderEvent(ar.GetV2beta1(), v1.EventTypeNormal, _resourceSynced, nil)
+					c.controller.recordStatus(ar.GetV2beta1(), _resourceSynced, nil, metav1.ConditionTrue, ar.GetV2beta1().GetGeneration())
 				case kube.ApisixRouteV2beta2:
-					c.controller.recorderEvent(ar.V2beta2(), v1.EventTypeNormal, _resourceSynced, nil)
-					c.controller.recordStatus(ar.V2beta2(), _resourceSynced, nil, metav1.ConditionTrue, ar.V2beta2().GetGeneration())
+					c.controller.recorderEvent(ar.GetV2beta2(), v1.EventTypeNormal, _resourceSynced, nil)
+					c.controller.recordStatus(ar.GetV2beta2(), _resourceSynced, nil, metav1.ConditionTrue, ar.GetV2beta2().GetGeneration())
 				case kube.ApisixRouteV2beta3:
-					c.controller.recorderEvent(ar.V2beta3(), v1.EventTypeNormal, _resourceSynced, nil)
-					c.controller.recordStatus(ar.V2beta3(), _resourceSynced, nil, metav1.ConditionTrue, ar.V2beta3().GetGeneration())
+					c.controller.recorderEvent(ar.GetV2beta3(), v1.EventTypeNormal, _resourceSynced, nil)
+					c.controller.recordStatus(ar.GetV2beta3(), _resourceSynced, nil, metav1.ConditionTrue, ar.GetV2beta3().GetGeneration())
 				}
 			} else {
 				log.Errorw("failed list ApisixRoute",
@@ -315,16 +315,16 @@ func (c *apisixRouteController) handleSyncErr(obj interface{}, errOrigin error) 
 		zap.Error(errOrigin),
 	)
 	if errLocal == nil {
-		switch ar.GroupVersion() {
+		switch ar.GetGroupVersion() {
 		case kube.ApisixRouteV2beta1:
-			c.controller.recorderEvent(ar.V2beta1(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
-			c.controller.recordStatus(ar.V2beta1(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, ar.V2beta1().GetGeneration())
+			c.controller.recorderEvent(ar.GetV2beta1(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
+			c.controller.recordStatus(ar.GetV2beta1(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, ar.GetV2beta1().GetGeneration())
 		case kube.ApisixRouteV2beta2:
-			c.controller.recorderEvent(ar.V2beta2(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
-			c.controller.recordStatus(ar.V2beta2(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, ar.V2beta2().GetGeneration())
+			c.controller.recorderEvent(ar.GetV2beta2(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
+			c.controller.recordStatus(ar.GetV2beta2(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, ar.GetV2beta2().GetGeneration())
 		case kube.ApisixRouteV2beta3:
-			c.controller.recorderEvent(ar.V2beta3(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
-			c.controller.recordStatus(ar.V2beta3(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, ar.V2beta3().GetGeneration())
+			c.controller.recorderEvent(ar.GetV2beta3(), v1.EventTypeWarning, _resourceSyncAborted, errOrigin)
+			c.controller.recordStatus(ar.GetV2beta3(), _resourceSyncAborted, errOrigin, metav1.ConditionFalse, ar.GetV2beta3().GetGeneration())
 		}
 	} else {
 		log.Errorw("failed list ApisixRoute",
@@ -354,7 +354,7 @@ func (c *apisixRouteController) onAdd(obj interface{}) {
 		Type: types.EventAdd,
 		Object: kube.ApisixRouteEvent{
 			Key:          key,
-			GroupVersion: ar.GroupVersion(),
+			GroupVersion: ar.GetGroupVersion(),
 		},
 	})
 
@@ -383,7 +383,7 @@ func (c *apisixRouteController) onUpdate(oldObj, newObj interface{}) {
 		Type: types.EventUpdate,
 		Object: kube.ApisixRouteEvent{
 			Key:          key,
-			GroupVersion: curr.GroupVersion(),
+			GroupVersion: curr.GetGroupVersion(),
 			OldObject:    prev,
 		},
 	})
@@ -415,7 +415,7 @@ func (c *apisixRouteController) onDelete(obj interface{}) {
 		Type: types.EventDelete,
 		Object: kube.ApisixRouteEvent{
 			Key:          key,
-			GroupVersion: ar.GroupVersion(),
+			GroupVersion: ar.GetGroupVersion(),
 		},
 		Tombstone: ar,
 	})

--- a/pkg/ingress/apisix_route.go
+++ b/pkg/ingress/apisix_route.go
@@ -364,7 +364,7 @@ func (c *apisixRouteController) onAdd(obj interface{}) {
 func (c *apisixRouteController) onUpdate(oldObj, newObj interface{}) {
 	prev := kube.MustNewApisixRoute(oldObj)
 	curr := kube.MustNewApisixRoute(newObj)
-	if prev.ResourceVersion() >= curr.ResourceVersion() {
+	if prev.GetResourceVersion() >= curr.GetResourceVersion() {
 		return
 	}
 	key, err := cache.MetaNamespaceKeyFunc(newObj)

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -220,13 +220,13 @@ func (c *ingressController) handleSyncErr(obj interface{}, err error) {
 		// add status
 		if ev.Type != types.EventDelete {
 			if errLocal == nil {
-				switch ing.GroupVersion() {
+				switch ing.GetGroupVersion() {
 				case kube.IngressV1:
-					c.controller.recordStatus(ing.V1(), _resourceSynced, nil, metav1.ConditionTrue, ing.V1().GetGeneration())
+					c.controller.recordStatus(ing.GetV1(), _resourceSynced, nil, metav1.ConditionTrue, ing.GetV1().GetGeneration())
 				case kube.IngressV1beta1:
-					c.controller.recordStatus(ing.V1beta1(), _resourceSynced, nil, metav1.ConditionTrue, ing.V1beta1().GetGeneration())
+					c.controller.recordStatus(ing.GetV1beta1(), _resourceSynced, nil, metav1.ConditionTrue, ing.GetV1beta1().GetGeneration())
 				case kube.IngressExtensionsV1beta1:
-					c.controller.recordStatus(ing.ExtensionsV1beta1(), _resourceSynced, nil, metav1.ConditionTrue, ing.ExtensionsV1beta1().GetGeneration())
+					c.controller.recordStatus(ing.GetExtensionsV1beta1(), _resourceSynced, nil, metav1.ConditionTrue, ing.GetExtensionsV1beta1().GetGeneration())
 				}
 			} else {
 				log.Errorw("failed to list ingress resource",
@@ -244,13 +244,13 @@ func (c *ingressController) handleSyncErr(obj interface{}, err error) {
 	)
 
 	if errLocal == nil {
-		switch ing.GroupVersion() {
+		switch ing.GetGroupVersion() {
 		case kube.IngressV1:
-			c.controller.recordStatus(ing.V1(), _resourceSyncAborted, err, metav1.ConditionTrue, ing.V1().GetGeneration())
+			c.controller.recordStatus(ing.GetV1(), _resourceSyncAborted, err, metav1.ConditionTrue, ing.GetV1().GetGeneration())
 		case kube.IngressV1beta1:
-			c.controller.recordStatus(ing.V1beta1(), _resourceSyncAborted, err, metav1.ConditionTrue, ing.V1beta1().GetGeneration())
+			c.controller.recordStatus(ing.GetV1beta1(), _resourceSyncAborted, err, metav1.ConditionTrue, ing.GetV1beta1().GetGeneration())
 		case kube.IngressExtensionsV1beta1:
-			c.controller.recordStatus(ing.ExtensionsV1beta1(), _resourceSyncAborted, err, metav1.ConditionTrue, ing.ExtensionsV1beta1().GetGeneration())
+			c.controller.recordStatus(ing.GetExtensionsV1beta1(), _resourceSyncAborted, err, metav1.ConditionTrue, ing.GetExtensionsV1beta1().GetGeneration())
 		}
 	} else {
 		log.Errorw("failed to list ingress resource",
@@ -288,7 +288,7 @@ func (c *ingressController) onAdd(obj interface{}) {
 		Type: types.EventAdd,
 		Object: kube.IngressEvent{
 			Key:          key,
-			GroupVersion: ing.GroupVersion(),
+			GroupVersion: ing.GetGroupVersion(),
 		},
 	})
 
@@ -298,7 +298,7 @@ func (c *ingressController) onAdd(obj interface{}) {
 func (c *ingressController) onUpdate(oldObj, newObj interface{}) {
 	prev := kube.MustNewIngress(oldObj)
 	curr := kube.MustNewIngress(newObj)
-	if prev.ResourceVersion() >= curr.ResourceVersion() {
+	if prev.GetResourceVersion() >= curr.GetResourceVersion() {
 		return
 	}
 
@@ -325,7 +325,7 @@ func (c *ingressController) onUpdate(oldObj, newObj interface{}) {
 		Type: types.EventUpdate,
 		Object: kube.IngressEvent{
 			Key:          key,
-			GroupVersion: curr.GroupVersion(),
+			GroupVersion: curr.GetGroupVersion(),
 			OldObject:    prev,
 		},
 	})
@@ -366,7 +366,7 @@ func (c *ingressController) OnDelete(obj interface{}) {
 		Type: types.EventDelete,
 		Object: kube.IngressEvent{
 			Key:          key,
-			GroupVersion: ing.GroupVersion(),
+			GroupVersion: ing.GetGroupVersion(),
 		},
 		Tombstone: ing,
 	})
@@ -379,15 +379,15 @@ func (c *ingressController) isIngressEffective(ing kube.Ingress) bool {
 		ic  *string
 		ica string
 	)
-	if ing.GroupVersion() == kube.IngressV1 {
-		ic = ing.V1().Spec.IngressClassName
-		ica = ing.V1().GetAnnotations()[_ingressKey]
-	} else if ing.GroupVersion() == kube.IngressV1beta1 {
-		ic = ing.V1beta1().Spec.IngressClassName
-		ica = ing.V1beta1().GetAnnotations()[_ingressKey]
+	if ing.GetGroupVersion() == kube.IngressV1 {
+		ic = ing.GetV1().Spec.IngressClassName
+		ica = ing.GetV1().GetAnnotations()[_ingressKey]
+	} else if ing.GetGroupVersion() == kube.IngressV1beta1 {
+		ic = ing.GetV1beta1().Spec.IngressClassName
+		ica = ing.GetV1beta1().GetAnnotations()[_ingressKey]
 	} else {
-		ic = ing.ExtensionsV1beta1().Spec.IngressClassName
-		ica = ing.ExtensionsV1beta1().GetAnnotations()[_ingressKey]
+		ic = ing.GetExtensionsV1beta1().Spec.IngressClassName
+		ica = ing.GetExtensionsV1beta1().GetAnnotations()[_ingressKey]
 	}
 
 	// kubernetes.io/ingress.class takes the precedence.

--- a/pkg/kube/apisix_plugin_config.go
+++ b/pkg/kube/apisix_plugin_config.go
@@ -22,14 +22,14 @@ import (
 )
 
 const (
-	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/GetV2beta3 group version
-	ApisixPluginConfigV2beta3 = "apisix.apache.org/V2beta3"
+	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/v2beta3 group version
+	ApisixPluginConfigV2beta3 = "apisix.apache.org/v2beta3"
 )
 
 // ApisixPluginConfigLister is an encapsulation for the lister of ApisixPluginConfig,
 // it aims at to be compatible with different ApisixPluginConfig versions.
 type ApisixPluginConfigLister interface {
-	// V2beta3 gets the ApisixPluginConfig in apisix.apache.org/GetV2beta3.
+	// V2beta3 gets the ApisixPluginConfig in apisix.apache.org/v2beta3.
 	V2beta3(string, string) (ApisixPluginConfig, error)
 }
 
@@ -45,7 +45,7 @@ type ApisixPluginConfig interface {
 	// GetGroupVersion returns the api group version of the
 	// real ApisixPluginConfig.
 	GetGroupVersion() string
-	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/GetV2beta3, the real
+	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/v2beta3, the real
 	// ApisixPluginConfig must be in this group version, otherwise will panic.
 	GetV2beta3() *configv2beta3.ApisixPluginConfig
 	// GetResourceVersion returns the the resource version field inside
@@ -68,7 +68,7 @@ type apisixPluginConfig struct {
 
 func (apc *apisixPluginConfig) GetV2beta3() *configv2beta3.ApisixPluginConfig {
 	if apc.GroupVersion != ApisixPluginConfigV2beta3 {
-		panic("not a apisix.apache.org/GetV2beta3 pluginConfig")
+		panic("not a apisix.apache.org/v2beta3 pluginConfig")
 	}
 	return apc.V2beta3
 }

--- a/pkg/kube/apisix_plugin_config.go
+++ b/pkg/kube/apisix_plugin_config.go
@@ -22,14 +22,14 @@ import (
 )
 
 const (
-	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/V2beta3 group version
-	ApisixPluginConfigV2beta3 = "apisix.apache.org/V2beta3"
+	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/GetV2beta3 group version
+	ApisixPluginConfigV2beta3 = "apisix.apache.org/GetV2beta3"
 )
 
 // ApisixPluginConfigLister is an encapsulation for the lister of ApisixPluginConfig,
 // it aims at to be compatible with different ApisixPluginConfig versions.
 type ApisixPluginConfigLister interface {
-	// V2beta3 gets the ApisixPluginConfig in apisix.apache.org/V2beta3.
+	// V2beta3 gets the ApisixPluginConfig in apisix.apache.org/GetV2beta3.
 	V2beta3(string, string) (ApisixPluginConfig, error)
 }
 
@@ -40,17 +40,17 @@ type ApisixPluginConfigInformer interface {
 }
 
 // ApisixPluginConfig is an encapsulation for ApisixPluginConfig resource with different
-// versions, for now, they are apisix.apache.org/v1 and apisix.apache.org/v2alpha1
+// versions, for now, they are apisix.apache.org/V1 and apisix.apache.org/v2alpha1
 type ApisixPluginConfig interface {
-	// GroupVersion returns the api group version of the
+	// GetGroupVersion returns the api group version of the
 	// real ApisixPluginConfig.
-	GroupVersion() string
-	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/V2beta3, the real
+	GetGroupVersion() string
+	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/GetV2beta3, the real
 	// ApisixPluginConfig must be in this group version, otherwise will panic.
-	V2beta3() *configv2beta3.ApisixPluginConfig
-	// ResourceVersion returns the the resource version field inside
+	GetV2beta3() *configv2beta3.ApisixPluginConfig
+	// GetResourceVersion returns the the resource version field inside
 	// the real ApisixPluginConfig.
-	ResourceVersion() string
+	GetResourceVersion() string
 }
 
 // ApisixPluginConfigEvent contains the ApisixPluginConfig key (namespace/name)
@@ -62,23 +62,23 @@ type ApisixPluginConfigEvent struct {
 }
 
 type apisixPluginConfig struct {
-	groupVersion string
-	v2beta3      *configv2beta3.ApisixPluginConfig
+	GroupVersion string
+	V2beta3      *configv2beta3.ApisixPluginConfig
 }
 
-func (apc *apisixPluginConfig) V2beta3() *configv2beta3.ApisixPluginConfig {
-	if apc.groupVersion != ApisixPluginConfigV2beta3 {
-		panic("not a apisix.apache.org/V2beta3 pluginConfig")
+func (apc *apisixPluginConfig) GetV2beta3() *configv2beta3.ApisixPluginConfig {
+	if apc.GroupVersion != ApisixPluginConfigV2beta3 {
+		panic("not a apisix.apache.org/GetV2beta3 pluginConfig")
 	}
-	return apc.v2beta3
+	return apc.V2beta3
 }
 
-func (apc *apisixPluginConfig) GroupVersion() string {
-	return apc.groupVersion
+func (apc *apisixPluginConfig) GetGroupVersion() string {
+	return apc.GroupVersion
 }
 
-func (apc *apisixPluginConfig) ResourceVersion() string {
-	return apc.V2beta3().ResourceVersion
+func (apc *apisixPluginConfig) GetResourceVersion() string {
+	return apc.GetV2beta3().ResourceVersion
 }
 
 type apisixPluginConfigLister struct {
@@ -91,8 +91,8 @@ func (l *apisixPluginConfigLister) V2beta3(namespace, name string) (ApisixPlugin
 		return nil, err
 	}
 	return &apisixPluginConfig{
-		groupVersion: ApisixPluginConfigV2beta3,
-		v2beta3:      apc,
+		GroupVersion: ApisixPluginConfigV2beta3,
+		V2beta3:      apc,
 	}, nil
 }
 
@@ -102,8 +102,8 @@ func MustNewApisixPluginConfig(obj interface{}) ApisixPluginConfig {
 	switch apc := obj.(type) {
 	case *configv2beta3.ApisixPluginConfig:
 		return &apisixPluginConfig{
-			groupVersion: ApisixPluginConfigV2beta3,
-			v2beta3:      apc,
+			GroupVersion: ApisixPluginConfigV2beta3,
+			V2beta3:      apc,
 		}
 	default:
 		panic("invalid ApisixPluginConfig type")
@@ -117,8 +117,8 @@ func NewApisixPluginConfig(obj interface{}) (ApisixPluginConfig, error) {
 	switch apc := obj.(type) {
 	case *configv2beta3.ApisixPluginConfig:
 		return &apisixPluginConfig{
-			groupVersion: ApisixPluginConfigV2beta3,
-			v2beta3:      apc,
+			GroupVersion: ApisixPluginConfigV2beta3,
+			V2beta3:      apc,
 		}, nil
 	default:
 		return nil, errors.New("invalid ApisixPluginConfig type")

--- a/pkg/kube/apisix_plugin_config.go
+++ b/pkg/kube/apisix_plugin_config.go
@@ -40,7 +40,7 @@ type ApisixPluginConfigInformer interface {
 }
 
 // ApisixPluginConfig is an encapsulation for ApisixPluginConfig resource with different
-// versions, for now, they are apisix.apache.org/V1 and apisix.apache.org/v2alpha1
+// versions, for now, they are apisix.apache.org/v1 and apisix.apache.org/v2alpha1
 type ApisixPluginConfig interface {
 	// GetGroupVersion returns the api group version of the
 	// real ApisixPluginConfig.

--- a/pkg/kube/apisix_plugin_config.go
+++ b/pkg/kube/apisix_plugin_config.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/GetV2beta3 group version
-	ApisixPluginConfigV2beta3 = "apisix.apache.org/GetV2beta3"
+	ApisixPluginConfigV2beta3 = "apisix.apache.org/V2beta3"
 )
 
 // ApisixPluginConfigLister is an encapsulation for the lister of ApisixPluginConfig,

--- a/pkg/kube/apisix_plugin_config.go
+++ b/pkg/kube/apisix_plugin_config.go
@@ -45,7 +45,7 @@ type ApisixPluginConfig interface {
 	// GetGroupVersion returns the api group version of the
 	// real ApisixPluginConfig.
 	GetGroupVersion() string
-	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/v2beta3, the real
+	// GetV2beta3 returns the ApisixPluginConfig in apisix.apache.org/v2beta3, the real
 	// ApisixPluginConfig must be in this group version, otherwise will panic.
 	GetV2beta3() *configv2beta3.ApisixPluginConfig
 	// GetResourceVersion returns the the resource version field inside

--- a/pkg/kube/apisix_plugin_config.go
+++ b/pkg/kube/apisix_plugin_config.go
@@ -22,14 +22,14 @@ import (
 )
 
 const (
-	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/v2beta3 group version
-	ApisixPluginConfigV2beta3 = "apisix.apache.org/v2beta3"
+	// ApisixPluginConfigV2beta3 represents the ApisixPluginConfig in apisix.apache.org/V2beta3 group version
+	ApisixPluginConfigV2beta3 = "apisix.apache.org/V2beta3"
 )
 
 // ApisixPluginConfigLister is an encapsulation for the lister of ApisixPluginConfig,
 // it aims at to be compatible with different ApisixPluginConfig versions.
 type ApisixPluginConfigLister interface {
-	// V2beta3 gets the ApisixPluginConfig in apisix.apache.org/v2beta3.
+	// V2beta3 gets the ApisixPluginConfig in apisix.apache.org/V2beta3.
 	V2beta3(string, string) (ApisixPluginConfig, error)
 }
 
@@ -45,7 +45,7 @@ type ApisixPluginConfig interface {
 	// GroupVersion returns the api group version of the
 	// real ApisixPluginConfig.
 	GroupVersion() string
-	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/v2beta3, the real
+	// V2beta3 returns the ApisixPluginConfig in apisix.apache.org/V2beta3, the real
 	// ApisixPluginConfig must be in this group version, otherwise will panic.
 	V2beta3() *configv2beta3.ApisixPluginConfig
 	// ResourceVersion returns the the resource version field inside
@@ -68,7 +68,7 @@ type apisixPluginConfig struct {
 
 func (apc *apisixPluginConfig) V2beta3() *configv2beta3.ApisixPluginConfig {
 	if apc.groupVersion != ApisixPluginConfigV2beta3 {
-		panic("not a apisix.apache.org/v2beta3 pluginConfig")
+		panic("not a apisix.apache.org/V2beta3 pluginConfig")
 	}
 	return apc.v2beta3
 }

--- a/pkg/kube/apisix_route.go
+++ b/pkg/kube/apisix_route.go
@@ -26,22 +26,22 @@ import (
 )
 
 const (
-	// ApisixRouteV2beta1 represents the ApisixRoute in apisix.apache.org/v2beta1 group version
-	ApisixRouteV2beta1 = "apisix.apache.org/v2beta1"
-	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/v2beta3 group version
-	ApisixRouteV2beta2 = "apisix.apache.org/v2beta2"
-	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/v2beta3 group version
-	ApisixRouteV2beta3 = "apisix.apache.org/v2beta3"
+	// ApisixRouteV2beta1 represents the ApisixRoute in apisix.apache.org/V2beta1 group version
+	ApisixRouteV2beta1 = "apisix.apache.org/V2beta1"
+	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/V2beta3 group version
+	ApisixRouteV2beta2 = "apisix.apache.org/V2beta2"
+	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/V2beta3 group version
+	ApisixRouteV2beta3 = "apisix.apache.org/V2beta3"
 )
 
 // ApisixRouteLister is an encapsulation for the lister of ApisixRoute,
 // it aims at to be compatible with different ApisixRoute versions.
 type ApisixRouteLister interface {
-	// V2beta1 gets the ApisixRoute in apisix.apache.org/v2beta1.
+	// V2beta1 gets the ApisixRoute in apisix.apache.org/V2beta1.
 	V2beta1(string, string) (ApisixRoute, error)
-	// V2beta2 gets the ApisixRoute in apisix.apache.org/v2beta3.
+	// V2beta2 gets the ApisixRoute in apisix.apache.org/V2beta3.
 	V2beta2(string, string) (ApisixRoute, error)
-	// V2beta3 gets the ApisixRoute in apisix.apache.org/v2beta3.
+	// V2beta3 gets the ApisixRoute in apisix.apache.org/V2beta3.
 	V2beta3(string, string) (ApisixRoute, error)
 }
 
@@ -56,16 +56,16 @@ type ApisixRouteInformer interface {
 type ApisixRoute interface {
 	// GroupVersion returns the api group version of the
 	// real ApisixRoute.
-	GroupVersion() string
-	// V2beta1 returns the ApisixRoute in apisix.apache.org/v2beta1, the real
+	GetGroupVersion() string
+	// V2beta1 returns the ApisixRoute in apisix.apache.org/V2beta1, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
-	V2beta1() *configv2beta1.ApisixRoute
-	// V2beta2 returns the ApisixRoute in apisix.apache.org/v2beta3, the real
+	GetV2beta1() *configv2beta1.ApisixRoute
+	// V2beta2 returns the ApisixRoute in apisix.apache.org/V2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
-	V2beta2() *configv2beta2.ApisixRoute
-	// V2beta3 returns the ApisixRoute in apisix.apache.org/v2beta3, the real
+	GetV2beta2() *configv2beta2.ApisixRoute
+	// V2beta3 returns the ApisixRoute in apisix.apache.org/V2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
-	V2beta3() *configv2beta3.ApisixRoute
+	GetV2beta3() *configv2beta3.ApisixRoute
 	// ResourceVersion returns the the resource version field inside
 	// the real ApisixRoute.
 	ResourceVersion() string
@@ -80,43 +80,43 @@ type ApisixRouteEvent struct {
 }
 
 type apisixRoute struct {
-	groupVersion string
-	v2beta1      *configv2beta1.ApisixRoute
-	v2beta2      *configv2beta2.ApisixRoute
-	v2beta3      *configv2beta3.ApisixRoute
+	GroupVersion string
+	V2beta1 *configv2beta1.ApisixRoute
+	V2beta2 *configv2beta2.ApisixRoute
+	V2beta3 *configv2beta3.ApisixRoute
 }
 
-func (ar *apisixRoute) V2beta1() *configv2beta1.ApisixRoute {
-	if ar.groupVersion != ApisixRouteV2beta1 {
-		panic("not a apisix.apache.org/v2beta1 route")
+func (ar *apisixRoute) GetV2beta1() *configv2beta1.ApisixRoute {
+	if ar.GroupVersion != ApisixRouteV2beta1 {
+		panic("not a apisix.apache.org/V2beta1 route")
 	}
-	return ar.v2beta1
+	return ar.V2beta1
 }
-func (ar *apisixRoute) V2beta2() *configv2beta2.ApisixRoute {
-	if ar.groupVersion != ApisixRouteV2beta2 {
-		panic("not a apisix.apache.org/v2beta3 route")
+func (ar *apisixRoute) GetV2beta2() *configv2beta2.ApisixRoute {
+	if ar.GroupVersion != ApisixRouteV2beta2 {
+		panic("not a apisix.apache.org/V2beta3 route")
 	}
-	return ar.v2beta2
-}
-
-func (ar *apisixRoute) V2beta3() *configv2beta3.ApisixRoute {
-	if ar.groupVersion != ApisixRouteV2beta3 {
-		panic("not a apisix.apache.org/v2beta3 route")
-	}
-	return ar.v2beta3
+	return ar.V2beta2
 }
 
-func (ar *apisixRoute) GroupVersion() string {
-	return ar.groupVersion
+func (ar *apisixRoute) GetV2beta3() *configv2beta3.ApisixRoute {
+	if ar.GroupVersion != ApisixRouteV2beta3 {
+		panic("not a apisix.apache.org/V2beta3 route")
+	}
+	return ar.V2beta3
+}
+
+func (ar *apisixRoute) GetGroupVersion() string {
+	return ar.GroupVersion
 }
 
 func (ar *apisixRoute) ResourceVersion() string {
-	if ar.groupVersion == ApisixRouteV2beta1 {
-		return ar.V2beta1().ResourceVersion
-	} else if ar.groupVersion == ApisixRouteV2beta2 {
-		return ar.V2beta2().ResourceVersion
+	if ar.GroupVersion == ApisixRouteV2beta1 {
+		return ar.GetV2beta1().ResourceVersion
+	} else if ar.GroupVersion == ApisixRouteV2beta2 {
+		return ar.GetV2beta2().ResourceVersion
 	}
-	return ar.V2beta3().ResourceVersion
+	return ar.GetV2beta3().ResourceVersion
 }
 
 type apisixRouteLister struct {
@@ -131,8 +131,8 @@ func (l *apisixRouteLister) V2beta1(namespace, name string) (ApisixRoute, error)
 		return nil, err
 	}
 	return &apisixRoute{
-		groupVersion: ApisixRouteV2beta1,
-		v2beta1:      ar,
+		GroupVersion: ApisixRouteV2beta1,
+		V2beta1:      ar,
 	}, nil
 }
 
@@ -142,8 +142,8 @@ func (l *apisixRouteLister) V2beta2(namespace, name string) (ApisixRoute, error)
 		return nil, err
 	}
 	return &apisixRoute{
-		groupVersion: ApisixRouteV2beta2,
-		v2beta2:      ar,
+		GroupVersion: ApisixRouteV2beta2,
+		V2beta2:      ar,
 	}, nil
 }
 
@@ -153,8 +153,8 @@ func (l *apisixRouteLister) V2beta3(namespace, name string) (ApisixRoute, error)
 		return nil, err
 	}
 	return &apisixRoute{
-		groupVersion: ApisixRouteV2beta3,
-		v2beta3:      ar,
+		GroupVersion: ApisixRouteV2beta3,
+		V2beta3:      ar,
 	}, nil
 }
 
@@ -164,18 +164,18 @@ func MustNewApisixRoute(obj interface{}) ApisixRoute {
 	switch ar := obj.(type) {
 	case *configv2beta1.ApisixRoute:
 		return &apisixRoute{
-			groupVersion: ApisixRouteV2beta1,
-			v2beta1:      ar,
+			GroupVersion: ApisixRouteV2beta1,
+			V2beta1:      ar,
 		}
 	case *configv2beta2.ApisixRoute:
 		return &apisixRoute{
-			groupVersion: ApisixRouteV2beta2,
-			v2beta2:      ar,
+			GroupVersion: ApisixRouteV2beta2,
+			V2beta2:      ar,
 		}
 	case *configv2beta3.ApisixRoute:
 		return &apisixRoute{
-			groupVersion: ApisixRouteV2beta3,
-			v2beta3:      ar,
+			GroupVersion: ApisixRouteV2beta3,
+			V2beta3:      ar,
 		}
 	default:
 		panic("invalid ApisixRoute type")
@@ -189,18 +189,18 @@ func NewApisixRoute(obj interface{}) (ApisixRoute, error) {
 	switch ar := obj.(type) {
 	case *configv2beta1.ApisixRoute:
 		return &apisixRoute{
-			groupVersion: ApisixRouteV2beta1,
-			v2beta1:      ar,
+			GroupVersion: ApisixRouteV2beta1,
+			V2beta1:      ar,
 		}, nil
 	case *configv2beta2.ApisixRoute:
 		return &apisixRoute{
-			groupVersion: ApisixRouteV2beta2,
-			v2beta2:      ar,
+			GroupVersion: ApisixRouteV2beta2,
+			V2beta2:      ar,
 		}, nil
 	case *configv2beta3.ApisixRoute:
 		return &apisixRoute{
-			groupVersion: ApisixRouteV2beta3,
-			v2beta3:      ar,
+			GroupVersion: ApisixRouteV2beta3,
+			V2beta3:      ar,
 		}, nil
 	default:
 		return nil, errors.New("invalid ApisixRoute type")

--- a/pkg/kube/apisix_route.go
+++ b/pkg/kube/apisix_route.go
@@ -81,9 +81,9 @@ type ApisixRouteEvent struct {
 
 type apisixRoute struct {
 	GroupVersion string
-	V2beta1 *configv2beta1.ApisixRoute
-	V2beta2 *configv2beta2.ApisixRoute
-	V2beta3 *configv2beta3.ApisixRoute
+	V2beta1      *configv2beta1.ApisixRoute
+	V2beta2      *configv2beta2.ApisixRoute
+	V2beta3      *configv2beta3.ApisixRoute
 }
 
 func (ar *apisixRoute) GetV2beta1() *configv2beta1.ApisixRoute {

--- a/pkg/kube/apisix_route.go
+++ b/pkg/kube/apisix_route.go
@@ -26,22 +26,22 @@ import (
 )
 
 const (
-	// ApisixRouteV2beta1 represents the ApisixRoute in apisix.apache.org/V2beta1 group version
+	// ApisixRouteV2beta1 represents the ApisixRoute in apisix.apache.org/v2beta1 group version
 	ApisixRouteV2beta1 = "apisix.apache.org/v2beta1"
-	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/GetV2beta3 group version
+	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/v2beta3 group version
 	ApisixRouteV2beta2 = "apisix.apache.org/v2beta2"
-	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/GetV2beta3 group version
+	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/v2beta3 group version
 	ApisixRouteV2beta3 = "apisix.apache.org/v2beta3"
 )
 
 // ApisixRouteLister is an encapsulation for the lister of ApisixRoute,
 // it aims at to be compatible with different ApisixRoute versions.
 type ApisixRouteLister interface {
-	// V2beta1 gets the ApisixRoute in apisix.apache.org/V2beta1.
+	// V2beta1 gets the ApisixRoute in apisix.apache.org/v2beta1.
 	V2beta1(string, string) (ApisixRoute, error)
-	// V2beta2 gets the ApisixRoute in apisix.apache.org/GetV2beta3.
+	// V2beta2 gets the ApisixRoute in apisix.apache.org/v2beta3.
 	V2beta2(string, string) (ApisixRoute, error)
-	// V2beta3 gets the ApisixRoute in apisix.apache.org/GetV2beta3.
+	// V2beta3 gets the ApisixRoute in apisix.apache.org/v2beta3.
 	V2beta3(string, string) (ApisixRoute, error)
 }
 
@@ -52,18 +52,18 @@ type ApisixRouteInformer interface {
 }
 
 // ApisixRoute is an encapsulation for ApisixRoute resource with different
-// versions, for now, they are apisix.apache.org/V1 and apisix.apache.org/v2alpha1
+// versions, for now, they are apisix.apache.org/v1 and apisix.apache.org/v2alpha1
 type ApisixRoute interface {
 	// GetGroupVersion returns the api group version of the
 	// real ApisixRoute.
 	GetGroupVersion() string
-	// V2beta1 returns the ApisixRoute in apisix.apache.org/V2beta1, the real
+	// V2beta1 returns the ApisixRoute in apisix.apache.org/v2beta1, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta1() *configv2beta1.ApisixRoute
-	// V2beta2 returns the ApisixRoute in apisix.apache.org/GetV2beta3, the real
+	// V2beta2 returns the ApisixRoute in apisix.apache.org/v2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta2() *configv2beta2.ApisixRoute
-	// GetV2beta3 returns the ApisixRoute in apisix.apache.org/GetV2beta3, the real
+	// GetV2beta3 returns the ApisixRoute in apisix.apache.org/v2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta3() *configv2beta3.ApisixRoute
 	// GetResourceVersion returns the the resource version field inside
@@ -88,20 +88,20 @@ type apisixRoute struct {
 
 func (ar *apisixRoute) GetV2beta1() *configv2beta1.ApisixRoute {
 	if ar.GroupVersion != ApisixRouteV2beta1 {
-		panic("not a apisix.apache.org/V2beta1 route")
+		panic("not a apisix.apache.org/v2beta1 route")
 	}
 	return ar.V2beta1
 }
 func (ar *apisixRoute) GetV2beta2() *configv2beta2.ApisixRoute {
 	if ar.GroupVersion != ApisixRouteV2beta2 {
-		panic("not a apisix.apache.org/GetV2beta3 route")
+		panic("not a apisix.apache.org/v2beta3 route")
 	}
 	return ar.V2beta2
 }
 
 func (ar *apisixRoute) GetV2beta3() *configv2beta3.ApisixRoute {
 	if ar.GroupVersion != ApisixRouteV2beta3 {
-		panic("not a apisix.apache.org/GetV2beta3 route")
+		panic("not a apisix.apache.org/v2beta3 route")
 	}
 	return ar.V2beta3
 }

--- a/pkg/kube/apisix_route.go
+++ b/pkg/kube/apisix_route.go
@@ -27,11 +27,11 @@ import (
 
 const (
 	// ApisixRouteV2beta1 represents the ApisixRoute in apisix.apache.org/V2beta1 group version
-	ApisixRouteV2beta1 = "apisix.apache.org/V2beta1"
+	ApisixRouteV2beta1 = "apisix.apache.org/v2beta1"
 	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/GetV2beta3 group version
-	ApisixRouteV2beta2 = "apisix.apache.org/V2beta2"
+	ApisixRouteV2beta2 = "apisix.apache.org/v2beta2"
 	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/GetV2beta3 group version
-	ApisixRouteV2beta3 = "apisix.apache.org/GetV2beta3"
+	ApisixRouteV2beta3 = "apisix.apache.org/v2beta3"
 )
 
 // ApisixRouteLister is an encapsulation for the lister of ApisixRoute,

--- a/pkg/kube/apisix_route.go
+++ b/pkg/kube/apisix_route.go
@@ -28,10 +28,10 @@ import (
 const (
 	// ApisixRouteV2beta1 represents the ApisixRoute in apisix.apache.org/V2beta1 group version
 	ApisixRouteV2beta1 = "apisix.apache.org/V2beta1"
-	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/V2beta3 group version
+	// ApisixRouteV2beta2 represents the ApisixRoute in apisix.apache.org/GetV2beta3 group version
 	ApisixRouteV2beta2 = "apisix.apache.org/V2beta2"
-	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/V2beta3 group version
-	ApisixRouteV2beta3 = "apisix.apache.org/V2beta3"
+	// ApisixRouteV2beta3 represents the ApisixRoute in apisix.apache.org/GetV2beta3 group version
+	ApisixRouteV2beta3 = "apisix.apache.org/GetV2beta3"
 )
 
 // ApisixRouteLister is an encapsulation for the lister of ApisixRoute,
@@ -39,9 +39,9 @@ const (
 type ApisixRouteLister interface {
 	// V2beta1 gets the ApisixRoute in apisix.apache.org/V2beta1.
 	V2beta1(string, string) (ApisixRoute, error)
-	// V2beta2 gets the ApisixRoute in apisix.apache.org/V2beta3.
+	// V2beta2 gets the ApisixRoute in apisix.apache.org/GetV2beta3.
 	V2beta2(string, string) (ApisixRoute, error)
-	// V2beta3 gets the ApisixRoute in apisix.apache.org/V2beta3.
+	// V2beta3 gets the ApisixRoute in apisix.apache.org/GetV2beta3.
 	V2beta3(string, string) (ApisixRoute, error)
 }
 
@@ -52,23 +52,23 @@ type ApisixRouteInformer interface {
 }
 
 // ApisixRoute is an encapsulation for ApisixRoute resource with different
-// versions, for now, they are apisix.apache.org/v1 and apisix.apache.org/v2alpha1
+// versions, for now, they are apisix.apache.org/V1 and apisix.apache.org/v2alpha1
 type ApisixRoute interface {
-	// GroupVersion returns the api group version of the
+	// GetGroupVersion returns the api group version of the
 	// real ApisixRoute.
 	GetGroupVersion() string
 	// V2beta1 returns the ApisixRoute in apisix.apache.org/V2beta1, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta1() *configv2beta1.ApisixRoute
-	// V2beta2 returns the ApisixRoute in apisix.apache.org/V2beta3, the real
+	// V2beta2 returns the ApisixRoute in apisix.apache.org/GetV2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta2() *configv2beta2.ApisixRoute
-	// V2beta3 returns the ApisixRoute in apisix.apache.org/V2beta3, the real
+	// GetV2beta3 returns the ApisixRoute in apisix.apache.org/GetV2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta3() *configv2beta3.ApisixRoute
-	// ResourceVersion returns the the resource version field inside
+	// GetResourceVersion returns the the resource version field inside
 	// the real ApisixRoute.
-	ResourceVersion() string
+	GetResourceVersion() string
 }
 
 // ApisixRouteEvent contains the ApisixRoute key (namespace/name)
@@ -94,14 +94,14 @@ func (ar *apisixRoute) GetV2beta1() *configv2beta1.ApisixRoute {
 }
 func (ar *apisixRoute) GetV2beta2() *configv2beta2.ApisixRoute {
 	if ar.GroupVersion != ApisixRouteV2beta2 {
-		panic("not a apisix.apache.org/V2beta3 route")
+		panic("not a apisix.apache.org/GetV2beta3 route")
 	}
 	return ar.V2beta2
 }
 
 func (ar *apisixRoute) GetV2beta3() *configv2beta3.ApisixRoute {
 	if ar.GroupVersion != ApisixRouteV2beta3 {
-		panic("not a apisix.apache.org/V2beta3 route")
+		panic("not a apisix.apache.org/GetV2beta3 route")
 	}
 	return ar.V2beta3
 }
@@ -110,7 +110,7 @@ func (ar *apisixRoute) GetGroupVersion() string {
 	return ar.GroupVersion
 }
 
-func (ar *apisixRoute) ResourceVersion() string {
+func (ar *apisixRoute) GetResourceVersion() string {
 	if ar.GroupVersion == ApisixRouteV2beta1 {
 		return ar.GetV2beta1().ResourceVersion
 	} else if ar.GroupVersion == ApisixRouteV2beta2 {

--- a/pkg/kube/apisix_route.go
+++ b/pkg/kube/apisix_route.go
@@ -57,10 +57,10 @@ type ApisixRoute interface {
 	// GetGroupVersion returns the api group version of the
 	// real ApisixRoute.
 	GetGroupVersion() string
-	// V2beta1 returns the ApisixRoute in apisix.apache.org/v2beta1, the real
+	// GetV2beta1 returns the ApisixRoute in apisix.apache.org/v2beta1, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta1() *configv2beta1.ApisixRoute
-	// V2beta2 returns the ApisixRoute in apisix.apache.org/v2beta3, the real
+	// GetV2beta2 returns the ApisixRoute in apisix.apache.org/v2beta3, the real
 	// ApisixRoute must be in this group version, otherwise will panic.
 	GetV2beta2() *configv2beta2.ApisixRoute
 	// GetV2beta3 returns the ApisixRoute in apisix.apache.org/v2beta3, the real

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -80,7 +80,7 @@ type IngressEvent struct {
 }
 
 type ingress struct {
-	GroupVersion string
+	GroupVersion      string
 	V1                *networkingv1.Ingress
 	V1beta1           *networkingv1beta1.Ingress
 	ExtensionsV1beta1 *extensionsv1beta1.Ingress

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -37,11 +37,11 @@ const (
 // IngressLister is an encapsulation for the lister of Kubernetes
 // Ingress, it aims at to be compatible with different Ingress versions.
 type IngressLister interface {
-	// V1 gets the ingress in networking/V1.
+	// V1 gets the ingress in networking/v1.
 	V1(string, string) (Ingress, error)
-	// V1beta1 gets the ingress in networking/V1beta1.
+	// V1beta1 gets the ingress in networking/v1beta1.
 	V1beta1(string, string) (Ingress, error)
-	// ExtensionsV1beta1 gets the ingress in extensions/V1beta1.
+	// ExtensionsV1beta1 gets the ingress in extensions/v1beta1.
 	ExtensionsV1beta1(string, string) (Ingress, error)
 }
 
@@ -52,21 +52,21 @@ type IngressInformer interface {
 }
 
 // Ingress is an encapsulation for Kubernetes Ingress with different
-// versions, for now, they are networking/V1 and networking/V1beta1.
+// versions, for now, they are networking/v1 and networking/v1beta1.
 type Ingress interface {
-	// GroupVersion returns the api group version of the
+	// GetGroupVersion returns the api group version of the
 	// real ingress.
 	GetGroupVersion() string
-	// V1 returns the ingress in networking/V1, the real
-	// ingress must be in networking/V1, or V1() will panic.
+	// GetV1 returns the ingress in networking/v1, the real
+	// ingress must be in networking/v1, or GetV1() will panic.
 	GetV1() *networkingv1.Ingress
-	// V1beta1 returns the ingress in networking/V1beta1, the real
-	// ingress must be in networking/V1beta1, or V1beta1() will panic.
+	// GetV1beta1 returns the ingress in networking/v1beta1, the real
+	// ingress must be in networking/v1beta1, or V1beta1() will panic.
 	GetV1beta1() *networkingv1beta1.Ingress
-	// ExtensionsV1beta1 returns the ingress in extensions/V1beta1, the real
-	// ingress must be in extensions/V1beta1, or ExtensionsV1beta1() will panic.
+	// GetExtensionsV1beta1 returns the ingress in extensions/v1beta1, the real
+	// ingress must be in extensions/v1beta1, or GetExtensionsV1beta1() will panic.
 	GetExtensionsV1beta1() *extensionsv1beta1.Ingress
-	// ResourceVersion returns the the resource version field inside
+	// GetResourceVersion returns the the resource version field inside
 	// the real Ingress.
 	GetResourceVersion() string
 }

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -27,11 +27,11 @@ import (
 
 const (
 	// IngressV1 represents the Ingress in networking/V1 group version.
-	IngressV1 = "networking/V1"
+	IngressV1 = "networking/v1"
 	// IngressV1beta1 represents the Ingress in networking/V1beta1 group version.
-	IngressV1beta1 = "networking/V1beta1"
+	IngressV1beta1 = "networking/v1beta1"
 	// IngressExtensionsV1beta1 represents the Ingress in extensions/V1beta1 group version.
-	IngressExtensionsV1beta1 = "extensions/V1beta1"
+	IngressExtensionsV1beta1 = "extensions/v1beta1"
 )
 
 // IngressLister is an encapsulation for the lister of Kubernetes

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -61,12 +61,12 @@ type Ingress interface {
 	// ingress must be in networking/v1, or GetV1() will panic.
 	GetV1() *networkingv1.Ingress
 	// GetV1beta1 returns the ingress in networking/v1beta1, the real
-	// ingress must be in networking/v1beta1, or V1beta1() will panic.
+	// ingress must be in networking/v1beta1, or GetV1beta1() will panic.
 	GetV1beta1() *networkingv1beta1.Ingress
 	// GetExtensionsV1beta1 returns the ingress in extensions/v1beta1, the real
 	// ingress must be in extensions/v1beta1, or GetExtensionsV1beta1() will panic.
 	GetExtensionsV1beta1() *extensionsv1beta1.Ingress
-	// GetResourceVersion returns the the resource version field inside
+	// GetResourceVersion returns the resource version field inside
 	// the real Ingress.
 	GetResourceVersion() string
 }

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	// IngressV1 represents the Ingress in networking/V1 group version.
+	// IngressV1 represents the Ingress in networking/v1 group version.
 	IngressV1 = "networking/v1"
-	// IngressV1beta1 represents the Ingress in networking/V1beta1 group version.
+	// IngressV1beta1 represents the Ingress in networking/v1beta1 group version.
 	IngressV1beta1 = "networking/v1beta1"
-	// IngressExtensionsV1beta1 represents the Ingress in extensions/V1beta1 group version.
+	// IngressExtensionsV1beta1 represents the Ingress in extensions/v1beta1 group version.
 	IngressExtensionsV1beta1 = "extensions/v1beta1"
 )
 
@@ -88,21 +88,21 @@ type ingress struct {
 
 func (ing *ingress) GetV1() *networkingv1.Ingress {
 	if ing.GroupVersion != IngressV1 {
-		panic("not a networking/V1 ingress")
+		panic("not a networking/v1 ingress")
 	}
 	return ing.V1
 }
 
 func (ing *ingress) GetV1beta1() *networkingv1beta1.Ingress {
 	if ing.GroupVersion != IngressV1beta1 {
-		panic("not a networking/V1beta1 ingress")
+		panic("not a networking/v1beta1 ingress")
 	}
 	return ing.V1beta1
 }
 
 func (ing *ingress) GetExtensionsV1beta1() *extensionsv1beta1.Ingress {
 	if ing.GroupVersion != IngressExtensionsV1beta1 {
-		panic("not a extensions/V1beta1 ingress")
+		panic("not a extensions/v1beta1 ingress")
 	}
 	return ing.ExtensionsV1beta1
 }

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -26,22 +26,22 @@ import (
 )
 
 const (
-	// IngressV1 represents the Ingress in networking/v1 group version.
-	IngressV1 = "networking/v1"
-	// IngressV1beta1 represents the Ingress in networking/v1beta1 group version.
-	IngressV1beta1 = "networking/v1beta1"
-	// IngressExtensionsV1beta1 represents the Ingress in extensions/v1beta1 group version.
-	IngressExtensionsV1beta1 = "extensions/v1beta1"
+	// IngressV1 represents the Ingress in networking/V1 group version.
+	IngressV1 = "networking/V1"
+	// IngressV1beta1 represents the Ingress in networking/V1beta1 group version.
+	IngressV1beta1 = "networking/V1beta1"
+	// IngressExtensionsV1beta1 represents the Ingress in extensions/V1beta1 group version.
+	IngressExtensionsV1beta1 = "extensions/V1beta1"
 )
 
 // IngressLister is an encapsulation for the lister of Kubernetes
 // Ingress, it aims at to be compatible with different Ingress versions.
 type IngressLister interface {
-	// V1 gets the ingress in networking/v1.
+	// V1 gets the ingress in networking/V1.
 	V1(string, string) (Ingress, error)
-	// V1beta1 gets the ingress in networking/v1beta1.
+	// V1beta1 gets the ingress in networking/V1beta1.
 	V1beta1(string, string) (Ingress, error)
-	// ExtensionsV1beta1 gets the ingress in extensions/v1beta1.
+	// ExtensionsV1beta1 gets the ingress in extensions/V1beta1.
 	ExtensionsV1beta1(string, string) (Ingress, error)
 }
 
@@ -52,23 +52,23 @@ type IngressInformer interface {
 }
 
 // Ingress is an encapsulation for Kubernetes Ingress with different
-// versions, for now, they are networking/v1 and networking/v1beta1.
+// versions, for now, they are networking/V1 and networking/V1beta1.
 type Ingress interface {
 	// GroupVersion returns the api group version of the
 	// real ingress.
-	GroupVersion() string
-	// V1 returns the ingress in networking/v1, the real
-	// ingress must be in networking/v1, or V1() will panic.
-	V1() *networkingv1.Ingress
-	// V1beta1 returns the ingress in networking/v1beta1, the real
-	// ingress must be in networking/v1beta1, or V1beta1() will panic.
-	V1beta1() *networkingv1beta1.Ingress
-	// ExtensionsV1beta1 returns the ingress in extensions/v1beta1, the real
-	// ingress must be in extensions/v1beta1, or ExtensionsV1beta1() will panic.
-	ExtensionsV1beta1() *extensionsv1beta1.Ingress
+	GetGroupVersion() string
+	// V1 returns the ingress in networking/V1, the real
+	// ingress must be in networking/V1, or V1() will panic.
+	GetV1() *networkingv1.Ingress
+	// V1beta1 returns the ingress in networking/V1beta1, the real
+	// ingress must be in networking/V1beta1, or V1beta1() will panic.
+	GetV1beta1() *networkingv1beta1.Ingress
+	// ExtensionsV1beta1 returns the ingress in extensions/V1beta1, the real
+	// ingress must be in extensions/V1beta1, or ExtensionsV1beta1() will panic.
+	GetExtensionsV1beta1() *extensionsv1beta1.Ingress
 	// ResourceVersion returns the the resource version field inside
 	// the real Ingress.
-	ResourceVersion() string
+	GetResourceVersion() string
 }
 
 // IngressEvents contains the ingress key (namespace/name)
@@ -80,45 +80,45 @@ type IngressEvent struct {
 }
 
 type ingress struct {
-	groupVersion      string
-	v1                *networkingv1.Ingress
-	v1beta1           *networkingv1beta1.Ingress
-	extensionsV1beta1 *extensionsv1beta1.Ingress
+	GroupVersion string
+	V1                *networkingv1.Ingress
+	V1beta1           *networkingv1beta1.Ingress
+	ExtensionsV1beta1 *extensionsv1beta1.Ingress
 }
 
-func (ing *ingress) V1() *networkingv1.Ingress {
-	if ing.groupVersion != IngressV1 {
-		panic("not a networking/v1 ingress")
+func (ing *ingress) GetV1() *networkingv1.Ingress {
+	if ing.GroupVersion != IngressV1 {
+		panic("not a networking/V1 ingress")
 	}
-	return ing.v1
+	return ing.V1
 }
 
-func (ing *ingress) V1beta1() *networkingv1beta1.Ingress {
-	if ing.groupVersion != IngressV1beta1 {
-		panic("not a networking/v1beta1 ingress")
+func (ing *ingress) GetV1beta1() *networkingv1beta1.Ingress {
+	if ing.GroupVersion != IngressV1beta1 {
+		panic("not a networking/V1beta1 ingress")
 	}
-	return ing.v1beta1
+	return ing.V1beta1
 }
 
-func (ing *ingress) ExtensionsV1beta1() *extensionsv1beta1.Ingress {
-	if ing.groupVersion != IngressExtensionsV1beta1 {
-		panic("not a extensions/v1beta1 ingress")
+func (ing *ingress) GetExtensionsV1beta1() *extensionsv1beta1.Ingress {
+	if ing.GroupVersion != IngressExtensionsV1beta1 {
+		panic("not a extensions/V1beta1 ingress")
 	}
-	return ing.extensionsV1beta1
+	return ing.ExtensionsV1beta1
 }
 
-func (ing *ingress) GroupVersion() string {
-	return ing.groupVersion
+func (ing *ingress) GetGroupVersion() string {
+	return ing.GroupVersion
 }
 
-func (ing *ingress) ResourceVersion() string {
-	if ing.GroupVersion() == IngressV1 {
-		return ing.V1().ResourceVersion
+func (ing *ingress) GetResourceVersion() string {
+	if ing.GetGroupVersion() == IngressV1 {
+		return ing.GetV1().ResourceVersion
 	}
-	if ing.GroupVersion() == IngressV1beta1 {
-		return ing.V1beta1().ResourceVersion
+	if ing.GetGroupVersion() == IngressV1beta1 {
+		return ing.GetV1beta1().ResourceVersion
 	}
-	return ing.ExtensionsV1beta1().ResourceVersion
+	return ing.GetExtensionsV1beta1().ResourceVersion
 }
 
 type ingressLister struct {
@@ -133,8 +133,8 @@ func (l *ingressLister) V1(namespace, name string) (Ingress, error) {
 		return nil, err
 	}
 	return &ingress{
-		groupVersion: IngressV1,
-		v1:           ing,
+		GroupVersion: IngressV1,
+		V1:           ing,
 	}, nil
 }
 
@@ -144,8 +144,8 @@ func (l *ingressLister) V1beta1(namespace, name string) (Ingress, error) {
 		return nil, err
 	}
 	return &ingress{
-		groupVersion: IngressV1beta1,
-		v1beta1:      ing,
+		GroupVersion: IngressV1beta1,
+		V1beta1:      ing,
 	}, nil
 }
 
@@ -155,8 +155,8 @@ func (l *ingressLister) ExtensionsV1beta1(namespace, name string) (Ingress, erro
 		return nil, err
 	}
 	return &ingress{
-		groupVersion:      IngressExtensionsV1beta1,
-		extensionsV1beta1: ing,
+		GroupVersion:      IngressExtensionsV1beta1,
+		ExtensionsV1beta1: ing,
 	}, nil
 }
 
@@ -166,18 +166,18 @@ func MustNewIngress(obj interface{}) Ingress {
 	switch ing := obj.(type) {
 	case *networkingv1.Ingress:
 		return &ingress{
-			groupVersion: IngressV1,
-			v1:           ing,
+			GroupVersion: IngressV1,
+			V1:           ing,
 		}
 	case *networkingv1beta1.Ingress:
 		return &ingress{
-			groupVersion: IngressV1beta1,
-			v1beta1:      ing,
+			GroupVersion: IngressV1beta1,
+			V1beta1:      ing,
 		}
 	case *extensionsv1beta1.Ingress:
 		return &ingress{
-			groupVersion:      IngressExtensionsV1beta1,
-			extensionsV1beta1: ing,
+			GroupVersion:      IngressExtensionsV1beta1,
+			ExtensionsV1beta1: ing,
 		}
 	default:
 		panic("invalid ingress type")
@@ -191,18 +191,18 @@ func NewIngress(obj interface{}) (Ingress, error) {
 	switch ing := obj.(type) {
 	case *networkingv1.Ingress:
 		return &ingress{
-			groupVersion: IngressV1,
-			v1:           ing,
+			GroupVersion: IngressV1,
+			V1:           ing,
 		}, nil
 	case *networkingv1beta1.Ingress:
 		return &ingress{
-			groupVersion: IngressV1beta1,
-			v1beta1:      ing,
+			GroupVersion: IngressV1beta1,
+			V1beta1:      ing,
 		}, nil
 	case *extensionsv1beta1.Ingress:
 		return &ingress{
-			groupVersion:      IngressExtensionsV1beta1,
-			extensionsV1beta1: ing,
+			GroupVersion:      IngressExtensionsV1beta1,
+			ExtensionsV1beta1: ing,
 		}, nil
 	default:
 		return nil, errors.New("invalid ingress type")

--- a/pkg/kube/translation/translator.go
+++ b/pkg/kube/translation/translator.go
@@ -255,14 +255,14 @@ func (t *translator) TranslateUpstreamNodes(endpoint kube.Endpoint, port int32, 
 }
 
 func (t *translator) TranslateIngress(ing kube.Ingress) (*TranslateContext, error) {
-	switch ing.GroupVersion() {
+	switch ing.GetGroupVersion() {
 	case kube.IngressV1:
-		return t.translateIngressV1(ing.V1())
+		return t.translateIngressV1(ing.GetV1())
 	case kube.IngressV1beta1:
-		return t.translateIngressV1beta1(ing.V1beta1())
+		return t.translateIngressV1beta1(ing.GetV1beta1())
 	case kube.IngressExtensionsV1beta1:
-		return t.translateIngressExtensionsV1beta1(ing.ExtensionsV1beta1())
+		return t.translateIngressExtensionsV1beta1(ing.GetExtensionsV1beta1())
 	default:
-		return nil, fmt.Errorf("translator: source group version not supported: %s", ing.GroupVersion())
+		return nil, fmt.Errorf("translator: source group version not supported: %s", ing.GetGroupVersion())
 	}
 }


### PR DESCRIPTION
### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
Resolved #912 
The encoding/json package and similar packages ignore unexported fields, so we should export these type.