### PR TITLE
e2e: delete duplicate log data on e2e-test failure

### DIFF
--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -37,6 +37,7 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gavv/httpexpect/v2"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
@@ -153,6 +154,8 @@ func NewScaffold(o *Options) *Scaffold {
 		opts: o,
 		t:    ginkgo.GinkgoT(),
 	}
+	// Disable logging of terratest library.
+	logger.Default = logger.Discard
 
 	ginkgo.BeforeEach(s.beforeEach)
 	ginkgo.AfterEach(s.afterEach)


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

```go
func (s *Scaffold) afterEach() {
	defer ginkgo.GinkgoRecover()

	if ginkgo.CurrentSpecReport().Failed() {
		if os.Getenv("E2E_ENV") == "ci" {
			// dump and delete related resource
			_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, "Dumping namespace contents")
			output, _ := k8s.RunKubectlAndGetOutputE(ginkgo.GinkgoT(), s.kubectlOptions, "get", "deploy,sts,svc,pods")
			if output != "" {
				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
			}
			output, _ = k8s.RunKubectlAndGetOutputE(ginkgo.GinkgoT(), s.kubectlOptions, "describe", "pods")
			if output != "" {
				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
			}
			// Get the logs of apisix
			output = s.GetDeploymentLogs("apisix-deployment-e2e-test")
			if output != "" {
				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
			}
			// Get the logs of ingress
			output = s.GetDeploymentLogs("ingress-apisix-controller-deployment-e2e-test")
			if output != "" {
				_, _ = fmt.Fprintln(ginkgo.GinkgoWriter, output)
			}
			err := k8s.DeleteNamespaceE(s.t, s.kubectlOptions, s.namespace)
			assert.Nilf(ginkgo.GinkgoT(), err, "deleting namespace %s", s.namespace)
		}
	} else {
		// if the test case is successful, just delete namespace
		err := k8s.DeleteNamespaceE(s.t, s.kubectlOptions, s.namespace)
		assert.Nilf(ginkgo.GinkgoT(), err, "deleting namespace %s", s.namespace)
	}

	for _, f := range s.finializers {
		runWithRecover(f)
	}

	// Wait for a while to prevent the worker node being overwhelming
	// (new cases will be run).
	time.Sleep(3 * time.Second)
}
```

1. `k8s.RunKubectlAndGetOutputE` Etc, the interface will print the log (terratest.logger). 
2. `fmt.Fprintln(ginkgo.GinkgoWriter, output)` also prints log (ginkgo.logger).
3. At this time, two identical log data will be generated

solve:
* Disable logging of terratest library.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
