### PR TITLE
fix: cluster.metricsCollector invoked before assign when MountWebhooks(#1428)

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/pkg/apisix"
 	"github.com/apache/apisix-ingress-controller/pkg/config"
 	"github.com/apache/apisix-ingress-controller/pkg/log"
+	"github.com/apache/apisix-ingress-controller/pkg/metrics"
 	"github.com/apache/apisix-ingress-controller/pkg/types"
 )
 
@@ -81,9 +82,10 @@ func NewServer(cfg *config.Config) (*Server, error) {
 		admission := gin.New()
 		admission.Use(gin.Recovery(), gin.Logger())
 		apirouter.MountWebhooks(admission, &apisix.ClusterOptions{
-			Name:     cfg.APISIX.DefaultClusterName,
-			AdminKey: cfg.APISIX.DefaultClusterAdminKey,
-			BaseURL:  cfg.APISIX.DefaultClusterBaseURL,
+			Name:             cfg.APISIX.DefaultClusterName,
+			AdminKey:         cfg.APISIX.DefaultClusterAdminKey,
+			BaseURL:          cfg.APISIX.DefaultClusterBaseURL,
+			MetricsCollector: metrics.NewPrometheusCollector(),
 		})
 
 		srv.admissionServer = &http.Server{


### PR DESCRIPTION


<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
