### PR TITLE
chore: fixed the crd version in doc

### DIFF
--- a/docs/en/latest/tutorials/proxy-the-httpbin-service.md
+++ b/docs/en/latest/tutorials/proxy-the-httpbin-service.md
@@ -46,7 +46,7 @@ In order to let Apache APISIX proxies requests to httpbin, we need to create an 
 
 ```yaml
 # httpbin-route.yaml
-apiVersion: apisix.apache.org/v2
+apiVersion: apisix.apache.org/v2beta3
 kind: ApisixRoute
 metadata:
   name: httpserver-route


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

```bash
$ kubectl apply -f httpbin-route.yaml
error: resource mapping not found for name: "httpserver-route" namespace: "" from "httpbin-route.yaml": no matches for kind "ApisixRoute" in version "apisix.apache.org/v2"
ensure CRDs are installed first

```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
