### PR TITLE
fix: fix tag for keyAuth field

### DIFF
--- a/pkg/kube/apisix/apis/config/v2/types.go
+++ b/pkg/kube/apisix/apis/config/v2/types.go
@@ -171,7 +171,7 @@ type ApisixRouteHTTPPluginConfig map[string]interface{}
 type ApisixRouteAuthentication struct {
 	Enable  bool                             `json:"enable" yaml:"enable"`
 	Type    string                           `json:"type" yaml:"type"`
-	KeyAuth ApisixRouteAuthenticationKeyAuth `json:"keyauth,omitempty" yaml:"keyauth,omitempty"`
+	KeyAuth ApisixRouteAuthenticationKeyAuth `json:"keyAuth,omitempty" yaml:"keyAuth,omitempty"`
 	JwtAuth ApisixRouteAuthenticationJwtAuth `json:"jwtAuth,omitempty" yaml:"jwtAuth,omitempty"`
 }
 

--- a/pkg/kube/apisix/apis/config/v2beta2/types.go
+++ b/pkg/kube/apisix/apis/config/v2beta2/types.go
@@ -131,7 +131,7 @@ type ApisixRouteHTTPPluginConfig map[string]interface{}
 type ApisixRouteAuthentication struct {
 	Enable  bool                             `json:"enable" yaml:"enable"`
 	Type    string                           `json:"type" yaml:"type"`
-	KeyAuth ApisixRouteAuthenticationKeyAuth `json:"keyauth,omitempty" yaml:"keyauth,omitempty"`
+	KeyAuth ApisixRouteAuthenticationKeyAuth `json:"keyAuth,omitempty" yaml:"keyAuth,omitempty"`
 }
 
 // ApisixRouteAuthenticationKeyAuth is the keyAuth-related

--- a/pkg/kube/apisix/apis/config/v2beta3/types.go
+++ b/pkg/kube/apisix/apis/config/v2beta3/types.go
@@ -172,7 +172,7 @@ type ApisixRouteHTTPPluginConfig map[string]interface{}
 type ApisixRouteAuthentication struct {
 	Enable  bool                             `json:"enable" yaml:"enable"`
 	Type    string                           `json:"type" yaml:"type"`
-	KeyAuth ApisixRouteAuthenticationKeyAuth `json:"keyauth,omitempty" yaml:"keyauth,omitempty"`
+	KeyAuth ApisixRouteAuthenticationKeyAuth `json:"keyAuth,omitempty" yaml:"keyAuth,omitempty"`
 	JwtAuth ApisixRouteAuthenticationJwtAuth `json:"jwtAuth,omitempty" yaml:"jwtAuth,omitempty"`
 }
 


### PR DESCRIPTION
### Type of change:

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:

I'm currently doing some work to migrate kong's configuration to apisixroute, when marshaling `github.com/apache/apisix-ingress-controller/pkg/kube/apisix/apis/config/v2beta3.ApisixRoute` object,  the output of `keyAuth` field is `keyauth`.
So when I applied the generated manifests to apiserver, action failed because of CRD's Scheme verification.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
