### PR TITLE
docs: Update issuer.yaml

### DIFF
--- a/docs/en/latest/tutorials/cert-manager/issuer.yaml
+++ b/docs/en/latest/tutorials/cert-manager/issuer.yaml
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer


### PR DESCRIPTION
error: resource mapping not found for name: "ca-issuer" namespace: "" from "issuer.yaml": no matches for kind "Issuer" in version "cert-manager.io/v1alpha2"
ensure CRDs are installed first

https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/