### PR TITLE
feat: Add support force-ssl-redirect to ingress translator

### DIFF
--- a/docs/en/latest/concepts/annotations.md
+++ b/docs/en/latest/concepts/annotations.md
@@ -104,6 +104,7 @@ Redirect
 You can use the following annotations to control the redirect behavior.
 
 * `k8s.apisix.apache.org/http-to-https`
+* `ingress.kubernetes.io/force-ssl-redirect`
 
 If this annotation set to `true` and the request is HTTP, it will be automatically redirected to HTTPS with 301 response code,
 and the URI will keep the same as client request.

--- a/pkg/kube/translation/annotations/redirect.go
+++ b/pkg/kube/translation/annotations/redirect.go
@@ -20,6 +20,8 @@ import (
 
 const (
 	_httpToHttps = AnnotationsPrefix + "http-to-https"
+	// _sslRedirectKey is kinda the standard found out there for ingresses
+	_sslRedirectKey = "ingress.kubernetes.io/force-ssl-redirect"
 )
 
 type redirect struct{}
@@ -36,7 +38,7 @@ func (r *redirect) PluginName() string {
 
 func (r *redirect) Handle(e Extractor) (interface{}, error) {
 	var plugin apisixv1.RedirectConfig
-	plugin.HttpToHttps = e.GetBoolAnnotation(_httpToHttps)
+	plugin.HttpToHttps = e.GetBoolAnnotation(_httpToHttps) || e.GetBoolAnnotation(_sslRedirectKey)
 	// To avoid empty redirect plugin config, adding the check about the redirect.
 	if plugin.HttpToHttps {
 		return &plugin, nil

--- a/pkg/kube/translation/ingress.go
+++ b/pkg/kube/translation/ingress.go
@@ -16,6 +16,7 @@ package translation
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -38,6 +39,9 @@ import (
 const (
 	_regexPriority = 100
 )
+
+// errPluginAnnotationsWithoutService makes sure that plugins are not used without service
+var errPluginAnnotationsWithoutService = errors.New("plugin annotations cannot be used without a valid service")
 
 func (t *translator) translateIngressV1(ing *networkingv1.Ingress) (*TranslateContext, error) {
 	ctx := defaultEmptyTranslateContext()
@@ -137,6 +141,9 @@ func (t *translator) translateIngressV1(ing *networkingv1.Ingress) (*TranslateCo
 				route.Priority = _regexPriority
 			}
 			if len(plugins) > 0 {
+				if pathRule.Backend.Service == nil {
+					return nil, errPluginAnnotationsWithoutService
+				}
 				route.Plugins = *(plugins.DeepCopy())
 
 				pluginConfig = apisixv1.NewDefaultPluginConfig()


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should make apsix use the annotation ingress.kubernetes.io/force-ssl-redirect: true
and convert it to a redirect plugins, making it compatible with common annotations for ingresses.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing 
list](https://github.com/apache/apisix-ingress-controller#community) first**
