### PR TITLE
test: keep namespace when test failed in dev mod

### DIFF
--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -185,5 +185,6 @@ jobs:
           ENABLE_PROXY: "false"
           E2E_SKIP_BUILD: "1"
           E2E_FLAKE_ATTEMPTS: "2"
+          E2E_ENV: "ci"
         run: |
           make e2e-test

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ GO_LDFLAGS ?= "-X=$(VERSYM)=$(VERSION) -X=$(GITSHASYM)=$(GITSHA) -X=$(BUILDOSSYM
 E2E_NODES ?= 4
 E2E_FLAKE_ATTEMPTS ?= 0
 E2E_SKIP_BUILD ?= 0
+E2E_ENV ?= "dev"
 
 ### build:                Build apisix-ingress-controller
 .PHONY: build
@@ -129,7 +130,7 @@ e2e-test: ginkgo-check pack-images e2e-wolf-rbac
 	cd test/e2e \
 		&& go mod download \
 		&& export REGISTRY=$(REGISTRY) \
-		&& ACK_GINKGO_RC=true ginkgo -cover -coverprofile=coverage.txt -r --randomize-all --randomize-suites --trace --nodes=$(E2E_NODES) --focus=$(E2E_FOCUS) --flake-attempts=$(E2E_FLAKE_ATTEMPTS)
+		&& E2E_ENV=$(E2E_ENV) ACK_GINKGO_RC=true ginkgo -cover -coverprofile=coverage.txt -r --randomize-all --randomize-suites --trace --nodes=$(E2E_NODES) --focus=$(E2E_FOCUS) --flake-attempts=$(E2E_FLAKE_ATTEMPTS)
 
 ### e2e-test-local:        Run e2e test cases (kind is required)
 .PHONY: e2e-test-local

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -32,6 +32,8 @@ a e2e test scaffold is prepared to run test cases easily. The source codes are i
 * Create a http server with [kennethreitz/httpbin](https://hub.docker.com/r/kennethreitz/httpbin/) as the upstream.
 
 The above mentioned steps are run before each case starts and all resources will be destroyed after the case finishes.
+Sepecially, if test case failed and e2e-test run in dev mode, the related resources will not be destroyed. This fearure is useful for debugging.
+Also, you can disable this feature by unset `E2E_ENV=dev`.
 
 Plugins
 -------

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -426,41 +426,33 @@ func (s *Scaffold) beforeEach() {
 func (s *Scaffold) afterEach() {
 	defer ginkgo.GinkgoRecover()
 
-	shouldDeleteNamespace := true
-	shouldDumpNamespace := false
 	if ginkgo.CurrentSpecReport().Failed() {
-		e2eEnv := os.Getenv("E2E_ENV")
-		switch e2eEnv {
-		case "ci":
-			shouldDumpNamespace = true
-		case "dev":
-			shouldDeleteNamespace = false
+		if os.Getenv("E2E_ENV") != "dev" {
+			// dump and delete related resource
+			_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, "Dumping namespace contents")
+			output, _ := k8s.RunKubectlAndGetOutputE(ginkgo.GinkgoT(), s.kubectlOptions, "get", "deploy,sts,svc,pods")
+			if output != "" {
+				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
+			}
+			output, _ = k8s.RunKubectlAndGetOutputE(ginkgo.GinkgoT(), s.kubectlOptions, "describe", "pods")
+			if output != "" {
+				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
+			}
+			// Get the logs of apisix
+			output = s.GetDeploymentLogs("apisix-deployment-e2e-test")
+			if output != "" {
+				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
+			}
+			// Get the logs of ingress
+			output = s.GetDeploymentLogs("ingress-apisix-controller-deployment-e2e-test")
+			if output != "" {
+				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
+			}
+			err := k8s.DeleteNamespaceE(s.t, s.kubectlOptions, s.namespace)
+			assert.Nilf(ginkgo.GinkgoT(), err, "deleting namespace %s", s.namespace)
 		}
-	}
-
-	if shouldDumpNamespace {
-		_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, "Dumping namespace contents")
-		output, _ := k8s.RunKubectlAndGetOutputE(ginkgo.GinkgoT(), s.kubectlOptions, "get", "deploy,sts,svc,pods")
-		if output != "" {
-			_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
-		}
-		output, _ = k8s.RunKubectlAndGetOutputE(ginkgo.GinkgoT(), s.kubectlOptions, "describe", "pods")
-		if output != "" {
-			_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
-		}
-		// Get the logs of apisix
-		output = s.GetDeploymentLogs("apisix-deployment-e2e-test")
-		if output != "" {
-			_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
-		}
-		// Get the logs of ingress
-		output = s.GetDeploymentLogs("ingress-apisix-controller-deployment-e2e-test")
-		if output != "" {
-			_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
-		}
-	}
-
-	if shouldDeleteNamespace {
+	} else {
+		// if the test case is successful, just delete namespace
 		err := k8s.DeleteNamespaceE(s.t, s.kubectlOptions, s.namespace)
 		assert.Nilf(ginkgo.GinkgoT(), err, "deleting namespace %s", s.namespace)
 	}


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

Related [issue](https://github.com/apache/apisix-ingress-controller/issues/1138)
Add environment variable `E2E_ENV` to indicate e2e-test environment. If test case failed and `E2E_ENV=dev`, related resources will not be deleted.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
