### PR TITLE
fix: sync resource after namespace changed

### DIFF
--- a/pkg/providers/apisix/apisix_consumer.go
+++ b/pkg/providers/apisix/apisix_consumer.go
@@ -324,7 +324,7 @@ func (c *apisixConsumerController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("consumer", "delete")
 }
 
-func (c *apisixConsumerController) ResourceSync(interval time.Duration) {
+func (c *apisixConsumerController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixConsumerInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -335,6 +335,9 @@ func (c *apisixConsumerController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && key != namespace {
 			continue
 		}
 		ac, err := kube.NewApisixConsumer(obj)

--- a/pkg/providers/apisix/apisix_global_rule.go
+++ b/pkg/providers/apisix/apisix_global_rule.go
@@ -340,7 +340,7 @@ func (c *apisixGlobalRuleController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("GlobalRule", "delete")
 }
 
-func (c *apisixGlobalRuleController) ResourceSync(interval time.Duration) {
+func (c *apisixGlobalRuleController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixGlobalRuleInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -355,6 +355,9 @@ func (c *apisixGlobalRuleController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && key != namespace {
 			continue
 		}
 		log.Debugw("ResourceSync",

--- a/pkg/providers/apisix/apisix_plugin_config.go
+++ b/pkg/providers/apisix/apisix_plugin_config.go
@@ -392,7 +392,7 @@ func (c *apisixPluginConfigController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("PluginConfig", "delete")
 }
 
-func (c *apisixPluginConfigController) ResourceSync(interval time.Duration) {
+func (c *apisixPluginConfigController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixPluginConfigInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -407,6 +407,9 @@ func (c *apisixPluginConfigController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && key != namespace {
 			continue
 		}
 		log.Debugw("ResourceSync",

--- a/pkg/providers/apisix/apisix_route.go
+++ b/pkg/providers/apisix/apisix_route.go
@@ -615,7 +615,9 @@ func (c *apisixRouteController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("route", "delete")
 }
 
-func (c *apisixRouteController) ResourceSync(interval time.Duration) {
+// ResourceSync syncs ApisixRoute resources within namespace to workqueue.
+// If namespace is "", it syncs all namespaces ApisixRoute resources.
+func (c *apisixRouteController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixRouteInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -635,7 +637,18 @@ func (c *apisixRouteController) ResourceSync(interval time.Duration) {
 			)
 			continue
 		}
+		ns, _, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			log.Errorw("split ApisixRoute meta key failed",
+				zap.Error(err),
+				zap.String("key", key),
+			)
+			continue
+		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && ns != namespace {
 			continue
 		}
 		ar := kube.MustNewApisixRoute(obj)
@@ -659,15 +672,6 @@ func (c *apisixRouteController) ResourceSync(interval time.Duration) {
 				GroupVersion: ar.GroupVersion(),
 			},
 		}, delay*time.Duration(i))
-
-		ns, _, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			log.Errorw("split ApisixRoute meta key failed",
-				zap.Error(err),
-				zap.String("key", key),
-			)
-			continue
-		}
 
 		var (
 			backends  []string

--- a/pkg/providers/apisix/apisix_tls.go
+++ b/pkg/providers/apisix/apisix_tls.go
@@ -405,7 +405,7 @@ func (c *apisixTlsController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("TLS", "delete")
 }
 
-func (c *apisixTlsController) ResourceSync(interval time.Duration) {
+func (c *apisixTlsController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixTlsInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -416,6 +416,9 @@ func (c *apisixTlsController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && key != namespace {
 			continue
 		}
 		tls, err := kube.NewApisixTls(obj)

--- a/pkg/providers/apisix/apisix_upstream.go
+++ b/pkg/providers/apisix/apisix_upstream.go
@@ -617,7 +617,7 @@ func (c *apisixUpstreamController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("upstream", "delete")
 }
 
-func (c *apisixUpstreamController) ResourceSync(interval time.Duration) {
+func (c *apisixUpstreamController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixUpstreamInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 	for i, obj := range objs {
@@ -627,6 +627,9 @@ func (c *apisixUpstreamController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && key != namespace {
 			continue
 		}
 		au, err := kube.NewApisixUpstream(obj)

--- a/pkg/providers/apisix/provider.go
+++ b/pkg/providers/apisix/provider.go
@@ -48,7 +48,7 @@ type Provider interface {
 	providertypes.Provider
 
 	Init(ctx context.Context) error
-	ResourceSync(interval time.Duration)
+	ResourceSync(interval time.Duration, namespace string)
 	NotifyServiceAdd(key string)
 	NotifyApisixUpstreamChange(key string)
 
@@ -135,30 +135,30 @@ func (p *apisixProvider) Run(ctx context.Context) {
 	e.Wait()
 }
 
-func (p *apisixProvider) ResourceSync(interval time.Duration) {
+func (p *apisixProvider) ResourceSync(interval time.Duration, namespace string) {
 	e := utils.ParallelExecutor{}
 
 	e.Add(func() {
-		p.apisixUpstreamController.ResourceSync(interval)
+		p.apisixUpstreamController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
-		p.apisixRouteController.ResourceSync(interval)
+		p.apisixRouteController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
-		p.apisixTlsController.ResourceSync(interval)
+		p.apisixTlsController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
 		p.apisixClusterConfigController.ResourceSync(interval)
 	})
 	e.Add(func() {
-		p.apisixConsumerController.ResourceSync(interval)
+		p.apisixConsumerController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
-		p.apisixPluginConfigController.ResourceSync(interval)
+		p.apisixPluginConfigController.ResourceSync(interval, namespace)
 	})
 	if p.common.Kubernetes.APIVersion == config.ApisixV2 {
 		e.Add(func() {
-			p.apisixGlobalRuleController.ResourceSync(interval)
+			p.apisixGlobalRuleController.ResourceSync(interval, namespace)
 		})
 	}
 

--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -67,6 +67,7 @@ const (
 type Controller struct {
 	name             string
 	namespace        string
+	resourceSyncCh   chan string
 	cfg              *config.Config
 	apisix           apisix.APISIX
 	apiServer        *api.Server
@@ -126,6 +127,7 @@ func NewController(cfg *config.Config) (*Controller, error) {
 	c := &Controller{
 		name:             podName,
 		namespace:        podNamespace,
+		resourceSyncCh:   make(chan string),
 		cfg:              cfg,
 		apiServer:        apiSrv,
 		apisix:           client,
@@ -442,7 +444,7 @@ func (c *Controller) run(ctx context.Context) {
 		Elector:             c.elector,
 	}
 
-	c.namespaceProvider, err = namespace.NewWatchingNamespaceProvider(ctx, c.kubeClient, c.cfg)
+	c.namespaceProvider, err = namespace.NewWatchingNamespaceProvider(ctx, c.kubeClient, c.cfg, c.resourceSyncCh)
 	if err != nil {
 		ctx.Done()
 		return
@@ -606,12 +608,19 @@ func (c *Controller) checkClusterHealth(ctx context.Context, cancelFunc context.
 	}
 }
 
-func (c *Controller) syncAllResources(interval time.Duration) {
+func (c *Controller) receiveResourceSyncEvent(namespace string) {
+	c.resourceSyncCh <- namespace
+}
+
+func (c *Controller) syncResources(interval time.Duration, namespace string) {
 	e := utils.ParallelExecutor{}
 
-	e.Add(c.ingressProvider.ResourceSync)
 	e.Add(func() {
-		c.apisixProvider.ResourceSync(interval)
+		c.ingressProvider.ResourceSync(namespace)
+	})
+
+	e.Add(func() {
+		c.apisixProvider.ResourceSync(interval, namespace)
 	})
 
 	e.Wait()
@@ -633,9 +642,10 @@ func (c *Controller) resourceSyncLoop(ctx context.Context, interval time.Duratio
 	defer ticker.Stop()
 	for {
 		select {
+		case namespace := <-c.resourceSyncCh:
+			c.syncResources(0, namespace)
 		case <-ticker.C:
-			c.syncAllResources(interval)
-			continue
+			c.syncResources(interval, "")
 		case <-ctx.Done():
 			return
 		}

--- a/pkg/providers/ingress/ingress.go
+++ b/pkg/providers/ingress/ingress.go
@@ -457,7 +457,7 @@ func (c *ingressController) isIngressEffective(ing kube.Ingress) bool {
 	return false
 }
 
-func (c *ingressController) ResourceSync() {
+func (c *ingressController) ResourceSync(namespace string) {
 	objs := c.IngressInformer.GetIndexer().List()
 	for _, obj := range objs {
 		key, err := cache.MetaNamespaceKeyFunc(obj)
@@ -466,6 +466,9 @@ func (c *ingressController) ResourceSync() {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		if namespace != "" && key != namespace {
 			continue
 		}
 		ing := kube.MustNewIngress(obj)

--- a/pkg/providers/ingress/provider.go
+++ b/pkg/providers/ingress/provider.go
@@ -46,7 +46,7 @@ var _ Provider = (*ingressProvider)(nil)
 type Provider interface {
 	providertypes.Provider
 
-	ResourceSync()
+	ResourceSync(namespace string)
 
 	SyncSecretChange(ctx context.Context, ev *types.Event, secret *corev1.Secret, secretMapKey string)
 }
@@ -88,10 +88,13 @@ func (p *ingressProvider) Run(ctx context.Context) {
 	e.Wait()
 }
 
-func (p *ingressProvider) ResourceSync() {
+func (p *ingressProvider) ResourceSync(namespace string) {
 	e := utils.ParallelExecutor{}
 
-	e.Add(p.ingressController.ResourceSync)
+	e.Add(
+		func() {
+			p.ingressController.ResourceSync(namespace)
+		})
 
 	e.Wait()
 }

--- a/pkg/providers/k8s/namespace/namespace_provider.go
+++ b/pkg/providers/k8s/namespace/namespace_provider.go
@@ -43,6 +43,7 @@ type WatchingNamespaceProvider interface {
 
 	IsWatchingNamespace(key string) bool
 	WatchingNamespaces() []string
+	//SyncResource(namespace string)
 }
 
 type watchingProvider struct {
@@ -60,7 +61,7 @@ type watchingProvider struct {
 	enableLabelsWatching bool
 }
 
-func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config) (WatchingNamespaceProvider, error) {
+func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config, syncCh chan string) (WatchingNamespaceProvider, error) {
 	c := &watchingProvider{
 		kube: kube,
 		cfg:  cfg,
@@ -89,7 +90,7 @@ func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cf
 	c.namespaceInformer = kubeFactory.Core().V1().Namespaces().Informer()
 	c.namespaceLister = kubeFactory.Core().V1().Namespaces().Lister()
 
-	c.controller = newNamespaceController(c)
+	c.controller = newNamespaceController(c, syncCh)
 
 	return c, nil
 }
@@ -175,4 +176,6 @@ func (c *watchingProvider) IsWatchingNamespace(key string) (ok bool) {
 	}
 	_, ok = c.watchingNamespaces.Load(ns)
 	return
+}
+func (c *watchingProvider) SyncResource() {
 }

--- a/pkg/providers/k8s/namespace/namespace_provider.go
+++ b/pkg/providers/k8s/namespace/namespace_provider.go
@@ -45,6 +45,21 @@ type WatchingNamespaceProvider interface {
 	WatchingNamespaces() []string
 }
 
+type watchingProvider struct {
+	kube *kube.KubeClient
+	cfg  *config.Config
+
+	watchingNamespaces *sync.Map
+	watchingLabels     types.Labels
+
+	namespaceInformer cache.SharedIndexInformer
+	namespaceLister   listerscorev1.NamespaceLister
+
+	controller *namespaceController
+
+	enableLabelsWatching bool
+}
+
 func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config) (WatchingNamespaceProvider, error) {
 	c := &watchingProvider{
 		kube: kube,
@@ -77,21 +92,6 @@ func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cf
 	c.controller = newNamespaceController(c)
 
 	return c, nil
-}
-
-type watchingProvider struct {
-	kube *kube.KubeClient
-	cfg  *config.Config
-
-	watchingNamespaces *sync.Map
-	watchingLabels     types.Labels
-
-	namespaceInformer cache.SharedIndexInformer
-	namespaceLister   listerscorev1.NamespaceLister
-
-	controller *namespaceController
-
-	enableLabelsWatching bool
 }
 
 func (c *watchingProvider) Init(ctx context.Context) error {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:
I deploy apisix with namespace_selector option. If I apply apisixroute in a namespace, and then label with that namespace. It does not work. 

Example:
1. deploy apisix with namespace_selector option
```
kubernetes:
  namespace_selector:
  - apisix=true
```
2. deploy apisixroute
```
kubectl create ns test
kubectl apply -f  -  <<EOF
apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: nginx
  namespace: test
spec:
  http:
  - backends:
    - serviceName: nginx
      servicePort: 80
    match:
      hosts:
      - xx.com
      paths:
      - /*
    name: nginx
EOF
kubectl label ns test apisix=true
```

apisix-ingress-controller does not sync that apisixroute after I label that namespace.
