### PR TITLE
fix: translate error of old ApisixRoute

### DIFF
--- a/test/e2e/suite-chore/consistency.go
+++ b/test/e2e/suite-chore/consistency.go
@@ -72,9 +72,6 @@ var _ = ginkgo.Describe("suite-chore: Consistency between APISIX and Ingress", f
 			assert.Nil(ginkgo.GinkgoT(), s.EnsureNumApisixRoutesCreated(1))
 			assert.Nil(ginkgo.GinkgoT(), s.EnsureNumApisixUpstreamsCreated(1))
 
-			routes, err := s.ListApisixRoutes()
-			assert.Nil(ginkgo.GinkgoT(), err)
-			assert.Len(ginkgo.GinkgoT(), routes, 1)
 			upstreams, err := s.ListApisixUpstreams()
 			assert.Nil(ginkgo.GinkgoT(), err)
 			assert.Len(ginkgo.GinkgoT(), upstreams, 1)
@@ -90,7 +87,7 @@ var _ = ginkgo.Describe("suite-chore: Consistency between APISIX and Ingress", f
 
 			time.Sleep(6 * time.Second)
 
-			routes, err = s.ListApisixRoutes()
+			routes, err := s.ListApisixRoutes()
 			assert.Nil(ginkgo.GinkgoT(), err)
 			assert.Len(ginkgo.GinkgoT(), routes, 1)
 			upstreams, err = s.ListApisixUpstreams()

--- a/test/e2e/suite-chore/consistency.go
+++ b/test/e2e/suite-chore/consistency.go
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package chore
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
+)
+
+var (
+	_routeConfig = `
+apiVersion: apisix.apache.org/v2beta3
+kind: ApisixRoute
+metadata:
+ name: httpbin-route
+spec:
+  http:
+  - name: rule1
+    match:
+      hosts:
+      - httpbin.org
+      paths:
+      - /*
+    backends:
+    - serviceName: %s
+      servicePort: %d
+`
+	_httpServiceConfig = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-service-e2e-test
+spec:
+  selector:
+    app: httpbin-deployment-e2e-test
+  ports:
+    - name: http
+      port: %d
+      protocol: TCP
+      targetPort: %d
+  type: ClusterIP
+`
+)
+
+var _ = ginkgo.Describe("suite-chore: Consistency between APISIX and Ingress", func() {
+	suites := func(s *scaffold.Scaffold) {
+		ginkgo.It("ApisixRoute and APISIX of route and upstream", func() {
+			httpService := fmt.Sprintf(_httpServiceConfig, 8080, 8080)
+			assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(httpService))
+
+			ar := fmt.Sprintf(_routeConfig, "httpbin-service-e2e-test", 8080)
+			assert.Nil(ginkgo.GinkgoT(), s.CreateVersionedApisixResource(ar))
+
+			assert.Nil(ginkgo.GinkgoT(), s.EnsureNumApisixRoutesCreated(1))
+			assert.Nil(ginkgo.GinkgoT(), s.EnsureNumApisixUpstreamsCreated(1))
+
+			routes, err := s.ListApisixRoutes()
+			assert.Nil(ginkgo.GinkgoT(), err)
+			assert.Len(ginkgo.GinkgoT(), routes, 1)
+			upstreams, err := s.ListApisixUpstreams()
+			assert.Nil(ginkgo.GinkgoT(), err)
+			assert.Len(ginkgo.GinkgoT(), upstreams, 1)
+			assert.Contains(ginkgo.GinkgoT(), upstreams[0].Name, "httpbin-service-e2e-test_8080")
+			// The correct httpbin pod port is 80
+			s.NewAPISIXClient().GET("/ip").WithHeader("Host", "httpbin.org").Expect().Status(http.StatusBadGateway)
+
+			httpService = fmt.Sprintf(_httpServiceConfig, 80, 80)
+			assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(httpService))
+
+			ar = fmt.Sprintf(_routeConfig, "httpbin-service-e2e-test", 80)
+			assert.Nil(ginkgo.GinkgoT(), s.CreateVersionedApisixResource(ar))
+
+			time.Sleep(6 * time.Second)
+
+			routes, err = s.ListApisixRoutes()
+			assert.Nil(ginkgo.GinkgoT(), err)
+			assert.Len(ginkgo.GinkgoT(), routes, 1)
+			upstreams, err = s.ListApisixUpstreams()
+			assert.Nil(ginkgo.GinkgoT(), err)
+			assert.Len(ginkgo.GinkgoT(), upstreams, 1)
+			assert.Contains(ginkgo.GinkgoT(), upstreams[0].Name, "httpbin-service-e2e-test_80")
+
+			s.NewAPISIXClient().GET("/ip").WithHeader("Host", "httpbin.org").Expect().Status(http.StatusOK)
+		})
+	}
+
+	ginkgo.Describe("suite-chore: scaffold v2beta3", func() {
+		suites(scaffold.NewDefaultV2beta3Scaffold())
+	})
+	ginkgo.Describe("suite-chore: scaffold v2", func() {
+		suites(scaffold.NewDefaultV2Scaffold())
+	})
+})


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ref: 
* #1165 
* #1186 

When translating old objects, translateupstream needs to parse the latest services, which will lead to data inconsistency. Thus, retry and data inconsistency are caused.

### What this PR does 
Implements an function responsible for converting old objects
1. Get route object from cache.
2. Using route to construct Upstream and PluginConfig.
3. Compare and write APISIX.


### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
