### PR TITLE
[cherry-pick] fix: Ingress delete events can be handler after svc be deleted (#1576)

### DIFF
--- a/pkg/providers/ingress/ingress.go
+++ b/pkg/providers/ingress/ingress.go
@@ -142,8 +142,13 @@ func (c *ingressController) sync(ctx context.Context, ev *types.Event) error {
 		}
 		ing = ev.Tombstone.(kube.Ingress)
 	}
+	var tctx *translation.TranslateContext
+	if ev.Type == types.EventDelete {
+		tctx, err = c.translator.TranslateIngressDeleteEvent(ing)
+	} else {
+		tctx, err = c.translator.TranslateIngress(ing)
+	}
 
-	tctx, err := c.translator.TranslateIngress(ing)
 	if err != nil {
 		log.Errorw("failed to translate ingress",
 			zap.Error(err),


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] Backport patches

Backport #1576 for v1.6.1