### PR TITLE
docs: added Docker to prerequisite of Installation with Kind 

### DIFF
--- a/docs/en/latest/deployments/kind.md
+++ b/docs/en/latest/deployments/kind.md
@@ -30,7 +30,7 @@ This document explains how you can install APISIX ingress locally on [kind](http
 
 ## Prerequisites
 
-* Install [Docker](https://docs.docker.com/engine/install/)
+* Install [Docker](https://docs.docker.com/engine/install/).
 * Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 * Install [Helm](https://helm.sh/).
 * Install [kubectl](https://kubernetes.io/docs/tasks/tools/).

--- a/docs/en/latest/deployments/kind.md
+++ b/docs/en/latest/deployments/kind.md
@@ -30,6 +30,7 @@ This document explains how you can install APISIX ingress locally on [kind](http
 
 ## Prerequisites
 
+* Install [Docker](https://docs.docker.com/engine/install/)
 * Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 * Install [Helm](https://helm.sh/).
 * Install [kubectl](https://kubernetes.io/docs/tasks/tools/).


### PR DESCRIPTION
Installing ingress controller with Kind on a clean Debian today. Installed the three pre-req items but still got the following: 

```
$ kind create cluster
ERROR: failed to create cluster: failed to get docker info: command "docker info --format '{{json .}}'" failed with error: exec: "docker": executable file not found in $PATH
```

Looks like Docker should be added 
