### PR TITLE
chore: enable stale GitHub action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 name: 'Close stale issues and PRs'
 
 on:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,53 @@
+name: 'Close stale issues and PRs'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    name: Prune Stale
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-message: >
+            This issue has been marked as stale due to 90 days of inactivity.
+            It will be closed in 30 days if no further activity occurs. If this issue is still
+            relevant, please simply write any comment. Even if closed, you can still revive the
+            issue at any time or discuss it on the dev@apisix.apache.org list.
+            Thank you for your contributions.
+          close-issue-message: >
+            This issue has been closed due to lack of activity. If you think that
+            is incorrect, or the issue requires additional review, you can revive the issue at
+            any time.
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
+          stale-pr-message: >
+            This pull request has been marked as stale due to 60 days of inactivity.
+            It will be closed in 30 days if no further activity occurs. If you think
+            that's incorrect or this pull request should instead be reviewed, please simply
+            write any comment. Even if closed, you can still revive the PR at any time or
+            discuss it on the dev@apisix.apache.org list.
+            Thank you for your contributions.
+          close-pr-message: >
+            This pull request/issue has been closed due to lack of activity. If you think that
+            is incorrect, or the pull request requires review, you can revive the PR at any time.
+          # Issues with these labels will never be considered stale.
+          exempt-issue-labels: 'triage/accepted,discuss,good first issue'
+          exempt-pr-labels: 'triage/accepted'
+          exempt-all-milestones: true
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          ascending: true


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
