### PR TITLE
feat: support disable resource periodically sync

### DIFF
--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -190,7 +190,7 @@ For example, no available LB exists in the bare metal environment.`)
 	cmd.PersistentFlags().StringVar(&cfg.APISIX.DefaultClusterBaseURL, "default-apisix-cluster-base-url", "", "the base URL of admin api / manager api for the default APISIX cluster")
 	cmd.PersistentFlags().StringVar(&cfg.APISIX.DefaultClusterAdminKey, "default-apisix-cluster-admin-key", "", "admin key used for the authorization of admin api / manager api for the default APISIX cluster")
 	cmd.PersistentFlags().StringVar(&cfg.APISIX.DefaultClusterName, "default-apisix-cluster-name", "default", "name of the default apisix cluster")
-	cmd.PersistentFlags().DurationVar(&cfg.ApisixResourceSyncInterval.Duration, "apisix-resource-sync-interval", 300*time.Second, "interval between syncs in seconds. Default value is 300s.")
+	cmd.PersistentFlags().DurationVar(&cfg.ApisixResourceSyncInterval.Duration, "apisix-resource-sync-interval", 1*time.Hour, "interval between syncs in seconds. Default value is 1h. Set to 0 to disable.")
 	cmd.PersistentFlags().StringVar(&cfg.PluginMetadataConfigMap, "plugin-metadata-cm", "plugin-metadata-config-map", "ConfigMap name of plugin metadata.")
 
 	return cmd

--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -457,9 +457,9 @@ func (c *Controller) checkClusterHealth(ctx context.Context, cancelFunc context.
 			// Finally failed health check, then give up leader.
 			log.Warnf("failed to check health for default cluster: %s, give up leader", err)
 			c.apiServer.HealthState.Lock()
-			defer c.apiServer.HealthState.Unlock()
-
 			c.apiServer.HealthState.Err = err
+			c.apiServer.HealthState.Unlock()
+
 			return
 		}
 		log.Debugf("success check health for default cluster")
@@ -477,6 +477,10 @@ func (c *Controller) syncAllResources() {
 }
 
 func (c *Controller) resourceSyncLoop(ctx context.Context, interval time.Duration) {
+	if interval == 0 {
+		log.Info("apisix-resource-sync-interval set to 0, periodically synchronization disabled.")
+		return
+	}
 	// The interval shall not be less than 60 seconds.
 	if interval < _mininumApisixResourceSyncInterval {
 		log.Warnw("The apisix-resource-sync-interval shall not be less than 60 seconds.",


### PR DESCRIPTION
- [ ] Bugfix
- [x] New feature provided
- [x] Improve performance

### What this PR does / why we need it:

The function can be useless if the user has never messed up ingress controller managed resources in APISIX. It should be able to be disabled.

Also, the default value `5m` is too small.  Every sync writes to etcd, causing etcd to store too many history records, making the dbsize grow dramatically over time.


(also fixes a small problem, `defer` shouldn't in loop)