### PR TITLE
fix: use field cluster.name as value but not "default"

### DIFF
--- a/pkg/apisix/consumer.go
+++ b/pkg/apisix/consumer.go
@@ -44,7 +44,7 @@ func (r *consumerClient) Get(ctx context.Context, name string) (*v1.Consumer, er
 	log.Debugw("try to look up consumer",
 		zap.String("name", name),
 		zap.String("url", r.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 	)
 	consumer, err := r.cluster.cache.GetConsumer(name)
 	if err == nil {
@@ -71,13 +71,13 @@ func (r *consumerClient) Get(ctx context.Context, name string) (*v1.Consumer, er
 			log.Warnw("consumer not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get consumer from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -106,7 +106,7 @@ func (r *consumerClient) Get(ctx context.Context, name string) (*v1.Consumer, er
 // to APISIX.
 func (r *consumerClient) List(ctx context.Context) ([]*v1.Consumer, error) {
 	log.Debugw("try to list consumers in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	consumerItems, err := r.cluster.listResource(ctx, r.url, "consumer")
@@ -140,7 +140,7 @@ func (r *consumerClient) Create(ctx context.Context, obj *v1.Consumer) (*v1.Cons
 	log.Debugw("try to create consumer",
 		zap.String("name", obj.Username),
 		zap.Any("plugins", obj.Plugins),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 
@@ -175,7 +175,7 @@ func (r *consumerClient) Create(ctx context.Context, obj *v1.Consumer) (*v1.Cons
 func (r *consumerClient) Delete(ctx context.Context, obj *v1.Consumer) error {
 	log.Debugw("try to delete consumer",
 		zap.String("name", obj.Username),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {
@@ -200,7 +200,7 @@ func (r *consumerClient) Update(ctx context.Context, obj *v1.Consumer) (*v1.Cons
 	log.Debugw("try to update consumer",
 		zap.String("name", obj.Username),
 		zap.Any("plugins", obj.Plugins),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/global_rule.go
+++ b/pkg/apisix/global_rule.go
@@ -45,7 +45,7 @@ func (r *globalRuleClient) Get(ctx context.Context, name string) (*v1.GlobalRule
 	log.Debugw("try to look up global_rule",
 		zap.String("name", name),
 		zap.String("url", r.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 	)
 	rid := id.GenID(name)
 	globalRule, err := r.cluster.cache.GetGlobalRule(rid)
@@ -73,13 +73,13 @@ func (r *globalRuleClient) Get(ctx context.Context, name string) (*v1.GlobalRule
 			log.Warnw("global_rule not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get global_rule from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -108,7 +108,7 @@ func (r *globalRuleClient) Get(ctx context.Context, name string) (*v1.GlobalRule
 // to APISIX.
 func (r *globalRuleClient) List(ctx context.Context) ([]*v1.GlobalRule, error) {
 	log.Debugw("try to list global_rules in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	globalRuleItems, err := r.cluster.listResource(ctx, r.url, "globalRule")
@@ -142,7 +142,7 @@ func (r *globalRuleClient) Create(ctx context.Context, obj *v1.GlobalRule) (*v1.
 	log.Debugw("try to create global_rule",
 		zap.String("id", obj.ID),
 		zap.Any("plugins", obj.Plugins),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 
@@ -177,7 +177,7 @@ func (r *globalRuleClient) Create(ctx context.Context, obj *v1.GlobalRule) (*v1.
 func (r *globalRuleClient) Delete(ctx context.Context, obj *v1.GlobalRule) error {
 	log.Debugw("try to delete global_rule",
 		zap.String("id", obj.ID),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {
@@ -202,7 +202,7 @@ func (r *globalRuleClient) Update(ctx context.Context, obj *v1.GlobalRule) (*v1.
 	log.Debugw("try to update global_rule",
 		zap.String("id", obj.ID),
 		zap.Any("plugins", obj.Plugins),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/plugin.go
+++ b/pkg/apisix/plugin.go
@@ -38,7 +38,7 @@ func newPluginClient(c *cluster) Plugin {
 // List returns the names of all plugins.
 func (p *pluginClient) List(ctx context.Context) ([]string, error) {
 	log.Debugw("try to list plugins' names in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", p.cluster.name),
 		zap.String("url", p.url),
 	)
 	pluginList, err := p.cluster.getList(ctx, p.url+"?all=true", "plugin")

--- a/pkg/apisix/plugin_metadata.go
+++ b/pkg/apisix/plugin_metadata.go
@@ -40,7 +40,7 @@ func (r *pluginMetadataClient) Get(ctx context.Context, name string) (*v1.Plugin
 	log.Debugw("try to look up pluginMetadata",
 		zap.String("name", name),
 		zap.String("url", r.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 	)
 
 	// TODO Add mutex here to avoid dog-pile effect.
@@ -51,7 +51,7 @@ func (r *pluginMetadataClient) Get(ctx context.Context, name string) (*v1.Plugin
 		log.Errorw("failed to get pluginMetadata from APISIX",
 			zap.String("name", name),
 			zap.String("url", url),
-			zap.String("cluster", "default"),
+			zap.String("cluster", r.cluster.name),
 			zap.Error(err),
 		)
 		return nil, err
@@ -72,7 +72,7 @@ func (r *pluginMetadataClient) Get(ctx context.Context, name string) (*v1.Plugin
 
 func (r *pluginMetadataClient) List(ctx context.Context) ([]*v1.PluginMetadata, error) {
 	log.Debugw("try to list pluginMetadatas in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	pluginMetadataItems, err := r.cluster.listResource(ctx, r.url, "pluginMetadata")
@@ -106,7 +106,7 @@ func (r *pluginMetadataClient) Delete(ctx context.Context, obj *v1.PluginMetadat
 	log.Debugw("try to delete pluginMetadata",
 		zap.String("name", obj.Name),
 		zap.Any("metadata", obj.Metadata),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {
@@ -125,7 +125,7 @@ func (r *pluginMetadataClient) Update(ctx context.Context, obj *v1.PluginMetadat
 	log.Debugw("try to update pluginMetadata",
 		zap.String("name", obj.Name),
 		zap.Any("metadata", obj.Metadata),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/pluginconfig.go
+++ b/pkg/apisix/pluginconfig.go
@@ -46,7 +46,7 @@ func (pc *pluginConfigClient) Get(ctx context.Context, name string) (*v1.PluginC
 	log.Debugw("try to look up pluginConfig",
 		zap.String("name", name),
 		zap.String("url", pc.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", pc.cluster.name),
 	)
 	rid := id.GenID(name)
 	pluginConfig, err := pc.cluster.cache.GetPluginConfig(rid)
@@ -74,13 +74,13 @@ func (pc *pluginConfigClient) Get(ctx context.Context, name string) (*v1.PluginC
 			log.Warnw("pluginConfig not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", pc.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get pluginConfig from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", pc.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -109,7 +109,7 @@ func (pc *pluginConfigClient) Get(ctx context.Context, name string) (*v1.PluginC
 // to APISIX.
 func (pc *pluginConfigClient) List(ctx context.Context) ([]*v1.PluginConfig, error) {
 	log.Debugw("try to list pluginConfig in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", pc.cluster.name),
 		zap.String("url", pc.url),
 	)
 	pluginConfigItems, err := pc.cluster.listResource(ctx, pc.url, "pluginConfig")
@@ -143,7 +143,7 @@ func (pc *pluginConfigClient) Create(ctx context.Context, obj *v1.PluginConfig) 
 	log.Debugw("try to create pluginConfig",
 		zap.String("name", obj.Name),
 		zap.Any("plugins", obj.Plugins),
-		zap.String("cluster", "default"),
+		zap.String("cluster", pc.cluster.name),
 		zap.String("url", pc.url),
 	)
 
@@ -179,7 +179,7 @@ func (pc *pluginConfigClient) Delete(ctx context.Context, obj *v1.PluginConfig) 
 	log.Debugw("try to delete pluginConfig",
 		zap.String("id", obj.ID),
 		zap.String("name", obj.Name),
-		zap.String("cluster", "default"),
+		zap.String("cluster", pc.cluster.name),
 		zap.String("url", pc.url),
 	)
 
@@ -206,7 +206,7 @@ func (pc *pluginConfigClient) Update(ctx context.Context, obj *v1.PluginConfig) 
 		zap.String("id", obj.ID),
 		zap.String("name", obj.Name),
 		zap.Any("plugins", obj.Plugins),
-		zap.String("cluster", "default"),
+		zap.String("cluster", pc.cluster.name),
 		zap.String("url", pc.url),
 	)
 	if err := pc.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/route.go
+++ b/pkg/apisix/route.go
@@ -46,7 +46,7 @@ func (r *routeClient) Get(ctx context.Context, name string) (*v1.Route, error) {
 	log.Debugw("try to look up route",
 		zap.String("name", name),
 		zap.String("url", r.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 	)
 	rid := id.GenID(name)
 	route, err := r.cluster.cache.GetRoute(rid)
@@ -74,13 +74,13 @@ func (r *routeClient) Get(ctx context.Context, name string) (*v1.Route, error) {
 			log.Warnw("route not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get route from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -109,7 +109,7 @@ func (r *routeClient) Get(ctx context.Context, name string) (*v1.Route, error) {
 // to APISIX.
 func (r *routeClient) List(ctx context.Context) ([]*v1.Route, error) {
 	log.Debugw("try to list routes in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	routeItems, err := r.cluster.listResource(ctx, r.url, "route")
@@ -143,7 +143,7 @@ func (r *routeClient) Create(ctx context.Context, obj *v1.Route) (*v1.Route, err
 	log.Debugw("try to create route",
 		zap.Strings("hosts", obj.Hosts),
 		zap.String("name", obj.Name),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 
@@ -179,7 +179,7 @@ func (r *routeClient) Delete(ctx context.Context, obj *v1.Route) error {
 	log.Debugw("try to delete route",
 		zap.String("id", obj.ID),
 		zap.String("name", obj.Name),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {
@@ -204,7 +204,7 @@ func (r *routeClient) Update(ctx context.Context, obj *v1.Route) (*v1.Route, err
 	log.Debugw("try to update route",
 		zap.String("id", obj.ID),
 		zap.String("name", obj.Name),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/schema.go
+++ b/pkg/apisix/schema.go
@@ -43,7 +43,7 @@ func (sc schemaClient) getSchema(ctx context.Context, name string) (*v1.Schema, 
 	log.Debugw("try to look up schema",
 		zap.String("name", name),
 		zap.String("url", sc.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", sc.cluster.name),
 	)
 
 	sid := id.GenID(name)
@@ -69,7 +69,7 @@ func (sc schemaClient) getSchema(ctx context.Context, name string) (*v1.Schema, 
 		log.Errorw("failed to get schema from APISIX",
 			zap.String("name", name),
 			zap.String("url", url),
-			zap.String("cluster", "default"),
+			zap.String("cluster", sc.cluster.name),
 			zap.Error(err),
 		)
 		return nil, err

--- a/pkg/apisix/ssl.go
+++ b/pkg/apisix/ssl.go
@@ -50,7 +50,7 @@ func (s *sslClient) Get(ctx context.Context, name string) (*v1.Ssl, error) {
 	log.Debugw("try to look up ssl",
 		zap.String("name", name),
 		zap.String("url", s.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", s.cluster.name),
 	)
 	sid := id.GenID(name)
 	ssl, err := s.cluster.cache.GetSSL(sid)
@@ -77,13 +77,13 @@ func (s *sslClient) Get(ctx context.Context, name string) (*v1.Ssl, error) {
 			log.Warnw("ssl not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", s.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get ssl from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", s.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -111,7 +111,7 @@ func (s *sslClient) Get(ctx context.Context, name string) (*v1.Ssl, error) {
 func (s *sslClient) List(ctx context.Context) ([]*v1.Ssl, error) {
 	log.Debugw("try to list ssl in APISIX",
 		zap.String("url", s.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", s.cluster.name),
 	)
 
 	sslItems, err := s.cluster.listResource(ctx, s.url, "ssl")
@@ -141,7 +141,7 @@ func (s *sslClient) List(ctx context.Context) ([]*v1.Ssl, error) {
 
 func (s *sslClient) Create(ctx context.Context, obj *v1.Ssl) (*v1.Ssl, error) {
 	log.Debugw("try to create ssl",
-		zap.String("cluster", "default"),
+		zap.String("cluster", s.cluster.name),
 		zap.String("url", s.url),
 		zap.String("id", obj.ID),
 	)
@@ -175,7 +175,7 @@ func (s *sslClient) Create(ctx context.Context, obj *v1.Ssl) (*v1.Ssl, error) {
 func (s *sslClient) Delete(ctx context.Context, obj *v1.Ssl) error {
 	log.Debugw("try to delete ssl",
 		zap.String("id", obj.ID),
-		zap.String("cluster", "default"),
+		zap.String("cluster", s.cluster.name),
 		zap.String("url", s.url),
 	)
 	if err := s.cluster.HasSynced(ctx); err != nil {
@@ -199,7 +199,7 @@ func (s *sslClient) Delete(ctx context.Context, obj *v1.Ssl) error {
 func (s *sslClient) Update(ctx context.Context, obj *v1.Ssl) (*v1.Ssl, error) {
 	log.Debugw("try to update ssl",
 		zap.String("id", obj.ID),
-		zap.String("cluster", "default"),
+		zap.String("cluster", s.cluster.name),
 		zap.String("url", s.url),
 	)
 	if err := s.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/stream_route.go
+++ b/pkg/apisix/stream_route.go
@@ -51,7 +51,7 @@ func (r *streamRouteClient) Get(ctx context.Context, name string) (*v1.StreamRou
 	log.Debugw("try to look up stream_route",
 		zap.String("name", name),
 		zap.String("url", r.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 	)
 	rid := id.GenID(name)
 	streamRoute, err := r.cluster.cache.GetStreamRoute(rid)
@@ -78,13 +78,13 @@ func (r *streamRouteClient) Get(ctx context.Context, name string) (*v1.StreamRou
 			log.Warnw("stream_route not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get stream_route from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", r.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -113,7 +113,7 @@ func (r *streamRouteClient) Get(ctx context.Context, name string) (*v1.StreamRou
 // to APISIX.
 func (r *streamRouteClient) List(ctx context.Context) ([]*v1.StreamRoute, error) {
 	log.Debugw("try to list stream_routes in APISIX",
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	streamRouteItems, err := r.cluster.listResource(ctx, r.url, "streamRoute")
@@ -146,7 +146,7 @@ func (r *streamRouteClient) Create(ctx context.Context, obj *v1.StreamRoute) (*v
 	log.Debugw("try to create stream_route",
 		zap.String("id", obj.ID),
 		zap.Int32("server_port", obj.ServerPort),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 		zap.String("sni", obj.SNI),
 	)
@@ -182,7 +182,7 @@ func (r *streamRouteClient) Create(ctx context.Context, obj *v1.StreamRoute) (*v
 func (r *streamRouteClient) Delete(ctx context.Context, obj *v1.StreamRoute) error {
 	log.Debugw("try to delete stream_route",
 		zap.String("id", obj.ID),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {
@@ -206,7 +206,7 @@ func (r *streamRouteClient) Delete(ctx context.Context, obj *v1.StreamRoute) err
 func (r *streamRouteClient) Update(ctx context.Context, obj *v1.StreamRoute) (*v1.StreamRoute, error) {
 	log.Debugw("try to update stream_route",
 		zap.String("id", obj.ID),
-		zap.String("cluster", "default"),
+		zap.String("cluster", r.cluster.name),
 		zap.String("url", r.url),
 	)
 	if err := r.cluster.HasSynced(ctx); err != nil {

--- a/pkg/apisix/upstream.go
+++ b/pkg/apisix/upstream.go
@@ -42,7 +42,7 @@ func (u *upstreamClient) Get(ctx context.Context, name string) (*v1.Upstream, er
 	log.Debugw("try to look up upstream",
 		zap.String("name", name),
 		zap.String("url", u.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 	uid := id.GenID(name)
 	ups, err := u.cluster.cache.GetUpstream(uid)
@@ -69,13 +69,13 @@ func (u *upstreamClient) Get(ctx context.Context, name string) (*v1.Upstream, er
 			log.Warnw("upstream not found",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", u.cluster.name),
 			)
 		} else {
 			log.Errorw("failed to get upstream from APISIX",
 				zap.String("name", name),
 				zap.String("url", url),
-				zap.String("cluster", "default"),
+				zap.String("cluster", u.cluster.name),
 				zap.Error(err),
 			)
 		}
@@ -104,7 +104,7 @@ func (u *upstreamClient) Get(ctx context.Context, name string) (*v1.Upstream, er
 func (u *upstreamClient) List(ctx context.Context) ([]*v1.Upstream, error) {
 	log.Debugw("try to list upstreams in APISIX",
 		zap.String("url", u.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 
 	upsItems, err := u.cluster.listResource(ctx, u.url, "upstream")
@@ -135,7 +135,7 @@ func (u *upstreamClient) Create(ctx context.Context, obj *v1.Upstream) (*v1.Upst
 	log.Debugw("try to create upstream",
 		zap.String("name", obj.Name),
 		zap.String("url", u.url),
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 
 	if err := u.cluster.upstreamServiceRelation.Create(ctx, obj.Name); err != nil {
@@ -173,7 +173,7 @@ func (u *upstreamClient) Delete(ctx context.Context, obj *v1.Upstream) error {
 	log.Debugw("try to delete upstream",
 		zap.String("id", obj.ID),
 		zap.String("name", obj.Name),
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 		zap.String("url", u.url),
 	)
 
@@ -199,7 +199,7 @@ func (u *upstreamClient) Update(ctx context.Context, obj *v1.Upstream) (*v1.Upst
 	log.Debugw("try to update upstream",
 		zap.String("id", obj.ID),
 		zap.String("name", obj.Name),
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 		zap.String("url", u.url),
 	)
 

--- a/pkg/apisix/upstreamservicerelation.go
+++ b/pkg/apisix/upstreamservicerelation.go
@@ -46,7 +46,7 @@ func newUpstreamServiceRelation(c *cluster) *upstreamService {
 func (u *upstreamService) Get(ctx context.Context, serviceName string) (*v1.UpstreamServiceRelation, error) {
 	log.Debugw("try to get upstreamService in cache",
 		zap.String("service_name", serviceName),
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 	us, err := u.cluster.cache.GetUpstreamServiceRelation(serviceName)
 	if err != nil && err != cache.ErrNotFound {
@@ -59,7 +59,7 @@ func (u *upstreamService) Get(ctx context.Context, serviceName string) (*v1.Upst
 
 func (u *upstreamService) Delete(ctx context.Context, serviceName string) error {
 	log.Debugw("try to delete upstreamService in cache",
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 	relation, err := u.Get(ctx, serviceName)
 	if err != nil {
@@ -89,7 +89,7 @@ func (u *upstreamService) Delete(ctx context.Context, serviceName string) error 
 
 func (u *upstreamService) Create(ctx context.Context, upstreamName string) error {
 	log.Debugw("try to create upstreamService in cache",
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 
 	args := strings.Split(upstreamName, "_")
@@ -127,7 +127,7 @@ func (u *upstreamService) Create(ctx context.Context, upstreamName string) error
 
 func (u *upstreamService) List(ctx context.Context) ([]*v1.UpstreamServiceRelation, error) {
 	log.Debugw("try to create upstreamService in cache",
-		zap.String("cluster", "default"),
+		zap.String("cluster", u.cluster.name),
 	)
 	usrs, err := u.cluster.cache.ListUpstreamServiceRelation()
 	if err != nil {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

the value is not always "default"

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
