### PR TITLE
fix: set the health check log level by gin to debug

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -51,7 +51,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	}
 	gin.SetMode(gin.ReleaseMode)
 	httpServer := gin.New()
-	httpServer.Use(log.GinRecovery(log.DefaultLogger, true), log.GinLogger(log.DefaultLogger))
+	httpServer.Use(log.GinRecovery(true), log.GinLogger())
 	apirouter.Mount(httpServer)
 
 	srv := &Server{

--- a/pkg/log/gin_logger.go
+++ b/pkg/log/gin_logger.go
@@ -27,7 +27,7 @@ import (
 )
 
 // GinLogger receive gin The default log of the framework
-func GinLogger(logger *Logger) gin.HandlerFunc {
+func GinLogger() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		path := c.Request.URL.Path
@@ -35,17 +35,17 @@ func GinLogger(logger *Logger) gin.HandlerFunc {
 		c.Next()
 		cost := time.Since(start)
 		if c.Writer.Status() >= 400 && c.Writer.Status() <= 599 {
-			logger.Errorf("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
+			Errorf("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
 				path, c.Writer.Status(), c.Request.Method, query, c.ClientIP(), c.Request.UserAgent(), c.Errors.ByType(gin.ErrorTypePrivate).String(), cost)
 		} else {
-			logger.Debugf("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
+			Debugf("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
 				path, c.Writer.Status(), c.Request.Method, query, c.ClientIP(), c.Request.UserAgent(), c.Errors.ByType(gin.ErrorTypePrivate).String(), cost)
 		}
 	}
 }
 
 // GinRecovery recover Drop the project that may appear panic
-func GinRecovery(logger *Logger, stack bool) gin.HandlerFunc {
+func GinRecovery(stack bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		defer func() {
 			if err := recover(); err != nil {
@@ -62,7 +62,7 @@ func GinRecovery(logger *Logger, stack bool) gin.HandlerFunc {
 				}
 				httpRequest, _ := httputil.DumpRequest(c.Request, false)
 				if brokenPipe {
-					logger.Errorf("path: %s, error: %s, request: %s",
+					Errorf("path: %s, error: %s, request: %s",
 						c.Request.URL.Path, err, string(httpRequest))
 					// If the connection is dead, we can't write a status to it.
 					c.Error(err.(error)) // nolint: errcheck
@@ -71,11 +71,11 @@ func GinRecovery(logger *Logger, stack bool) gin.HandlerFunc {
 					return
 				}
 				if stack {
-					logger.Errorf("error: [Recovery from panic] %s, request: %s, stack: %s",
+					Errorf("error: [Recovery from panic] %s, request: %s, stack: %s",
 						err, string(httpRequest), string(debug.Stack()),
 					)
 				} else {
-					logger.Errorf("error: [Recovery from panic] %s, request: %s",
+					Errorf("error: [Recovery from panic] %s, request: %s",
 						err, string(httpRequest))
 				}
 				c.AbortWithStatus(http.StatusInternalServerError)

--- a/pkg/log/gin_logger.go
+++ b/pkg/log/gin_logger.go
@@ -38,7 +38,7 @@ func GinLogger(logger *Logger) gin.HandlerFunc {
 			logger.Errorf("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
 				path, c.Writer.Status(), c.Request.Method, query, c.ClientIP(), c.Request.UserAgent(), c.Errors.ByType(gin.ErrorTypePrivate).String(), cost)
 		} else {
-			logger.Infof("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
+			logger.Debugf("path: %s, status: %d, method: %s, query: %s, ip: %s, user-agent: %s, errors: %s, cost: %s",
 				path, c.Writer.Status(), c.Request.Method, query, c.ClientIP(), c.Request.UserAgent(), c.Errors.ByType(gin.ErrorTypePrivate).String(), cost)
 		}
 	}

--- a/pkg/log/gin_logger_test.go
+++ b/pkg/log/gin_logger_test.go
@@ -49,11 +49,12 @@ func TestGinLogger(t *testing.T) {
 	t.Run("test log with gin logger", func(t *testing.T) {
 		fws := &fakeWriteSyncer{}
 		logger, err := NewLogger(WithLogLevel("debug"), WithWriteSyncer(fws))
+		DefaultLogger = logger
 		assert.Nil(t, err, "failed to new logger: ", err)
 		defer logger.Close()
 
 		router := gin.New()
-		router.Use(GinLogger(logger))
+		router.Use(GinLogger())
 		router.GET("/healthz", func(c *gin.Context) {})
 		performRequest(router, "GET", "/healthz")
 		res := string(fws.bytes())
@@ -64,11 +65,12 @@ func TestGinLogger(t *testing.T) {
 	t.Run("test log with gin logger 4xx and 5xx", func(t *testing.T) {
 		fws := &fakeWriteSyncer{}
 		logger, err := NewLogger(WithLogLevel("debug"), WithWriteSyncer(fws))
+		DefaultLogger = logger
 		assert.Nil(t, err, "failed to new logger: ", err)
 		defer logger.Close()
 
 		router := gin.New()
-		router.Use(GinLogger(logger))
+		router.Use(GinLogger())
 		router.GET("/healthz", func(c *gin.Context) { c.JSON(500, nil) })
 		performRequest(router, "GET", "/healthz")
 		res := string(fws.bytes())
@@ -90,11 +92,12 @@ func TestGinRecovery(t *testing.T) {
 	t.Run("test log with gin recovery with stack", func(t *testing.T) {
 		fws := &fakeWriteSyncer{}
 		logger, err := NewLogger(WithLogLevel("debug"), WithWriteSyncer(fws))
+		DefaultLogger = logger
 		assert.Nil(t, err, "failed to new logger: ", err)
 		defer logger.Close()
 
 		router := gin.New()
-		router.Use(GinRecovery(logger, true))
+		router.Use(GinRecovery(true))
 		router.GET("/healthz", func(c *gin.Context) { panic("test log with gin recovery") })
 		performRequest(router, "GET", "/healthz")
 		res := string(fws.bytes())
@@ -107,11 +110,12 @@ func TestGinRecovery(t *testing.T) {
 	t.Run("test log with gin recovery", func(t *testing.T) {
 		fws := &fakeWriteSyncer{}
 		logger, err := NewLogger(WithLogLevel("debug"), WithWriteSyncer(fws))
+		DefaultLogger = logger
 		assert.Nil(t, err, "failed to new logger: ", err)
 		defer logger.Close()
 
 		router := gin.New()
-		router.Use(GinRecovery(logger, false))
+		router.Use(GinRecovery(false))
 		router.GET("/healthz", func(c *gin.Context) { panic("test log with gin recovery") })
 		performRequest(router, "GET", "/healthz")
 		res := string(fws.bytes())


### PR DESCRIPTION
### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
close: #1546

- [x] Modify log level (this can meet your basic needs)
- [x] Replace the logger of this part with the same logger as other part


`gin_logger` now does not require passing of `DefaultLogger` to it. It uses the same logger as other parts.