### PR TITLE
fix: missing upstream name in gateway-api routes

### DIFF
--- a/pkg/providers/gateway/translation/gateway_httproute.go
+++ b/pkg/providers/gateway/translation/gateway_httproute.go
@@ -194,7 +194,7 @@ func (t *translator) TranslateGatewayHTTPRouteV1beta1(httpRoute *gatewayv1beta1.
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to translate Rules[%v].BackendRefs[%v]", i, j))
 			}
-			name := apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
+			ups.Name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
 
 			// APISIX limits max length of label value
 			// https://github.com/apache/apisix/blob/5b95b85faea3094d5e466ee2d39a52f1f805abbb/apisix/schema_def.lua#L85
@@ -202,7 +202,12 @@ func (t *translator) TranslateGatewayHTTPRouteV1beta1(httpRoute *gatewayv1beta1.
 			ups.Labels["meta_backend"] = utils.TruncateString(string(backend.Name), 64)
 			ups.Labels["meta_port"] = fmt.Sprintf("%v", int32(*backend.Port))
 
-			ups.ID = id.GenID(name)
+			ups.ID = id.GenID(ups.Name)
+			log.Debugw("translated HTTPRoute upstream",
+				zap.Int("backendRefs_index", j),
+				zap.String("backendRefs_name", string(backend.Name)),
+				zap.String("name", ups.Name),
+			)
 			ctx.AddUpstream(ups)
 			ruleUpstreams = append(ruleUpstreams, ups)
 

--- a/pkg/providers/gateway/translation/gateway_httproute_test.go
+++ b/pkg/providers/gateway/translation/gateway_httproute_test.go
@@ -16,6 +16,9 @@ package translation
 
 import (
 	"context"
+	"fmt"
+	"github.com/apache/apisix-ingress-controller/pkg/providers/utils"
+	"k8s.io/client-go/kubernetes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,59 +38,76 @@ import (
 	v1 "github.com/apache/apisix-ingress-controller/pkg/types/apisix/v1"
 )
 
-func mockHTTPRouteTranslator(t *testing.T) (*translator, <-chan struct{}) {
+func refKind(str gatewayv1beta1.Kind) *gatewayv1beta1.Kind {
+	return &str
+}
+func refNamespace(str gatewayv1beta1.Namespace) *gatewayv1beta1.Namespace {
+	return &str
+}
+func refInt32(i int32) *int32 {
+	return &i
+}
+func refPortNumber(i gatewayv1beta1.PortNumber) *gatewayv1beta1.PortNumber {
+	return &i
+}
+
+func newServiceAndEndpoints(t *testing.T, client kubernetes.Interface, ns, svcName string, ports, targetPorts []int32, address []string) (*corev1.Service, *corev1.Endpoints) {
 	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc",
-			Namespace: "test",
+			Name:      svcName,
+			Namespace: ns,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name: "port1",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 9080,
-					},
-				},
-				{
-					Name: "port2",
-					Port: 443,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 9443,
-					},
-				},
-			},
+			Ports: []corev1.ServicePort{},
 		},
 	}
+
 	endpoints := &corev1.Endpoints{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc",
-			Namespace: "test",
+			Name:      svcName,
+			Namespace: ns,
 		},
 		Subsets: []corev1.EndpointSubset{
 			{
-				Ports: []corev1.EndpointPort{
-					{
-						Name: "port1",
-						Port: 9080,
-					},
-					{
-						Name: "port2",
-						Port: 9443,
-					},
-				},
-				Addresses: []corev1.EndpointAddress{
-					{IP: "192.168.1.1"},
-					{IP: "192.168.1.2"},
-				},
+				Ports:     []corev1.EndpointPort{},
+				Addresses: []corev1.EndpointAddress{},
 			},
 		},
 	}
+
+	for i, port := range ports {
+		targetPort := targetPorts[i]
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+			Name: fmt.Sprintf("port%v", i),
+			Port: port,
+			TargetPort: intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: targetPort,
+			},
+		})
+		endpoints.Subsets[0].Ports = append(endpoints.Subsets[0].Ports, corev1.EndpointPort{
+			Name: fmt.Sprintf("port%v", i),
+			Port: targetPort,
+		})
+	}
+
+	for _, addr := range address {
+		endpoints.Subsets[0].Addresses = append(endpoints.Subsets[0].Addresses, corev1.EndpointAddress{
+			IP: addr,
+		})
+	}
+
+	_, err := client.CoreV1().Endpoints(ns).Create(context.Background(), endpoints, metav1.CreateOptions{})
+	assert.Nil(t, err)
+	_, err = client.CoreV1().Services(ns).Create(context.Background(), svc, metav1.CreateOptions{})
+	assert.Nil(t, err)
+
+	return svc, endpoints
+}
+
+func mockHTTPRouteTranslator(t *testing.T) (*translator, <-chan struct{}) {
 
 	client := fake.NewSimpleClientset()
 	informersFactory := informers.NewSharedInformerFactory(client, 0)
@@ -97,10 +117,8 @@ func mockHTTPRouteTranslator(t *testing.T) (*translator, <-chan struct{}) {
 	apisixClient := fakeapisix.NewSimpleClientset()
 	apisixInformersFactory := apisixinformers.NewSharedInformerFactory(apisixClient, 0)
 
-	_, err := client.CoreV1().Endpoints("test").Create(context.Background(), endpoints, metav1.CreateOptions{})
-	assert.Nil(t, err)
-	_, err = client.CoreV1().Services("test").Create(context.Background(), svc, metav1.CreateOptions{})
-	assert.Nil(t, err)
+	newServiceAndEndpoints(t, client, "test", "svc", []int32{80, 443}, []int32{9080, 9443}, []string{"192.168.1.1", "192.168.1.2"})
+	newServiceAndEndpoints(t, client, "test", "svc2", []int32{81, 444}, []int32{9081, 9444}, []string{"192.168.1.3", "192.168.1.4"})
 
 	tr := &translator{
 		&TranslatorOptions{
@@ -138,34 +156,6 @@ func mockHTTPRouteTranslator(t *testing.T) (*translator, <-chan struct{}) {
 }
 
 func TestTranslateGatewayHTTPRouteExactMatch(t *testing.T) {
-	refStr := func(str string) *string {
-		return &str
-	}
-	refKind := func(str gatewayv1beta1.Kind) *gatewayv1beta1.Kind {
-		return &str
-	}
-	refNamespace := func(str gatewayv1beta1.Namespace) *gatewayv1beta1.Namespace {
-		return &str
-	}
-	refMethod := func(str gatewayv1beta1.HTTPMethod) *gatewayv1beta1.HTTPMethod {
-		return &str
-	}
-	refPathMatchType := func(str gatewayv1beta1.PathMatchType) *gatewayv1beta1.PathMatchType {
-		return &str
-	}
-	refHeaderMatchType := func(str gatewayv1beta1.HeaderMatchType) *gatewayv1beta1.HeaderMatchType {
-		return &str
-	}
-	refQueryParamMatchType := func(str gatewayv1beta1.QueryParamMatchType) *gatewayv1beta1.QueryParamMatchType {
-		return &str
-	}
-	refInt32 := func(i int32) *int32 {
-		return &i
-	}
-	refPortNumber := func(i gatewayv1beta1.PortNumber) *gatewayv1beta1.PortNumber {
-		return &i
-	}
-
 	tr, processCh := mockHTTPRouteTranslator(t)
 	<-processCh
 	<-processCh
@@ -184,29 +174,29 @@ func TestTranslateGatewayHTTPRouteExactMatch(t *testing.T) {
 					Matches: []gatewayv1beta1.HTTPRouteMatch{
 						{
 							Path: &gatewayv1beta1.HTTPPathMatch{
-								Type:  refPathMatchType(gatewayv1beta1.PathMatchPathPrefix),
-								Value: refStr("/path"),
+								Type:  utils.PtrOf(gatewayv1beta1.PathMatchPathPrefix),
+								Value: utils.PtrOf("/path"),
 							},
 							Headers: []gatewayv1beta1.HTTPHeaderMatch{
 								{
-									Type:  refHeaderMatchType(gatewayv1beta1.HeaderMatchExact),
+									Type:  utils.PtrOf(gatewayv1beta1.HeaderMatchExact),
 									Name:  "REFERER",
 									Value: "api7.com",
 								},
 							},
 							QueryParams: []gatewayv1beta1.HTTPQueryParamMatch{
 								{
-									Type:  refQueryParamMatchType(gatewayv1beta1.QueryParamMatchExact),
+									Type:  utils.PtrOf(gatewayv1beta1.QueryParamMatchExact),
 									Name:  "user",
 									Value: "api7",
 								},
 								{
-									Type:  refQueryParamMatchType(gatewayv1beta1.QueryParamMatchExact),
+									Type:  utils.PtrOf(gatewayv1beta1.QueryParamMatchExact),
 									Name:  "title",
 									Value: "ingress",
 								},
 							},
-							Method: refMethod(gatewayv1beta1.HTTPMethodGet),
+							Method: utils.PtrOf(gatewayv1beta1.HTTPMethodGet),
 						},
 					},
 					Filters: []gatewayv1beta1.HTTPRouteFilter{
@@ -271,38 +261,10 @@ func TestTranslateGatewayHTTPRouteExactMatch(t *testing.T) {
 	assert.Equal(t, "192.168.1.1", u.Nodes[0].Host)
 	assert.Equal(t, 9080, u.Nodes[0].Port)
 	assert.Equal(t, "192.168.1.2", u.Nodes[1].Host)
-	assert.Equal(t, 9080, u.Nodes[0].Port)
+	assert.Equal(t, 9080, u.Nodes[1].Port)
 }
 
 func TestTranslateGatewayHTTPRouteRegexMatch(t *testing.T) {
-	refStr := func(str string) *string {
-		return &str
-	}
-	refKind := func(str gatewayv1beta1.Kind) *gatewayv1beta1.Kind {
-		return &str
-	}
-	refNamespace := func(str gatewayv1beta1.Namespace) *gatewayv1beta1.Namespace {
-		return &str
-	}
-	refMethod := func(str gatewayv1beta1.HTTPMethod) *gatewayv1beta1.HTTPMethod {
-		return &str
-	}
-	refPathMatchType := func(str gatewayv1beta1.PathMatchType) *gatewayv1beta1.PathMatchType {
-		return &str
-	}
-	refHeaderMatchType := func(str gatewayv1beta1.HeaderMatchType) *gatewayv1beta1.HeaderMatchType {
-		return &str
-	}
-	refQueryParamMatchType := func(str gatewayv1beta1.QueryParamMatchType) *gatewayv1beta1.QueryParamMatchType {
-		return &str
-	}
-	refInt32 := func(i int32) *int32 {
-		return &i
-	}
-	refPortNumber := func(i gatewayv1beta1.PortNumber) *gatewayv1beta1.PortNumber {
-		return &i
-	}
-
 	tr, processCh := mockHTTPRouteTranslator(t)
 	<-processCh
 	<-processCh
@@ -321,29 +283,29 @@ func TestTranslateGatewayHTTPRouteRegexMatch(t *testing.T) {
 					Matches: []gatewayv1beta1.HTTPRouteMatch{
 						{
 							Path: &gatewayv1beta1.HTTPPathMatch{
-								Type:  refPathMatchType(gatewayv1beta1.PathMatchRegularExpression),
-								Value: refStr("/path"),
+								Type:  utils.PtrOf(gatewayv1beta1.PathMatchRegularExpression),
+								Value: utils.PtrOf("/path"),
 							},
 							Headers: []gatewayv1beta1.HTTPHeaderMatch{
 								{
-									Type:  refHeaderMatchType(gatewayv1beta1.HeaderMatchRegularExpression),
+									Type:  utils.PtrOf(gatewayv1beta1.HeaderMatchRegularExpression),
 									Name:  "REFERER",
 									Value: "api7.com",
 								},
 							},
 							QueryParams: []gatewayv1beta1.HTTPQueryParamMatch{
 								{
-									Type:  refQueryParamMatchType(gatewayv1beta1.QueryParamMatchRegularExpression),
+									Type:  utils.PtrOf(gatewayv1beta1.QueryParamMatchRegularExpression),
 									Name:  "user",
 									Value: "api7",
 								},
 								{
-									Type:  refQueryParamMatchType(gatewayv1beta1.QueryParamMatchRegularExpression),
+									Type:  utils.PtrOf(gatewayv1beta1.QueryParamMatchRegularExpression),
 									Name:  "title",
 									Value: "ingress",
 								},
 							},
-							Method: refMethod(gatewayv1beta1.HTTPMethodGet),
+							Method: utils.PtrOf(gatewayv1beta1.HTTPMethodGet),
 						},
 					},
 					Filters: []gatewayv1beta1.HTTPRouteFilter{
@@ -408,7 +370,139 @@ func TestTranslateGatewayHTTPRouteRegexMatch(t *testing.T) {
 	assert.Equal(t, "192.168.1.1", u.Nodes[0].Host)
 	assert.Equal(t, 9080, u.Nodes[0].Port)
 	assert.Equal(t, "192.168.1.2", u.Nodes[1].Host)
-	assert.Equal(t, 9080, u.Nodes[0].Port)
+	assert.Equal(t, 9080, u.Nodes[1].Port)
 }
 
-// TODO: Multiple BackendRefs, Multiple Rules, Multiple Matches
+// TODO: Multiple Rules, Multiple Matches
+
+func TestTranslateGatewayHTTPRouteMultipleBackendRefs(t *testing.T) {
+	tr, processCh := mockHTTPRouteTranslator(t)
+	<-processCh
+	<-processCh
+
+	httpRoute := &gatewayv1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http_route",
+			Namespace: "test",
+		},
+		Spec: gatewayv1beta1.HTTPRouteSpec{
+			Hostnames: []gatewayv1beta1.Hostname{
+				"example.com",
+			},
+			Rules: []gatewayv1beta1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1beta1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1beta1.HTTPPathMatch{
+								Type:  utils.PtrOf(gatewayv1beta1.PathMatchPathPrefix),
+								Value: utils.PtrOf("/path"),
+							},
+						},
+					},
+					Filters: []gatewayv1beta1.HTTPRouteFilter{
+						// TODO
+					},
+					BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1beta1.BackendRef{
+								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+									Kind:      refKind("Service"),
+									Name:      "svc",
+									Namespace: refNamespace("test"),
+									Port:      refPortNumber(80),
+								},
+								Weight: refInt32(100), // TODO
+							},
+							Filters: []gatewayv1beta1.HTTPRouteFilter{
+								// TODO
+							},
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1beta1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1beta1.HTTPPathMatch{
+								Type:  utils.PtrOf(gatewayv1beta1.PathMatchPathPrefix),
+								Value: utils.PtrOf("/path2"),
+							},
+						},
+					},
+					Filters: []gatewayv1beta1.HTTPRouteFilter{
+						// TODO
+					},
+					BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1beta1.BackendRef{
+								BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+									Kind:      refKind("Service"),
+									Name:      "svc2",
+									Namespace: refNamespace("test"),
+									Port:      refPortNumber(81),
+								},
+								Weight: refInt32(100), // TODO
+							},
+							Filters: []gatewayv1beta1.HTTPRouteFilter{
+								// TODO
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tctx, err := tr.TranslateGatewayHTTPRouteV1beta1(httpRoute)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 2, len(tctx.Routes))
+	assert.Equal(t, 2, len(tctx.Upstreams))
+
+	// === route 1 ===
+	r := tctx.Routes[0]
+	u := tctx.Upstreams[0]
+
+	// Metadata
+	// FIXME
+	assert.NotEqual(t, "", u.ID)
+	assert.Equal(t, u.ID, r.UpstreamId)
+
+	// hosts
+	assert.Equal(t, 1, len(r.Hosts))
+	assert.Equal(t, "example.com", r.Hosts[0])
+
+	// matches
+	assert.Equal(t, "/path*", r.Uri)
+
+	// backend refs
+	assert.Equal(t, "http", u.Scheme) // FIXME
+	assert.Equal(t, 2, len(u.Nodes))
+	assert.Equal(t, "192.168.1.1", u.Nodes[0].Host)
+	assert.Equal(t, 9080, u.Nodes[0].Port)
+	assert.Equal(t, "192.168.1.2", u.Nodes[1].Host)
+	assert.Equal(t, 9080, u.Nodes[1].Port)
+
+	// === route 2 ===
+	r = tctx.Routes[1]
+	u = tctx.Upstreams[1]
+
+	// Metadata
+	// FIXME
+	assert.NotEqual(t, "", u.ID)
+	assert.Equal(t, u.ID, r.UpstreamId)
+
+	// hosts
+	assert.Equal(t, 1, len(r.Hosts))
+	assert.Equal(t, "example.com", r.Hosts[0])
+
+	// matches
+	assert.Equal(t, "/path2*", r.Uri)
+
+	// backend refs
+	assert.Equal(t, "http", u.Scheme) // FIXME
+	assert.Equal(t, 2, len(u.Nodes))
+	assert.Equal(t, "192.168.1.3", u.Nodes[0].Host)
+	assert.Equal(t, 9081, u.Nodes[0].Port)
+	assert.Equal(t, "192.168.1.4", u.Nodes[1].Host)
+	assert.Equal(t, 9081, u.Nodes[1].Port)
+}

--- a/pkg/providers/gateway/translation/gateway_httproute_test.go
+++ b/pkg/providers/gateway/translation/gateway_httproute_test.go
@@ -17,8 +17,6 @@ package translation
 import (
 	"context"
 	"fmt"
-	"github.com/apache/apisix-ingress-controller/pkg/providers/utils"
-	"k8s.io/client-go/kubernetes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -35,6 +34,7 @@ import (
 	fakeapisix "github.com/apache/apisix-ingress-controller/pkg/kube/apisix/client/clientset/versioned/fake"
 	apisixinformers "github.com/apache/apisix-ingress-controller/pkg/kube/apisix/client/informers/externalversions"
 	"github.com/apache/apisix-ingress-controller/pkg/providers/translation"
+	"github.com/apache/apisix-ingress-controller/pkg/providers/utils"
 	v1 "github.com/apache/apisix-ingress-controller/pkg/types/apisix/v1"
 )
 

--- a/pkg/providers/gateway/translation/gateway_tlsroute.go
+++ b/pkg/providers/gateway/translation/gateway_tlsroute.go
@@ -90,13 +90,13 @@ func (t *translator) TranslateGatewayTLSRouteV1Alpha2(tlsRoute *gatewayv1alpha2.
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to translate Rules[%v].BackendRefs[%v]", i, j))
 			}
-			name := apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
+			ups.Name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
 
 			ups.Labels["meta_namespace"] = utils.TruncateString(ns, 64)
 			ups.Labels["meta_backend"] = utils.TruncateString(string(backend.Name), 64)
 			ups.Labels["meta_port"] = fmt.Sprintf("%v", int32(*backend.Port))
 
-			ups.ID = id.GenID(name)
+			ups.ID = id.GenID(ups.Name)
 			ctx.AddUpstream(ups)
 			ruleUpstreams = append(ruleUpstreams, ups)
 		}

--- a/pkg/providers/gateway/translation/gateway_udproute.go
+++ b/pkg/providers/gateway/translation/gateway_udproute.go
@@ -73,13 +73,15 @@ func (t *translator) TranslateGatewayUDPRouteV1Alpha2(udpRoute *gatewayv1alpha2.
 			sr := apisixv1.NewDefaultStreamRoute()
 			name := apisixv1.ComposeStreamRouteName(ns, udpRoute.Name, fmt.Sprintf("%d-%d", i, j))
 			sr.ID = id.GenID(name)
+
 			ups, err := t.KubeTranslator.TranslateService(ns, string(backend.Name), "", int32(*backend.Port))
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to translate Rules[%v].BackendRefs[%v]", i, j))
 			}
 			ups.Scheme = apisixv1.SchemeUDP
-			name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
-			ups.ID = id.GenID(name)
+			ups.Name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
+			ups.ID = id.GenID(ups.Name)
+
 			sr.UpstreamId = ups.ID
 			ctx.AddStreamRoute(sr)
 			if !ctx.CheckUpstreamExist(ups.Name) {

--- a/pkg/providers/k8s/secret.go
+++ b/pkg/providers/k8s/secret.go
@@ -61,7 +61,7 @@ func newSecretController(common *providertypes.Common, namespaceProvider namespa
 
 		namespaceProvider: namespaceProvider,
 		apisixProvider:    apisixProvider,
-		ingressProvider:   apisixProvider,
+		ingressProvider:   ingressProvider,
 	}
 
 	c.secretInformer.AddEventHandler(


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Bugfix: should set `upstream.Name` since `TranslateContext` use it as the key. Otherwise, the generated upstream will be ignored.

### Pre-submission checklist: 

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
