### PR TITLE
chore: protect v1.5.0 and enable CI for it

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,3 +40,6 @@ github:
       master:
         required_pull_request_reviews:
           required_approving_review_count: 2
+      v1.5.0:
+        required_pull_request_reviews:
+          required_approving_review_count: 1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,9 @@ on:
   pull_request:
     type: [review_requested, ready_for_review]
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches:
+      - master
+      - v1.5.0
   schedule:
     - cron: '25 5 * * 5'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 
 permissions:

--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 
 concurrency:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 
 jobs:

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 
 jobs:

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 jobs:
   changes:

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -19,9 +19,12 @@
 name: spell-checker
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 jobs:
   misspell:

--- a/.github/workflows/unit-test-ci.yml
+++ b/.github/workflows/unit-test-ci.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 jobs:
   changes:

--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches:
       - master
+      - v1.5.0
     type: [review_requested, ready_for_review]
 jobs:
   changes:


### PR DESCRIPTION
we should protect v1.5.0 branch and enable CI for it.