### PR TITLE
[cherry-pick] fix: missing upstream name in gateway-api routes (#1754)

### DIFF
--- a/pkg/providers/gateway/translation/gateway_httproute.go
+++ b/pkg/providers/gateway/translation/gateway_httproute.go
@@ -192,7 +192,7 @@ func (t *translator) TranslateGatewayHTTPRouteV1beta1(httpRoute *gatewayv1beta1.
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to translate Rules[%v].BackendRefs[%v]", i, j))
 			}
-			name := apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
+			ups.Name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
 
 			// APISIX limits max length of label value
 			// https://github.com/apache/apisix/blob/5b95b85faea3094d5e466ee2d39a52f1f805abbb/apisix/schema_def.lua#L85
@@ -200,7 +200,12 @@ func (t *translator) TranslateGatewayHTTPRouteV1beta1(httpRoute *gatewayv1beta1.
 			ups.Labels["meta_backend"] = utils.TruncateString(string(backend.Name), 64)
 			ups.Labels["meta_port"] = fmt.Sprintf("%v", int32(*backend.Port))
 
-			ups.ID = id.GenID(name)
+			ups.ID = id.GenID(ups.Name)
+			log.Debugw("translated HTTPRoute upstream",
+				zap.Int("backendRefs_index", j),
+				zap.String("backendRefs_name", string(backend.Name)),
+				zap.String("name", ups.Name),
+			)
 			ctx.AddUpstream(ups)
 			ruleUpstreams = append(ruleUpstreams, ups)
 

--- a/pkg/providers/gateway/translation/gateway_tlsroute.go
+++ b/pkg/providers/gateway/translation/gateway_tlsroute.go
@@ -90,13 +90,13 @@ func (t *translator) TranslateGatewayTLSRouteV1Alpha2(tlsRoute *gatewayv1alpha2.
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to translate Rules[%v].BackendRefs[%v]", i, j))
 			}
-			name := apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
+			ups.Name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
 
 			ups.Labels["meta_namespace"] = utils.TruncateString(ns, 64)
 			ups.Labels["meta_backend"] = utils.TruncateString(string(backend.Name), 64)
 			ups.Labels["meta_port"] = fmt.Sprintf("%v", int32(*backend.Port))
 
-			ups.ID = id.GenID(name)
+			ups.ID = id.GenID(ups.Name)
 			ctx.AddUpstream(ups)
 			ruleUpstreams = append(ruleUpstreams, ups)
 		}

--- a/pkg/providers/gateway/translation/gateway_udproute.go
+++ b/pkg/providers/gateway/translation/gateway_udproute.go
@@ -73,13 +73,15 @@ func (t *translator) TranslateGatewayUDPRouteV1Alpha2(udpRoute *gatewayv1alpha2.
 			sr := apisixv1.NewDefaultStreamRoute()
 			name := apisixv1.ComposeStreamRouteName(ns, udpRoute.Name, fmt.Sprintf("%d-%d", i, j))
 			sr.ID = id.GenID(name)
+
 			ups, err := t.KubeTranslator.TranslateService(ns, string(backend.Name), "", int32(*backend.Port))
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to translate Rules[%v].BackendRefs[%v]", i, j))
 			}
 			ups.Scheme = apisixv1.SchemeUDP
-			name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
-			ups.ID = id.GenID(name)
+			ups.Name = apisixv1.ComposeUpstreamName(ns, string(backend.Name), "", int32(*backend.Port), types.ResolveGranularity.Endpoint)
+			ups.ID = id.GenID(ups.Name)
+
 			sr.UpstreamId = ups.ID
 			ctx.AddStreamRoute(sr)
 			if !ctx.CheckUpstreamExist(ups.Name) {

--- a/pkg/providers/k8s/secret.go
+++ b/pkg/providers/k8s/secret.go
@@ -61,7 +61,7 @@ func newSecretController(common *providertypes.Common, namespaceProvider namespa
 
 		namespaceProvider: namespaceProvider,
 		apisixProvider:    apisixProvider,
-		ingressProvider:   apisixProvider,
+		ingressProvider:   ingressProvider,
 	}
 
 	c.secretInformer.AddEventHandler(


### PR DESCRIPTION

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] Backport patches

Backport #1754
