### PR TITLE
docs: ensure parity in examples

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -49,10 +49,10 @@ values={[
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  name: httpserver-route
+  name: httpbin-route
 spec:
   http:
-    - name: rule1
+    - name: route-1
       match:
         hosts:
           - local.httpbin.org
@@ -71,7 +71,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: httpserver-ingress
+  name: httpbin-route
 spec:
   ingressClassName: apisix
   rules:


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Update example to make sure that there is parity with both native Ingress resource and APISIX CRD.