### PR TITLE
chore: split run-e2e-test to separate action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,13 +135,17 @@ lint:
 unit-test:
 	go test -cover -coverprofile=coverage.txt ./...
 
-### e2e-test:             Run e2e test cases (in existing clusters directly)
-.PHONY: e2e-test
-e2e-test: ginkgo-check pack-images e2e-wolf-rbac e2e-ldap install install-gateway-api
+### run-e2e-test          Run e2e test cases only
+.PHONY: run-e2e-test
+run-e2e-test:
 	cd test/e2e \
 		&& go mod download \
 		&& export REGISTRY=$(REGISTRY) \
 		&& APISIX_ADMIN_API_VERSION=$(APISIX_ADMIN_API_VERSION) E2E_ENV=$(E2E_ENV) ACK_GINKGO_RC=true ginkgo -cover -coverprofile=coverage.txt -r --randomize-all --randomize-suites --trace --nodes=$(E2E_NODES) --focus=$(E2E_FOCUS) --flake-attempts=$(E2E_FLAKE_ATTEMPTS)
+
+### e2e-test:             Run e2e test cases (in existing clusters directly)
+.PHONY: e2e-test
+e2e-test: ginkgo-check pack-images e2e-wolf-rbac e2e-ldap install install-gateway-api run-e2e-test
 
 ### e2e-test-local:       Run e2e test cases (kind is required)
 .PHONY: e2e-test-local


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [x] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:
Split run-e2e-test to separate action, so that we can just run e2e test without running other dependencies actions, it will make our testing in the local environment more flexible.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
