### PR TITLE
chore: Make docker compose and docker-compose compatible

### DIFF
--- a/test/e2e/testdata/ldap/cmd.sh
+++ b/test/e2e/testdata/ldap/cmd.sh
@@ -20,17 +20,27 @@
 cd test/e2e/testdata/ldap/
 
 OPTION=$1
+COMPOSE_CMD=""
+
+if command -v "docker-compose" > /dev/null 2>&1; then
+    COMPOSE_CMD="docker-compose"
+elif command -v "docker" > /dev/null 2>&1; then
+    COMPOSE_CMD="docker compose"
+else
+    echo "docker-compose or docker compose not found"
+    exit 1
+fi
 
 if  [ $OPTION = "ip" ]; then
     echo -n `docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' openldap`
 elif [ $OPTION = "start" ]; then
-    docker-compose -f 'docker-compose.yaml'  -p 'openldap' down
+    $COMPOSE_CMD -f 'docker-compose.yaml'  -p 'openldap' down
 
     # start openldap
-    docker-compose -f 'docker-compose.yaml'  -p 'openldap' up -d
+    $COMPOSE_CMD -f 'docker-compose.yaml'  -p 'openldap' up -d
 
 elif [ $OPTION = "stop" ]; then
-    docker-compose -f  'docker-compose.yaml'  -p 'openldap' down
+    $COMPOSE_CMD -f  'docker-compose.yaml'  -p 'openldap' down
 else
     echo "argument is one of [ip, start, stop]"
 fi

--- a/test/e2e/testdata/wolf-rbac/cmd.sh
+++ b/test/e2e/testdata/wolf-rbac/cmd.sh
@@ -20,20 +20,30 @@
 cd test/e2e/testdata/wolf-rbac/
 
 OPTION=$1
+COMPOSE_CMD=""
+
+if command -v "docker-compose" > /dev/null 2>&1; then
+    COMPOSE_CMD="docker-compose"
+elif command -v "docker" > /dev/null 2>&1; then
+    COMPOSE_CMD="docker compose"
+else
+    echo "docker-compose or docker compose not found"
+    exit 1
+fi
 
 if  [ $OPTION = "ip" ]; then
     echo -n `docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' wolf-server`
 elif [ $OPTION = "start" ]; then
-    docker-compose -f 'docker-compose.yaml'  -p 'wolf-rbac' down
+    $COMPOSE_CMD -f 'docker-compose.yaml'  -p 'wolf-rbac' down
     rm -rf db-psql.sql
 
     wget https://raw.githubusercontent.com/iGeeky/wolf/f6ddeb75a37bff90406f0f0a2b7ae5d16f6f3bd4/server/script/db-psql.sql
 
     # start database
-    docker-compose up -d database
+    $COMPOSE_CMD up -d database
 
     # start wolf-server
-    docker-compose up -d server restful-demo agent-or agent-demo
+    $COMPOSE_CMD up -d server restful-demo agent-or agent-demo
 
     sleep 6
 
@@ -68,7 +78,7 @@ elif [ $OPTION = "start" ]; then
         "appIDs": ["test-app"]
     }'
 elif [ $OPTION = "stop" ]; then
-    docker-compose -f 'docker-compose.yaml'  -p 'wolf-rbac' down
+    $COMPOSE_CMD -f 'docker-compose.yaml'  -p 'wolf-rbac' down
     rm -rf db-psql.sql
 else
     echo "argument is one of [ip, start, stop]"


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

This PR makes `docker-compose` and `docker compose` compatible. The source issue(#1201) is this. 
This PR will solve the problem of `docker-compose` not being found when doing the e2e-test locally.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
