### PR TITLE
chore: use httptest.NewRequest instead of http.Request as incoming server request in test case

### DIFF
--- a/pkg/api/router/router_test.go
+++ b/pkg/api/router/router_test.go
@@ -60,8 +60,7 @@ func TestApisixHealthz(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
-	req, err := http.NewRequest("GET", "/metrics", nil)
-	assert.Nil(t, err, nil)
+	req := httptest.NewRequest("GET", "/metrics", nil)
 	c.Request = req
 	mountMetrics(r)
 	metrics(c)
@@ -72,8 +71,7 @@ func TestMetrics(t *testing.T) {
 func TestWebhooks(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
-	req, err := http.NewRequest("POST", "/validation", nil)
-	assert.Nil(t, err, nil)
+	req := httptest.NewRequest("POST", "/validation", nil)
 	c.Request = req
 	MountWebhooks(r, &apisix.ClusterOptions{})
 

--- a/pkg/api/router/router_test.go
+++ b/pkg/api/router/router_test.go
@@ -60,8 +60,7 @@ func TestApisixHealthz(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
-	req := httptest.NewRequest("GET", "/metrics", nil)
-	c.Request = req
+	c.Request = httptest.NewRequest("GET", "/metrics", nil)
 	mountMetrics(r)
 	metrics(c)
 
@@ -71,8 +70,7 @@ func TestMetrics(t *testing.T) {
 func TestWebhooks(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
-	req := httptest.NewRequest("POST", "/validation", nil)
-	c.Request = req
+	c.Request = httptest.NewRequest("POST", "/validation", nil)
 	MountWebhooks(r, &apisix.ClusterOptions{})
 
 	assert.Equal(t, http.StatusOK, w.Code)


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

use httptest.NewRequest instead of http.Request as incoming server request.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
