### PR TITLE
docs: update the apisix image version and ingress image version

### DIFF
--- a/docs/en/latest/tutorials/the-hard-way.md
+++ b/docs/en/latest/tutorials/the-hard-way.md
@@ -322,7 +322,7 @@ spec:
     spec:
       containers:
         - name: apisix
-          image: "apache/apisix:2.15-alpine"
+          image: "apache/apisix:2.15.0-alpine"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -766,7 +766,7 @@ spec:
             - ingress
             - --config-path
             - /ingress-apisix/conf/config.yaml
-          image: "apache/apisix-ingress-controller:1.4.0"
+          image: "apache/apisix-ingress-controller:1.6.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [x] Update docs

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
1. where is no apisix 2.15-alpine image in docker hub, with 2.15 and base image on alpine, there is 2.15.0-alpine in the hub, so if someone follow the doc will get imagePullErr.
2. I just test apisix-ingress-controller the original version 1.4.0 works, but the newest version is to 1.6.0, so maybe update the ingress controller image version is also needed.
