### PR TITLE
fix: Referencing empty objects during tcproute and httproute updates

### DIFF
--- a/pkg/providers/gateway/gateway_httproute.go
+++ b/pkg/providers/gateway/gateway_httproute.go
@@ -252,8 +252,9 @@ func (c *gatewayHTTPRouteController) onUpdate(oldObj, newObj interface{}) {
 	)
 
 	c.workqueue.Add(&types.Event{
-		Type:   types.EventUpdate,
-		Object: key,
+		Type:      types.EventUpdate,
+		Object:    key,
+		OldObject: oldHTTPRoute,
 	})
 }
 

--- a/pkg/providers/gateway/gateway_httproute.go
+++ b/pkg/providers/gateway/gateway_httproute.go
@@ -163,22 +163,17 @@ func (c *gatewayHTTPRouteController) sync(ctx context.Context, ev *types.Event) 
 	} else {
 		var oldCtx *translation.TranslateContext
 		oldObj := ev.OldObject.(*gatewayv1beta1.HTTPRoute)
-		oldCtx, err = c.controller.translator.TranslateGatewayHTTPRouteV1beta1(oldObj)
-		if err != nil {
-			log.Errorw("failed to translate old HTTPRoute",
-				zap.String("version", oldObj.APIVersion),
-				zap.String("event_type", "update"),
-				zap.Any("HTTPRoute", oldObj),
-				zap.Error(err),
-			)
-			return err
-		}
+		oldCtx, _ = c.controller.translator.TranslateGatewayHTTPRouteV1beta1(oldObj)
+		if oldCtx != nil {
 
-		om := &utils.Manifest{
-			Routes:    oldCtx.Routes,
-			Upstreams: oldCtx.Upstreams,
+			om := &utils.Manifest{
+				Routes:    oldCtx.Routes,
+				Upstreams: oldCtx.Upstreams,
+			}
+			added, updated, deleted = m.Diff(om)
+		} else {
+			added = m
 		}
-		added, updated, deleted = m.Diff(om)
 	}
 
 	return utils.SyncManifests(ctx, c.controller.APISIX, c.controller.APISIXClusterName, added, updated, deleted, false)

--- a/pkg/providers/gateway/gateway_tcproute.go
+++ b/pkg/providers/gateway/gateway_tcproute.go
@@ -246,8 +246,9 @@ func (c *gatewayTCPRouteController) onUpdate(oldObj, newObj interface{}) {
 		zap.Any("new object", newObj),
 	)
 	c.workqueue.Add(&types.Event{
-		Type:   types.EventUpdate,
-		Object: key,
+		Type:      types.EventUpdate,
+		Object:    key,
+		OldObject: oldTCPRoute,
 	})
 }
 


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

close: #1826 


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
