### PR TITLE
docs: fix type of .spec.plugins

### DIFF
--- a/docs/en/latest/concepts/apisix_global_rule.md
+++ b/docs/en/latest/concepts/apisix_global_rule.md
@@ -39,7 +39,7 @@ metadata:
   name: global
 spec:
   plugins:
-    name: limit-count
+  - name: limit-count
     enalbed: true 
     config:
       time_window": 60,


### PR DESCRIPTION
Maybe someone forgot to add the `-` letter :)
