### PR TITLE
fix: ingress update event handler not filter by watching namespaces

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -307,6 +307,9 @@ func (c *ingressController) onUpdate(oldObj, newObj interface{}) {
 		log.Errorf("found ingress resource with bad meta namespace key: %s", err)
 		return
 	}
+	if !c.controller.isWatchingNamespace(key) {
+		return
+	}
 	valid := c.isIngressEffective(curr)
 	if valid {
 		log.Debugw("ingress update event arrived",


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/apache/apisix-ingress-controller/issues/869
Since the ingress update event handler is not filtered according to the watching namespaces, and our e2e uses two ginkgo nodes, it will cause the lb status test case to be interfered with the ingress controller in other test cases. This is why e2e is unstable as described in https://github.com/apache/apisix-ingress-controller/issues/869.
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
