### PR TITLE
fix: namespace_selector invalid when restarting

### DIFF
--- a/pkg/api/validation/utils.go
+++ b/pkg/api/validation/utils.go
@@ -99,14 +99,3 @@ func validateSchema(schemaLoader *gojsonschema.JSONLoader, obj interface{}) (boo
 
 	return false, resultErr
 }
-
-func HasValueInSyncMap(m *sync.Map) bool {
-	hasValue := false
-	if m != nil {
-		m.Range(func(k, v interface{}) bool {
-			hasValue = true
-			return false
-		})
-	}
-	return hasValue
-}

--- a/pkg/api/validation/utils_test.go
+++ b/pkg/api/validation/utils_test.go
@@ -16,10 +16,8 @@
 package validation
 
 import (
-	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/xeipuuv/gojsonschema"
 
 	v2beta3 "github.com/apache/apisix-ingress-controller/pkg/kube/apisix/apis/config/v2beta3"
@@ -47,11 +45,4 @@ func Test_validateSchema(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestHasValueInSyncMap(t *testing.T) {
-	m := new(sync.Map)
-	assert.False(t, HasValueInSyncMap(m), "sync.Map should be empty")
-	m.Store("hello", "test")
-	assert.True(t, HasValueInSyncMap(m), "sync.Map should not be empty")
 }

--- a/pkg/providers/k8s/namespace/namespace_provider.go
+++ b/pkg/providers/k8s/namespace/namespace_provider.go
@@ -23,13 +23,11 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listerscorev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/apache/apisix-ingress-controller/pkg/api/validation"
 	"github.com/apache/apisix-ingress-controller/pkg/config"
 	"github.com/apache/apisix-ingress-controller/pkg/kube"
 	"github.com/apache/apisix-ingress-controller/pkg/log"
@@ -48,44 +46,25 @@ type WatchingNamespaceProvider interface {
 }
 
 func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config) (WatchingNamespaceProvider, error) {
-	var (
-		watchingNamespaces = new(sync.Map)
-		watchingLabels     = make(map[string]string)
-	)
-	if len(cfg.Kubernetes.AppNamespaces) > 1 || cfg.Kubernetes.AppNamespaces[0] != v1.NamespaceAll {
-		for _, ns := range cfg.Kubernetes.AppNamespaces {
-			watchingNamespaces.Store(ns, struct{}{})
-		}
-	}
-	// support namespace label-selector
-	for _, selector := range cfg.Kubernetes.NamespaceSelector {
-		labelSlice := strings.Split(selector, "=")
-		watchingLabels[labelSlice[0]] = labelSlice[1]
-	}
-
-	// watchingNamespaces and watchingLabels are empty means to monitor all namespaces.
-	if !validation.HasValueInSyncMap(watchingNamespaces) && len(watchingLabels) == 0 {
-		opts := metav1.ListOptions{}
-		// list all namespaces
-		nsList, err := kube.Client.CoreV1().Namespaces().List(ctx, opts)
-		if err != nil {
-			log.Error(err.Error())
-			ctx.Done()
-		} else {
-			wns := new(sync.Map)
-			for _, v := range nsList.Items {
-				wns.Store(v.Name, struct{}{})
-			}
-			watchingNamespaces = wns
-		}
-	}
-
 	c := &watchingProvider{
 		kube: kube,
 		cfg:  cfg,
 
-		watchingNamespaces: watchingNamespaces,
-		watchingLabels:     watchingLabels,
+		watchingNamespaces: new(sync.Map),
+		watchingLabels:     make(map[string]string),
+
+		enableLabelsWatching: false,
+	}
+
+	if len(cfg.Kubernetes.NamespaceSelector) == 0 {
+		return c, nil
+	}
+
+	// support namespace label-selector
+	c.enableLabelsWatching = true
+	for _, selector := range cfg.Kubernetes.NamespaceSelector {
+		labelSlice := strings.Split(selector, "=")
+		c.watchingLabels[labelSlice[0]] = labelSlice[1]
 	}
 
 	kubeFactory := kube.NewSharedIndexInformerFactory()
@@ -108,6 +87,8 @@ type watchingProvider struct {
 	namespaceLister   listerscorev1.NamespaceLister
 
 	controller *namespaceController
+
+	enableLabelsWatching bool
 }
 
 func (c *watchingProvider) Init(ctx context.Context) error {
@@ -138,12 +119,14 @@ func (c *watchingProvider) initWatchingNamespacesByLabels(ctx context.Context) e
 }
 
 func (c *watchingProvider) Run(ctx context.Context) {
-	e := utils.ParallelExecutor{}
+	if !c.enableLabelsWatching {
+		return
+	}
 
+	e := utils.ParallelExecutor{}
 	e.Add(func() {
 		c.namespaceInformer.Run(ctx.Done())
 	})
-
 	e.Add(func() {
 		c.controller.run(ctx)
 	})
@@ -153,17 +136,30 @@ func (c *watchingProvider) Run(ctx context.Context) {
 
 func (c *watchingProvider) WatchingNamespaces() []string {
 	var keys []string
-	c.watchingNamespaces.Range(func(key, _ interface{}) bool {
-		keys = append(keys, key.(string))
-		return true
-	})
+	if c.enableLabelsWatching {
+		c.watchingNamespaces.Range(func(key, _ interface{}) bool {
+			keys = append(keys, key.(string))
+			return true
+		})
+	} else {
+		namespaces, err := c.kube.Client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			log.Warnw("Namespace list get failed",
+				zap.Error(err),
+			)
+			return nil
+		}
+		for _, ns := range namespaces.Items {
+			keys = append(keys, ns.Name)
+		}
+	}
 	return keys
 }
 
 // IsWatchingNamespace accepts a resource key, getting the namespace part
 // and checking whether the namespace is being watched.
 func (c *watchingProvider) IsWatchingNamespace(key string) (ok bool) {
-	if !validation.HasValueInSyncMap(c.watchingNamespaces) {
+	if !c.enableLabelsWatching {
 		ok = true
 		return
 	}

--- a/pkg/providers/k8s/namespace/namespace_provider.go
+++ b/pkg/providers/k8s/namespace/namespace_provider.go
@@ -19,6 +19,7 @@ package namespace
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -64,6 +65,9 @@ func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cf
 	c.enableLabelsWatching = true
 	for _, selector := range cfg.Kubernetes.NamespaceSelector {
 		labelSlice := strings.Split(selector, "=")
+		if len(labelSlice) != 2 {
+			return nil, fmt.Errorf("Bad namespace-selector format: %s, expected namespace-selector format: xxx=xxx", selector)
+		}
 		c.watchingLabels[labelSlice[0]] = labelSlice[1]
 	}
 

--- a/test/e2e/scaffold/ingress.go
+++ b/test/e2e/scaffold/ingress.go
@@ -428,7 +428,7 @@ func (s *Scaffold) newIngressAPISIXController() error {
 	})
 
 	var ingressAPISIXDeployment string
-	label := "\"\""
+	label := `""`
 	if labels := s.NamespaceSelectorLabelStrings(); labels != nil && !s.opts.DisableNamespaceSelector {
 		label = labels[0]
 	}

--- a/test/e2e/scaffold/ingress.go
+++ b/test/e2e/scaffold/ingress.go
@@ -428,13 +428,17 @@ func (s *Scaffold) newIngressAPISIXController() error {
 	})
 
 	var ingressAPISIXDeployment string
-	label := fmt.Sprintf("apisix.ingress.watch=%s", s.namespace)
+	label := "\"\""
+	if labels := s.NamespaceSelectorLabelStrings(); labels != nil && !s.opts.DisableNamespaceSelector {
+		label = labels[0]
+	}
+
 	if s.opts.EnableWebhooks {
 		ingressAPISIXDeployment = fmt.Sprintf(s.FormatRegistry(_ingressAPISIXDeploymentTemplate), s.opts.IngressAPISIXReplicas, s.namespace, s.opts.ApisixResourceSyncInterval,
-			s.FormatNamespaceLabel(label), s.opts.ApisixResourceVersion, s.opts.APISIXPublishAddress, _volumeMounts, _webhookCertSecret)
+			label, s.opts.ApisixResourceVersion, s.opts.APISIXPublishAddress, _volumeMounts, _webhookCertSecret)
 	} else {
 		ingressAPISIXDeployment = fmt.Sprintf(s.FormatRegistry(_ingressAPISIXDeploymentTemplate), s.opts.IngressAPISIXReplicas, s.namespace, s.opts.ApisixResourceSyncInterval,
-			s.FormatNamespaceLabel(label), s.opts.ApisixResourceVersion, s.opts.APISIXPublishAddress, "", _webhookCertSecret)
+			label, s.opts.ApisixResourceVersion, s.opts.APISIXPublishAddress, "", _webhookCertSecret)
 	}
 
 	err = k8s.KubectlApplyFromStringE(s.t, s.kubectlOptions, ingressAPISIXDeployment)
@@ -538,7 +542,10 @@ func (s *Scaffold) GetIngressPodDetails() ([]corev1.Pod, error) {
 // ScaleIngressController scales the number of Ingress Controller pods to desired.
 func (s *Scaffold) ScaleIngressController(desired int) error {
 	var ingressDeployment string
-	label := fmt.Sprintf("apisix.ingress.watch=%s", s.namespace)
+	var label string
+	if labels := s.NamespaceSelectorLabelStrings(); labels != nil {
+		label = labels[0]
+	}
 	if s.opts.EnableWebhooks {
 		ingressDeployment = fmt.Sprintf(s.FormatRegistry(_ingressAPISIXDeploymentTemplate), desired, s.namespace, s.opts.ApisixResourceSyncInterval, label, s.opts.ApisixResourceVersion, s.opts.APISIXPublishAddress, _volumeMounts, _webhookCertSecret)
 	} else {

--- a/test/e2e/scaffold/k8s.go
+++ b/test/e2e/scaffold/k8s.go
@@ -161,14 +161,18 @@ func (s *Scaffold) CreateResourceFromStringWithNamespace(yaml, namespace string)
 		s.kubectlOptions.Namespace = originalNamespace
 	}()
 	s.addFinalizers(func() {
-		originalNamespace := s.kubectlOptions.Namespace
-		s.kubectlOptions.Namespace = namespace
-		defer func() {
-			s.kubectlOptions.Namespace = originalNamespace
-		}()
-		assert.Nil(s.t, k8s.KubectlDeleteFromStringE(s.t, s.kubectlOptions, yaml))
+		_ = s.DeleteResourceFromStringWithNamespace(yaml, namespace)
 	})
 	return k8s.KubectlApplyFromStringE(s.t, s.kubectlOptions, yaml)
+}
+
+func (s *Scaffold) DeleteResourceFromStringWithNamespace(yaml, namespace string) error {
+	originalNamespace := s.kubectlOptions.Namespace
+	s.kubectlOptions.Namespace = namespace
+	defer func() {
+		s.kubectlOptions.Namespace = originalNamespace
+	}()
+	return k8s.KubectlDeleteFromStringE(s.t, s.kubectlOptions, yaml)
 }
 
 func (s *Scaffold) ensureNumApisixCRDsCreated(url string, desired int) error {

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -368,6 +368,19 @@ func (s *Scaffold) RestartAPISIXDeploy() {
 	assert.NoError(s.t, err, "renew apisix tunnels")
 }
 
+func (s *Scaffold) RestartIngressControllerDeploy() {
+	pods, err := k8s.ListPodsE(s.t, s.kubectlOptions, metav1.ListOptions{
+		LabelSelector: "app=ingress-apisix-controller-deployment-e2e-test",
+	})
+	assert.NoError(s.t, err, "list ingress-controller pod")
+	for _, pod := range pods {
+		err = s.KillPod(pod.Name)
+		assert.NoError(s.t, err, "killing ingress-controller pod")
+	}
+	err = s.WaitAllIngressControllerPodsAvailable()
+	assert.NoError(s.t, err, "waiting for new ingress-controller instance ready")
+}
+
 func (s *Scaffold) beforeEach() {
 	var err error
 	s.namespace = fmt.Sprintf("ingress-apisix-e2e-tests-%s-%d", s.opts.Name, time.Now().Nanosecond())

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -53,9 +53,12 @@ type Options struct {
 	APISIXAdminAPIKey          string
 	EnableWebhooks             bool
 	APISIXPublishAddress       string
-	disableNamespaceSelector   bool
 	ApisixResourceSyncInterval string
 	ApisixResourceVersion      string
+
+	NamespaceSelectorLabel   map[string]string
+	DisableNamespaceSelector bool
+	DisableNamespaceLabel    bool
 }
 
 type Scaffold struct {
@@ -96,10 +99,10 @@ var (
 	}
 
 	createVersionedApisixResourceMap = map[string]struct{}{
-		"ApisixRoute":        struct{}{},
-		"ApisixConsumer":     struct{}{},
-		"ApisixPluginConfig": struct{}{},
-		"ApisixUpstream":     struct{}{},
+		"ApisixRoute":        {},
+		"ApisixConsumer":     {},
+		"ApisixPluginConfig": {},
+		"ApisixUpstream":     {},
 	}
 )
 
@@ -388,11 +391,19 @@ func (s *Scaffold) beforeEach() {
 		ConfigPath: s.opts.Kubeconfig,
 		Namespace:  s.namespace,
 	}
-
 	s.finializers = nil
-	labels := make(map[string]string)
-	labels["apisix.ingress.watch"] = s.namespace
-	k8s.CreateNamespaceWithMetadata(s.t, s.kubectlOptions, metav1.ObjectMeta{Name: s.namespace, Labels: labels})
+
+	label := map[string]string{}
+	if !s.opts.DisableNamespaceLabel {
+		if s.opts.NamespaceSelectorLabel == nil {
+			label["apisix.ingress.watch"] = s.namespace
+			s.opts.NamespaceSelectorLabel = label
+		} else {
+			label = s.opts.NamespaceSelectorLabel
+		}
+	}
+
+	k8s.CreateNamespaceWithMetadata(s.t, s.kubectlOptions, metav1.ObjectMeta{Name: s.namespace, Labels: label})
 
 	s.nodes, err = k8s.GetReadyNodesE(s.t, s.kubectlOptions)
 	assert.Nil(s.t, err, "querying ready nodes")
@@ -554,14 +565,6 @@ func (s *Scaffold) FormatRegistry(workloadTemplate string) string {
 	}
 }
 
-// FormatNamespaceLabel set label to be empty if s.opts.disableNamespaceSelector is true.
-func (s *Scaffold) FormatNamespaceLabel(label string) string {
-	if s.opts.disableNamespaceSelector {
-		return "\"\""
-	}
-	return label
-}
-
 var (
 	versionRegex = regexp.MustCompile(`apiVersion: apisix.apache.org/v.*?\n`)
 	kindRegex    = regexp.MustCompile(`kind: (.*?)\n`)
@@ -577,10 +580,6 @@ func (s *Scaffold) getKindValue(yml string) string {
 		return ""
 	}
 	return subStr[1]
-}
-
-func (s *Scaffold) DisableNamespaceSelector() {
-	s.opts.disableNamespaceSelector = true
 }
 
 func waitExponentialBackoff(condFunc func() (bool, error)) error {
@@ -626,4 +625,16 @@ func (s *Scaffold) CreateVersionedApisixResourceWithNamespace(yml, namespace str
 
 func ApisixResourceVersion() *apisixResourceVersionInfo {
 	return apisixResourceVersion
+}
+
+func (s *Scaffold) NamespaceSelectorLabelStrings() []string {
+	var labels []string
+	for k, v := range s.opts.NamespaceSelectorLabel {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	return labels
+}
+
+func (s *Scaffold) NamespaceSelectorLabel() map[string]string {
+	return s.opts.NamespaceSelectorLabel
 }

--- a/test/e2e/suite-ingress/suite-ingress-features/namespace.go
+++ b/test/e2e/suite-ingress/suite-ingress-features/namespace.go
@@ -151,7 +151,7 @@ spec:
 			_ = s.NewAPISIXClient().GET("/headers").WithHeader("Host", "local.httpbin.org").Expect().Status(http.StatusNotFound)
 
 			// remove route1
-			assert.Nil(ginkgo.GinkgoT(), s.DeleteResourceFromStringWithNamespace(route1, namespace1), "delte ingress")
+			assert.Nil(ginkgo.GinkgoT(), s.DeleteResourceFromStringWithNamespace(route1, namespace1), "delete ingress")
 			time.Sleep(6 * time.Second)
 
 			deleteNamespace(namespace1)
@@ -177,7 +177,7 @@ spec:
 	})
 })
 
-var _ = ginkgo.Describe("suite-ingress-features: namespacing fltering disable", func() {
+var _ = ginkgo.Describe("suite-ingress-features: namespacing filtering disable", func() {
 	s := scaffold.NewScaffold(&scaffold.Options{
 		Name:                     "disable-namespace-selector",
 		IngressAPISIXReplicas:    1,
@@ -336,7 +336,7 @@ spec:
 			}},
 			metav1.UpdateOptions{},
 		)
-		assert.Nil(ginkgo.GinkgoT(), err, "creating namespace")
+		assert.Nil(ginkgo.GinkgoT(), err, "unlabel the namespace")
 		time.Sleep(6 * time.Second)
 		routes, err := s.ListApisixRoutes()
 		assert.Nil(ginkgo.GinkgoT(), err)

--- a/test/e2e/suite-ingress/suite-ingress-features/namespace.go
+++ b/test/e2e/suite-ingress/suite-ingress-features/namespace.go
@@ -191,7 +191,7 @@ var _ = ginkgo.Describe("suite-ingress-features: namespacing fltering disable", 
 				ConfigPath: scaffold.GetKubeconfig(),
 			}, namespace)
 			_, err := s.NewHTTPBINWithNamespace(namespace)
-			assert.Nil(ginkgo.GinkgoT(), err, "create second httpbin service")
+			assert.Nil(ginkgo.GinkgoT(), err, "create new httpbin service")
 		})
 
 		// clean this tmp namespace when test case is done.
@@ -270,7 +270,7 @@ spec:
 	})
 })
 
-var _ = ginkgo.Describe("suite-ingress-features: namespacing ub-label", func() {
+var _ = ginkgo.Describe("suite-ingress-features: namespacing un-label", func() {
 	labelName, labelValue := fmt.Sprintf("namespace-selector-%d", time.Now().Nanosecond()), "watch"
 	s := scaffold.NewScaffold(&scaffold.Options{
 		Name:                  "un-label",


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

* When all namespace do not have  labels(namespace_selector), all resources will be monitored, and the namespace_selector function will not be available.
![image](https://user-images.githubusercontent.com/79972061/185866056-6d1fafdf-ae45-4526-bfca-629058e7258d.png)

e2e-test:
* **[un-label]** When restarting, all ns without labels will be monitored
* **[ingress-controller restart]** When restarting, all ns without labels will be monitored

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
