### PR TITLE
[v1.6 cherry-pick]fix: allow passing plugin config name for route with no backends (#1578)

### DIFF
--- a/pkg/providers/apisix/translation/apisix_route.go
+++ b/pkg/providers/apisix/translation/apisix_route.go
@@ -325,6 +325,10 @@ func (t *translator) translateHTTPRouteV2(ctx *translation.TranslateContext, ar 
 		route.EnableWebsocket = part.Websocket
 		route.Plugins = pluginMap
 		route.Timeout = timeout
+		if part.PluginConfigName != "" {
+			route.PluginConfigId = id.GenID(apisixv1.ComposePluginConfigName(ar.Namespace, part.PluginConfigName))
+		}
+
 		ctx.AddRoute(route)
 
 		// --- translate "Backends" ---
@@ -347,9 +351,6 @@ func (t *translator) translateHTTPRouteV2(ctx *translation.TranslateContext, ar 
 
 			upstreamName := apisixv1.ComposeUpstreamName(ar.Namespace, backend.ServiceName, backend.Subset, svcPort, backend.ResolveGranularity)
 			route.UpstreamId = id.GenID(upstreamName)
-			if part.PluginConfigName != "" {
-				route.PluginConfigId = id.GenID(apisixv1.ComposePluginConfigName(ar.Namespace, part.PluginConfigName))
-			}
 
 			if len(backends) > 0 {
 				weight := translation.DefaultWeight

--- a/test/e2e/suite-plugins/suite-plugins-other/plugin_config.go
+++ b/test/e2e/suite-plugins/suite-plugins-other/plugin_config.go
@@ -539,5 +539,68 @@ spec:
 	})
 	ginkgo.Describe("suite-plugins-other: scaffold v2", func() {
 		suites(scaffold.NewDefaultV2Scaffold)
+
+		s := scaffold.NewDefaultV2Scaffold()
+		ginkgo.It("applies plugin config for route with upstream", func() {
+			apc := fmt.Sprintf(`
+apiVersion: apisix.apache.org/v2
+kind: ApisixPluginConfig
+metadata:
+ name: httpbin-plugins
+spec:
+ plugins:
+ - name: proxy-rewrite
+   enable: true
+   config:
+     regex_uri:
+     - ^/httpbin/(.*)
+     - /$1
+`)
+			assert.Nil(ginkgo.GinkgoT(), s.CreateVersionedApisixResource(apc))
+
+			au := fmt.Sprintf(`
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+ name: httpbin-upstream
+spec:
+ externalNodes:
+ - type: Domain
+   name: httpbin.org
+`)
+			assert.Nil(ginkgo.GinkgoT(), s.CreateVersionedApisixResource(au))
+
+			ar := fmt.Sprintf(`
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+ name: httpbin-route
+spec:
+ http:
+ - name: httpbin-route-rule
+   match:
+    hosts:
+    - httpbin.org
+    paths:
+    - /httpbin/*
+    methods:
+    - GET
+   upstreams:
+   - name: httpbin-upstream
+   plugin_config_name: httpbin-plugins
+`)
+
+			assert.Nil(ginkgo.GinkgoT(), s.CreateVersionedApisixResource(ar))
+
+			err := s.EnsureNumApisixUpstreamsCreated(1)
+			assert.Nil(ginkgo.GinkgoT(), err, "Checking number of upstreams")
+			err = s.EnsureNumApisixPluginConfigCreated(1)
+			assert.Nil(ginkgo.GinkgoT(), err, "Checking number of pluginConfigs")
+			err = s.EnsureNumApisixRoutesCreated(1)
+			assert.Nil(ginkgo.GinkgoT(), err, "Checking number of routes")
+
+			resp := s.NewAPISIXClient().GET("/httpbin/ip").WithHeader("Host", "httpbin.org").Expect()
+			resp.Status(http.StatusOK)
+		})
 	})
 })


### PR DESCRIPTION


<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
cherry-pick #1578 
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
