### PR TITLE
e2e: incorrect label

### DIFF
--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -196,5 +196,5 @@ jobs:
           E2E_FLAKE_ATTEMPTS: "2"
           E2E_ENV: "ci"
         run: |
-          echo ${E2E_FOCUS} | grep "suite-cluster" && export E2E_FOCUS=1
+          echo ${E2E_FOCUS} | grep "suite-cluster" && export E2E_NODES=1
           make e2e-test

--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -196,4 +196,5 @@ jobs:
           E2E_FLAKE_ATTEMPTS: "2"
           E2E_ENV: "ci"
         run: |
+          echo ${E2E_FOCUS} | grep "suite-cluster" && export E2E_FOCUS=1
           make e2e-test

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ VERSYM="github.com/apache/apisix-ingress-controller/pkg/version._buildVersion"
 GITSHASYM="github.com/apache/apisix-ingress-controller/pkg/version._buildGitRevision"
 BUILDOSSYM="github.com/apache/apisix-ingress-controller/pkg/version._buildOS"
 GO_LDFLAGS ?= "-X=$(VERSYM)=$(VERSION) -X=$(GITSHASYM)=$(GITSHA) -X=$(BUILDOSSYM)=$(OSNAME)/$(OSARCH)"
-E2E_NODES ?= 4
+E2E_NODES ?= 2
 E2E_FLAKE_ATTEMPTS ?= 0
 E2E_SKIP_BUILD ?= 0
 E2E_ENV ?= "dev"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-annotations"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-chore"
+	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-cluster-config"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-features"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-gateway"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-ingress/suite-ingress-features"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,7 +17,7 @@ package e2e
 import (
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-annotations"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-chore"
-	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-cluster-config"
+	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-cluster"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-features"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-gateway"
 	_ "github.com/apache/apisix-ingress-controller/test/e2e/suite-ingress/suite-ingress-features"

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -439,18 +439,17 @@ func (s *Scaffold) beforeEach() {
 	}
 	s.finalizers = nil
 
-	if !s.opts.DisableNamespaceLabel {
-		if s.opts.NamespaceSelectorLabel != nil {
-			s.label = s.opts.NamespaceSelectorLabel
-		} else {
-			s.label = map[string]string{"apisix.ingress.watch": s.namespace}
-		}
+	if s.opts.NamespaceSelectorLabel != nil {
+		s.label = s.opts.NamespaceSelectorLabel
+	} else {
+		s.label = map[string]string{"apisix.ingress.watch": s.namespace}
 	}
 
-	fmt.Println(s.namespace)
-	fmt.Println(s.kubectlOptions)
-	fmt.Println(s.label)
-	k8s.CreateNamespaceWithMetadata(s.t, s.kubectlOptions, metav1.ObjectMeta{Name: s.namespace, Labels: s.label})
+	var nsLabel map[string]string
+	if !s.opts.DisableNamespaceLabel {
+		nsLabel = s.label
+	}
+	k8s.CreateNamespaceWithMetadata(s.t, s.kubectlOptions, metav1.ObjectMeta{Name: s.namespace, Labels: nsLabel})
 
 	s.nodes, err = k8s.GetReadyNodesE(s.t, s.kubectlOptions)
 	assert.Nil(s.t, err, "querying ready nodes")

--- a/test/e2e/suite-cluster/apisix_cluster_config.go
+++ b/test/e2e/suite-cluster/apisix_cluster_config.go
@@ -1,0 +1,259 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ingress
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/apache/apisix-ingress-controller/pkg/config"
+	"github.com/apache/apisix-ingress-controller/pkg/id"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
+)
+
+var _ = ginkgo.Describe("suite-cluster: ApisixClusterConfig with v2 and v2beta3 ", func() {
+	suites := func(scaffoldFunc func() *scaffold.Scaffold) {
+		s := scaffoldFunc()
+
+		ginkgo.It("enable prometheus", func() {
+			adminSvc, adminPort := s.ApisixAdminServiceAndPort()
+			assert.Nil(ginkgo.GinkgoT(), s.NewApisixClusterConfig("default", true, true), "creating ApisixClusterConfig")
+
+			defer func() {
+				assert.Nil(ginkgo.GinkgoT(), s.DeleteApisixClusterConfig("default", true, true))
+			}()
+
+			// Wait until the ApisixClusterConfig create event was delivered.
+			time.Sleep(3 * time.Second)
+
+			ar := fmt.Sprintf(`
+apiVersion: apisix.apache.org/v2beta3
+kind: ApisixRoute
+metadata:
+  name: default
+spec:
+  http:
+  - name: public-api
+    match:
+      paths:
+      - /apisix/prometheus/metrics
+    backends:
+    - serviceName: %s
+      servicePort: %d
+    plugins:
+    - name: public-api
+      enable: true
+`, adminSvc, adminPort)
+
+			err := s.CreateVersionedApisixResource(ar)
+			assert.Nil(ginkgo.GinkgoT(), err, "creating ApisixRouteConfig")
+
+			time.Sleep(3 * time.Second)
+
+			grs, err := s.ListApisixGlobalRules()
+			assert.Nil(ginkgo.GinkgoT(), err, "listing global_rules")
+			assert.Len(ginkgo.GinkgoT(), grs, 1)
+			assert.Equal(ginkgo.GinkgoT(), grs[0].ID, id.GenID("default"))
+			assert.Len(ginkgo.GinkgoT(), grs[0].Plugins, 1)
+			_, ok := grs[0].Plugins["prometheus"]
+			assert.Equal(ginkgo.GinkgoT(), ok, true)
+
+			resp := s.NewAPISIXClient().GET("/apisix/prometheus/metrics").Expect()
+			resp.Status(http.StatusOK)
+			resp.Body().Contains("# HELP apisix_etcd_modify_indexes Etcd modify index for APISIX keys")
+			resp.Body().Contains("# HELP apisix_etcd_reachable Config server etcd reachable from APISIX, 0 is unreachable")
+			resp.Body().Contains("# HELP apisix_node_info Info of APISIX node")
+
+			time.Sleep(3 * time.Second)
+
+			if s.ApisixResourceVersion() != config.ApisixV2beta3 {
+				resp1 := s.NewAPISIXClient().GET("/apisix/prometheus/metrics").Expect()
+				resp1.Status(http.StatusOK)
+				resp1.Body().Contains("public-api")
+			}
+		})
+	}
+
+	ginkgo.Describe("suite-features: scaffold v2beta3", func() {
+		suites(scaffold.NewDefaultV2beta3Scaffold)
+	})
+	ginkgo.Describe("suite-features: scaffold v2", func() {
+		suites(scaffold.NewDefaultV2Scaffold)
+	})
+})
+
+var _ = ginkgo.Describe("suite-cluster: Testin ApisixClusterConfig with IngressClass apisix", func() {
+	s := scaffold.NewScaffold(&scaffold.Options{
+		Name:                  "ingress-class",
+		IngressAPISIXReplicas: 1,
+		IngressClass:          "apisix",
+	})
+
+	ginkgo.It("ApisiClusterConfig should be ignored", func() {
+		// create ApisixConsumer resource with ingressClassName: ignore
+		acc := `
+apiVersion: apisix.apache.org/v2
+kind: ApisixClusterConfig
+metadata:
+  name: default
+spec:
+  ingressClassName: ignore
+  monitoring:
+    prometheus:
+      enable: true
+      prefer_name: true
+`
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(acc, ""))
+		time.Sleep(6 * time.Second)
+
+		agrs, err := s.ListApisixGlobalRules()
+		assert.Nil(ginkgo.GinkgoT(), err)
+		assert.Len(ginkgo.GinkgoT(), agrs, 0)
+	})
+
+	ginkgo.It("ApisiClusterConfig should be handled", func() {
+		// create ApisixConsumer resource without ingressClassName
+		acc := `
+apiVersion: apisix.apache.org/v2
+kind: ApisixClusterConfig
+metadata:
+  name: default
+spec:
+  monitoring:
+    prometheus:
+      enable: true
+      prefer_name: true
+`
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(acc, ""))
+		time.Sleep(6 * time.Second)
+
+		agrs, err := s.ListApisixGlobalRules()
+		assert.Nil(ginkgo.GinkgoT(), err)
+		assert.Len(ginkgo.GinkgoT(), agrs, 1)
+		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
+		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
+		_, ok := agrs[0].Plugins["prometheus"]
+		assert.Equal(ginkgo.GinkgoT(), ok, true)
+
+		// update ApisixConsumer resource with ingressClassName: apisix
+		acc = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixClusterConfig
+metadata:
+  name: default
+spec:
+  ingressClassName: apisix
+  monitoring:
+    prometheus:
+      enable: true
+      prefer_name: true
+`
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(acc, ""))
+		time.Sleep(6 * time.Second)
+
+		agrs, err = s.ListApisixGlobalRules()
+		assert.Nil(ginkgo.GinkgoT(), err)
+		assert.Len(ginkgo.GinkgoT(), agrs, 1)
+		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
+		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
+		_, ok = agrs[0].Plugins["prometheus"]
+		assert.Equal(ginkgo.GinkgoT(), ok, true)
+	})
+})
+
+var _ = ginkgo.Describe("suite-cluster: Testing ApisixClusterConfig with IngressClass apisix-and-all", func() {
+	s := scaffold.NewScaffold(&scaffold.Options{
+		Name:                  "ingress-class",
+		IngressAPISIXReplicas: 1,
+		IngressClass:          "apisix-and-all",
+	})
+
+	ginkgo.It("ApisiClusterConfig should be handled", func() {
+		// create ApisixConsumer resource without ingressClassName
+		acc := `
+apiVersion: apisix.apache.org/v2
+kind: ApisixClusterConfig
+metadata:
+  name: default
+spec:
+  monitoring:
+    prometheus:
+      enable: true
+      prefer_name: true
+`
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(acc, ""))
+		time.Sleep(6 * time.Second)
+
+		agrs, err := s.ListApisixGlobalRules()
+		assert.Nil(ginkgo.GinkgoT(), err)
+		assert.Len(ginkgo.GinkgoT(), agrs, 1)
+		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
+		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
+		_, ok := agrs[0].Plugins["prometheus"]
+		assert.Equal(ginkgo.GinkgoT(), ok, true)
+
+		// update ApisixConsumer resource with ingressClassName: apisix
+		acc = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixClusterConfig
+metadata:
+  name: default
+spec:
+  ingressClassName: apisix
+  monitoring:
+    prometheus:
+      enable: true
+      prefer_name: true
+`
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(acc, ""))
+		time.Sleep(6 * time.Second)
+
+		agrs, err = s.ListApisixGlobalRules()
+		assert.Nil(ginkgo.GinkgoT(), err)
+		assert.Len(ginkgo.GinkgoT(), agrs, 1)
+		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
+		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
+		_, ok = agrs[0].Plugins["prometheus"]
+		assert.Equal(ginkgo.GinkgoT(), ok, true)
+
+		// update ApisixConsumer resource with ingressClassName: watch
+		acc = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixClusterConfig
+metadata:
+  name: default
+spec:
+  ingressClassName: watch
+  monitoring:
+    prometheus:
+      enable: true
+      prefer_name: true
+`
+		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromStringWithNamespace(acc, ""))
+		time.Sleep(6 * time.Second)
+
+		agrs, err = s.ListApisixGlobalRules()
+		assert.Nil(ginkgo.GinkgoT(), err)
+		assert.Len(ginkgo.GinkgoT(), agrs, 1)
+		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
+		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
+		_, ok = agrs[0].Plugins["prometheus"]
+		assert.Equal(ginkgo.GinkgoT(), ok, true)
+	})
+})

--- a/test/e2e/suite-cluster/apisix_cluster_config.go
+++ b/test/e2e/suite-cluster/apisix_cluster_config.go
@@ -90,10 +90,10 @@ spec:
 		})
 	}
 
-	ginkgo.Describe("suite-features: scaffold v2beta3", func() {
+	ginkgo.Describe("suite-cluster: scaffold v2beta3", func() {
 		suites(scaffold.NewDefaultV2beta3Scaffold)
 	})
-	ginkgo.Describe("suite-features: scaffold v2", func() {
+	ginkgo.Describe("suite-cluster: scaffold v2", func() {
 		suites(scaffold.NewDefaultV2Scaffold)
 	})
 })

--- a/test/e2e/suite-cluster/apisix_cluster_config.go
+++ b/test/e2e/suite-cluster/apisix_cluster_config.go
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package ingress
+package cluster
 
 import (
 	"fmt"

--- a/test/e2e/suite-features/global_rule.go
+++ b/test/e2e/suite-features/global_rule.go
@@ -15,88 +15,13 @@
 package features
 
 import (
-	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/apache/apisix-ingress-controller/pkg/config"
-	"github.com/apache/apisix-ingress-controller/pkg/id"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
 )
-
-var _ = ginkgo.Describe("suite-features: ApisixClusterConfig", func() {
-	suites := func(scaffoldFunc func() *scaffold.Scaffold) {
-		s := scaffoldFunc()
-
-		ginkgo.It("enable prometheus", func() {
-			adminSvc, adminPort := s.ApisixAdminServiceAndPort()
-			assert.Nil(ginkgo.GinkgoT(), s.NewApisixClusterConfig("default", true, true), "creating ApisixClusterConfig")
-
-			defer func() {
-				assert.Nil(ginkgo.GinkgoT(), s.DeleteApisixClusterConfig("default", true, true))
-			}()
-
-			// Wait until the ApisixClusterConfig create event was delivered.
-			time.Sleep(3 * time.Second)
-
-			ar := fmt.Sprintf(`
-apiVersion: apisix.apache.org/v2beta3
-kind: ApisixRoute
-metadata:
-  name: default
-spec:
-  http:
-  - name: public-api
-    match:
-      paths:
-      - /apisix/prometheus/metrics
-    backends:
-    - serviceName: %s
-      servicePort: %d
-    plugins:
-    - name: public-api
-      enable: true
-`, adminSvc, adminPort)
-
-			err := s.CreateVersionedApisixResource(ar)
-			assert.Nil(ginkgo.GinkgoT(), err, "creating ApisixRouteConfig")
-
-			time.Sleep(3 * time.Second)
-
-			grs, err := s.ListApisixGlobalRules()
-			assert.Nil(ginkgo.GinkgoT(), err, "listing global_rules")
-			assert.Len(ginkgo.GinkgoT(), grs, 1)
-			assert.Equal(ginkgo.GinkgoT(), grs[0].ID, id.GenID("default"))
-			assert.Len(ginkgo.GinkgoT(), grs[0].Plugins, 1)
-			_, ok := grs[0].Plugins["prometheus"]
-			assert.Equal(ginkgo.GinkgoT(), ok, true)
-
-			resp := s.NewAPISIXClient().GET("/apisix/prometheus/metrics").Expect()
-			resp.Status(http.StatusOK)
-			resp.Body().Contains("# HELP apisix_etcd_modify_indexes Etcd modify index for APISIX keys")
-			resp.Body().Contains("# HELP apisix_etcd_reachable Config server etcd reachable from APISIX, 0 is unreachable")
-			resp.Body().Contains("# HELP apisix_node_info Info of APISIX node")
-
-			time.Sleep(3 * time.Second)
-
-			if s.ApisixResourceVersion() != config.ApisixV2beta3 {
-				resp1 := s.NewAPISIXClient().GET("/apisix/prometheus/metrics").Expect()
-				resp1.Status(http.StatusOK)
-				resp1.Body().Contains("public-api")
-			}
-		})
-	}
-
-	ginkgo.Describe("suite-features: scaffold v2beta3", func() {
-		suites(scaffold.NewDefaultV2beta3Scaffold)
-	})
-	ginkgo.Describe("suite-features: scaffold v2", func() {
-		suites(scaffold.NewDefaultV2Scaffold)
-	})
-})
 
 var _ = ginkgo.Describe("suite-features: ApisiGlobalRule", func() {
 	s := scaffold.NewDefaultScaffold()

--- a/test/e2e/suite-ingress/suite-ingress-features/ingress-class.go
+++ b/test/e2e/suite-ingress/suite-ingress-features/ingress-class.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/apache/apisix-ingress-controller/pkg/id"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 
@@ -473,81 +472,6 @@ spec:
 		assert.Contains(ginkgo.GinkgoT(), acs[0].Username, "james")
 		assert.Equal(ginkgo.GinkgoT(), map[string]interface{}{"key": "james-key"}, acs[0].Plugins["key-auth"])
 	})
-
-	ginkgo.It("ApisiClusterConfig should be ignored", func() {
-		// create ApisixConsumer resource with ingressClassName: ignore
-		acc := `
-apiVersion: apisix.apache.org/v2
-kind: ApisixClusterConfig
-metadata:
-  name: default
-spec:
-  ingressClassName: ignore
-  monitoring:
-    prometheus:
-      enable: true
-      prefer_name: true
-`
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(acc))
-		time.Sleep(6 * time.Second)
-
-		agrs, err := s.ListApisixGlobalRules()
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Len(ginkgo.GinkgoT(), agrs, 1)
-		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
-		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
-		_, ok := agrs[0].Plugins["prometheus"]
-		assert.Equal(ginkgo.GinkgoT(), ok, true)
-	})
-
-	ginkgo.It("ApisiClusterConfig should be handled", func() {
-		// create ApisixConsumer resource without ingressClassName
-		acc := `
-apiVersion: apisix.apache.org/v2
-kind: ApisixClusterConfig
-metadata:
-  name: default
-spec:
-  monitoring:
-    prometheus:
-      enable: true
-      prefer_name: true
-`
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(acc))
-		time.Sleep(6 * time.Second)
-
-		agrs, err := s.ListApisixGlobalRules()
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Len(ginkgo.GinkgoT(), agrs, 1)
-		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
-		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
-		_, ok := agrs[0].Plugins["prometheus"]
-		assert.Equal(ginkgo.GinkgoT(), ok, true)
-
-		// update ApisixConsumer resource with ingressClassName: apisix
-		acc = `
-apiVersion: apisix.apache.org/v2
-kind: ApisixClusterConfig
-metadata:
-  name: default
-spec:
-  ingressClassName: apisix
-  monitoring:
-    prometheus:
-      enable: true
-      prefer_name: true
-`
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(acc))
-		time.Sleep(6 * time.Second)
-
-		agrs, err = s.ListApisixGlobalRules()
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Len(ginkgo.GinkgoT(), agrs, 1)
-		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
-		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
-		_, ok = agrs[0].Plugins["prometheus"]
-		assert.Equal(ginkgo.GinkgoT(), ok, true)
-	})
 })
 
 var _ = ginkgo.Describe("suite-ingress-features: Testing CRDs with IngressClass apisix-and-all", func() {
@@ -845,78 +769,5 @@ spec:
 		assert.Len(ginkgo.GinkgoT(), acs, 1)
 		assert.Contains(ginkgo.GinkgoT(), acs[0].Username, "james")
 		assert.Equal(ginkgo.GinkgoT(), map[string]interface{}{"key": "james-password"}, acs[0].Plugins["key-auth"])
-	})
-
-	ginkgo.It("ApisiClusterConfig should be handled", func() {
-		// create ApisixConsumer resource without ingressClassName
-		acc := `
-apiVersion: apisix.apache.org/v2
-kind: ApisixClusterConfig
-metadata:
-  name: default
-spec:
-  monitoring:
-    prometheus:
-      enable: true
-      prefer_name: true
-`
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(acc))
-		time.Sleep(6 * time.Second)
-
-		agrs, err := s.ListApisixGlobalRules()
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Len(ginkgo.GinkgoT(), agrs, 1)
-		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
-		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
-		_, ok := agrs[0].Plugins["prometheus"]
-		assert.Equal(ginkgo.GinkgoT(), ok, true)
-
-		// update ApisixConsumer resource with ingressClassName: apisix
-		acc = `
-apiVersion: apisix.apache.org/v2
-kind: ApisixClusterConfig
-metadata:
-  name: default
-spec:
-  ingressClassName: apisix
-  monitoring:
-    prometheus:
-      enable: true
-      prefer_name: true
-`
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(acc))
-		time.Sleep(6 * time.Second)
-
-		agrs, err = s.ListApisixGlobalRules()
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Len(ginkgo.GinkgoT(), agrs, 1)
-		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
-		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
-		_, ok = agrs[0].Plugins["prometheus"]
-		assert.Equal(ginkgo.GinkgoT(), ok, true)
-
-		// update ApisixConsumer resource with ingressClassName: watch
-		acc = `
-apiVersion: apisix.apache.org/v2
-kind: ApisixClusterConfig
-metadata:
-  name: default
-spec:
-  ingressClassName: watch
-  monitoring:
-    prometheus:
-      enable: true
-      prefer_name: true
-`
-		assert.Nil(ginkgo.GinkgoT(), s.CreateResourceFromString(acc))
-		time.Sleep(6 * time.Second)
-
-		agrs, err = s.ListApisixGlobalRules()
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Len(ginkgo.GinkgoT(), agrs, 1)
-		assert.Equal(ginkgo.GinkgoT(), agrs[0].ID, id.GenID("default"))
-		assert.Len(ginkgo.GinkgoT(), agrs[0].Plugins, 1)
-		_, ok = agrs[0].Plugins["prometheus"]
-		assert.Equal(ginkgo.GinkgoT(), ok, true)
 	})
 })


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

https://github.com/apache/apisix-ingress-controller/actions/runs/4475046823/jobs/7864164247

#### Ci is currently very unstable for two main reasons:

1. Opts.NamespaceLabel resources are mutually exclusive
  -  **It may inject incorrect labels, resulting in incorrect configuration of the namespaceSelector and failure of the test case.**

2. ApisixClusterConfig resources are mutually exclusive: 
  - **In concurrent scenarios, resources at the cluster level cannot be isolated through ns, which may result in resources from other use cases being incorrectly watched.**

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
