### PR TITLE
docs: add ApisixPluginConfig and update examples

### DIFF
--- a/docs/en/latest/concepts/apisix_plugin_config.md
+++ b/docs/en/latest/concepts/apisix_plugin_config.md
@@ -1,0 +1,55 @@
+---
+title: ApisixPluginConfig
+keywords:
+  - APISIX ingress
+  - Apache APISIX
+  - ApisixPluginConfig
+description: Guide to using ApisixPluginConfig custom Kubernetes resource.
+---
+
+`ApisixPluginConfig` is a Kubernetes CRD that can be used to extract commonly used Plugins and can be bound directly to multiple Routes.
+
+See [reference](https://apisix.apache.org/docs/ingress-controller/references/apisix_pluginconfig_v2/) for the full API documentation.
+
+The example below shows how you can configure an `ApisixPluginConfig` resource:
+
+```yaml
+apiVersion: apisix.apache.org/v2
+kind: ApisixPluginConfig
+metadata:
+ name: echo-and-cors-apc
+spec:
+ plugins:
+ - name: echo
+   enable: true
+   config:
+    before_body: "This is the prologue"
+    after_body: "This is the epilogue"
+    headers:
+     X-Foo: v1
+     X-Foo2: v2
+ - name: cors
+   enable: true
+```
+
+You can then configure a Route to use the `echo-and-cors-apc` Plugin configuration:
+
+```yaml
+apiVersion: apisix.apache.org/v2beta3
+kind: ApisixRoute
+metadata:
+ name: httpbin-route
+spec:
+ http:
+  - name: rule1
+    match:
+      hosts:
+      - httpbin.org
+      paths:
+      - /ip
+    backends:
+    - serviceName: %s
+      servicePort: %d
+      weight: 10
+    plugin_config_name: echo-and-cors-apc
+```

--- a/docs/en/latest/concepts/apisix_plugin_config.md
+++ b/docs/en/latest/concepts/apisix_plugin_config.md
@@ -9,7 +9,7 @@ description: Guide to using ApisixPluginConfig custom Kubernetes resource.
 
 `ApisixPluginConfig` is a Kubernetes CRD that can be used to extract commonly used Plugins and can be bound directly to multiple Routes.
 
-See [reference](https://apisix.apache.org/docs/ingress-controller/references/apisix_pluginconfig_v2/) for the full API documentation.
+See [reference](https://apisix.apache.org/docs/ingress-controller/references/apisix_pluginconfig_v2) for the full API documentation.
 
 The example below shows how you can configure an `ApisixPluginConfig` resource:
 

--- a/docs/en/latest/concepts/apisix_plugin_config.md
+++ b/docs/en/latest/concepts/apisix_plugin_config.md
@@ -17,19 +17,19 @@ The example below shows how you can configure an `ApisixPluginConfig` resource:
 apiVersion: apisix.apache.org/v2
 kind: ApisixPluginConfig
 metadata:
- name: echo-and-cors-apc
+  name: echo-and-cors-apc
 spec:
- plugins:
- - name: echo
-   enable: true
-   config:
-    before_body: "This is the prologue"
-    after_body: "This is the epilogue"
-    headers:
-     X-Foo: v1
-     X-Foo2: v2
- - name: cors
-   enable: true
+  plugins:
+  - name: echo
+    enable: true
+    config:
+      before_body: "This is the prologue"
+      after_body: "This is the epilogue"
+      headers:
+       X-Foo: v1
+       X-Foo2: v2
+  - name: cors
+    enable: true
 ```
 
 You can then configure a Route to use the `echo-and-cors-apc` Plugin configuration:
@@ -38,9 +38,9 @@ You can then configure a Route to use the `echo-and-cors-apc` Plugin configurati
 apiVersion: apisix.apache.org/v2beta3
 kind: ApisixRoute
 metadata:
- name: httpbin-route
+  name: httpbin-route
 spec:
- http:
+  http:
   - name: rule1
     match:
       hosts:

--- a/docs/en/latest/concepts/apisix_route.md
+++ b/docs/en/latest/concepts/apisix_route.md
@@ -190,9 +190,9 @@ The example below configures [limit-count](https://apisix.apache.org/docs/apisix
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
- name: httpbin-route
+  name: httpbin-route
 spec:
- http:
+  http:
  - name: rule1
    match:
      hosts:

--- a/docs/en/latest/concepts/apisix_route.md
+++ b/docs/en/latest/concepts/apisix_route.md
@@ -184,28 +184,36 @@ If the Plugin is not enabled in APISIX by default, you can enable it by adding i
 
 :::
 
-The example below configures [cors](https://apisix.apache.org/docs/apisix/plugins/cors/) Plugin for the route:
+The example below configures [limit-count](https://apisix.apache.org/docs/apisix/plugins/limit-count) Plugin for the route:
 
 ```yaml
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  name: httpbin-route
+ name: httpbin-route
 spec:
-  http:
-    - name: httpbin
-      match:
-        hosts:
-        - local.httpbin.org
-        paths:
-          - /*
-      backends:
-      - serviceName: foo
-        servicePort: 80
-      plugins:
-        - name: cors
-          enable: true
+ http:
+ - name: rule1
+   match:
+     hosts:
+     - httpbin.org
+     paths:
+       - /ip
+   backends:
+   - serviceName: %s
+     servicePort: %d
+     weight: 10
+   plugins:
+   - name: limit-count
+     enable: true
+     config:
+       rejected_code: 503
+       count: 2
+       time_window: 3
+       key: remote_addr
 ```
+
+You can also use the [ApisixPluginConfig](https://apisix.apache.org/docs/ingress-controller/concepts/apisix_plugin_config) CRD to extract and reuse commonly used Plugins and bind them directly to a Route.
 
 ### Config with secretRef
 

--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -66,6 +66,7 @@
         "concepts/apisix_upstream",
         "concepts/apisix_tls",
         "concepts/apisix_cluster_config",
+        "concepts/apisix_plugin_config",
         "concepts/annotations"
       ]
     },


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Fixes #1552

Updates concepts/ApisixRoute docs with a better example of using a Plugin and adds documentation for the ApisixPluginConfig CRD.