### PR TITLE
docs: update the-hard-way doc contoller image version to 1.6.0

### DIFF
--- a/docs/en/latest/tutorials/the-hard-way.md
+++ b/docs/en/latest/tutorials/the-hard-way.md
@@ -322,7 +322,7 @@ spec:
     spec:
       containers:
         - name: apisix
-          image: "apache/apisix:2.15-alpine"
+          image: "apache/apisix:2.15.0-alpine"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/docs/en/latest/tutorials/the-hard-way.md
+++ b/docs/en/latest/tutorials/the-hard-way.md
@@ -766,7 +766,7 @@ spec:
             - ingress
             - --config-path
             - /ingress-apisix/conf/config.yaml
-          image: "apache/apisix-ingress-controller:1.4.0"
+          image: "apache/apisix-ingress-controller:1.6.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Update docs

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
if the image verion keeps to 1.4.0, the controller pod will CRASH, update it to 1.6.0
<!--- If it fixes an open issue, please link to the issue here. -->

