### PR TITLE
fix: sync resource after namespace changed

### DIFF
--- a/pkg/providers/apisix/apisix_consumer.go
+++ b/pkg/providers/apisix/apisix_consumer.go
@@ -324,7 +324,9 @@ func (c *apisixConsumerController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("consumer", "delete")
 }
 
-func (c *apisixConsumerController) ResourceSync(interval time.Duration) {
+// ResourceSync syncs ApisixConsumer resources within namespace to workqueue.
+// If namespace is "", it syncs all namespaces ApisixConsumer resources.
+func (c *apisixConsumerController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixConsumerInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -335,6 +337,17 @@ func (c *apisixConsumerController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		ns, _, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			log.Errorw("split ApisixRoute meta key failed",
+				zap.Error(err),
+				zap.String("key", key),
+			)
+			continue
+		}
+		if namespace != "" && ns != namespace {
 			continue
 		}
 		ac, err := kube.NewApisixConsumer(obj)

--- a/pkg/providers/apisix/apisix_route.go
+++ b/pkg/providers/apisix/apisix_route.go
@@ -615,7 +615,9 @@ func (c *apisixRouteController) onDelete(obj interface{}) {
 	c.MetricsCollector.IncrEvents("route", "delete")
 }
 
-func (c *apisixRouteController) ResourceSync(interval time.Duration) {
+// ResourceSync syncs ApisixRoute resources within namespace to workqueue.
+// If namespace is "", it syncs all namespaces ApisixRoute resources.
+func (c *apisixRouteController) ResourceSync(interval time.Duration, namespace string) {
 	objs := c.ApisixRouteInformer.GetIndexer().List()
 	delay := GetSyncDelay(interval, len(objs))
 
@@ -636,6 +638,17 @@ func (c *apisixRouteController) ResourceSync(interval time.Duration) {
 			continue
 		}
 		if !c.namespaceProvider.IsWatchingNamespace(key) {
+			continue
+		}
+		ns, _, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			log.Errorw("split ApisixRoute meta key failed",
+				zap.Error(err),
+				zap.String("key", key),
+			)
+			continue
+		}
+		if namespace != "" && ns != namespace {
 			continue
 		}
 		ar := kube.MustNewApisixRoute(obj)
@@ -659,15 +672,6 @@ func (c *apisixRouteController) ResourceSync(interval time.Duration) {
 				GroupVersion: ar.GroupVersion(),
 			},
 		}, delay*time.Duration(i))
-
-		ns, _, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			log.Errorw("split ApisixRoute meta key failed",
-				zap.Error(err),
-				zap.String("key", key),
-			)
-			continue
-		}
 
 		var (
 			backends  []string

--- a/pkg/providers/apisix/provider.go
+++ b/pkg/providers/apisix/provider.go
@@ -48,7 +48,7 @@ type Provider interface {
 	providertypes.Provider
 
 	Init(ctx context.Context) error
-	ResourceSync(interval time.Duration)
+	ResourceSync(interval time.Duration, namespace string)
 	NotifyServiceAdd(key string)
 	NotifyApisixUpstreamChange(key string)
 
@@ -135,30 +135,30 @@ func (p *apisixProvider) Run(ctx context.Context) {
 	e.Wait()
 }
 
-func (p *apisixProvider) ResourceSync(interval time.Duration) {
+func (p *apisixProvider) ResourceSync(interval time.Duration, namespace string) {
 	e := utils.ParallelExecutor{}
 
 	e.Add(func() {
-		p.apisixUpstreamController.ResourceSync(interval)
+		p.apisixUpstreamController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
-		p.apisixRouteController.ResourceSync(interval)
+		p.apisixRouteController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
-		p.apisixTlsController.ResourceSync(interval)
+		p.apisixTlsController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
 		p.apisixClusterConfigController.ResourceSync(interval)
 	})
 	e.Add(func() {
-		p.apisixConsumerController.ResourceSync(interval)
+		p.apisixConsumerController.ResourceSync(interval, namespace)
 	})
 	e.Add(func() {
-		p.apisixPluginConfigController.ResourceSync(interval)
+		p.apisixPluginConfigController.ResourceSync(interval, namespace)
 	})
 	if p.common.Kubernetes.APIVersion == config.ApisixV2 {
 		e.Add(func() {
-			p.apisixGlobalRuleController.ResourceSync(interval)
+			p.apisixGlobalRuleController.ResourceSync(interval, namespace)
 		})
 	}
 

--- a/pkg/providers/ingress/provider.go
+++ b/pkg/providers/ingress/provider.go
@@ -46,7 +46,7 @@ var _ Provider = (*ingressProvider)(nil)
 type Provider interface {
 	providertypes.Provider
 
-	ResourceSync()
+	ResourceSync(namespace string)
 
 	SyncSecretChange(ctx context.Context, ev *types.Event, secret *corev1.Secret, secretMapKey string)
 }
@@ -88,10 +88,13 @@ func (p *ingressProvider) Run(ctx context.Context) {
 	e.Wait()
 }
 
-func (p *ingressProvider) ResourceSync() {
+func (p *ingressProvider) ResourceSync(namespace string) {
 	e := utils.ParallelExecutor{}
 
-	e.Add(p.ingressController.ResourceSync)
+	e.Add(
+		func() {
+			p.ingressController.ResourceSync(namespace)
+		})
 
 	e.Wait()
 }

--- a/pkg/providers/k8s/namespace/namespace_provider.go
+++ b/pkg/providers/k8s/namespace/namespace_provider.go
@@ -60,7 +60,7 @@ type watchingProvider struct {
 	enableLabelsWatching bool
 }
 
-func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config) (WatchingNamespaceProvider, error) {
+func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config, syncCh chan string) (WatchingNamespaceProvider, error) {
 	c := &watchingProvider{
 		kube: kube,
 		cfg:  cfg,
@@ -89,7 +89,7 @@ func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cf
 	c.namespaceInformer = kubeFactory.Core().V1().Namespaces().Informer()
 	c.namespaceLister = kubeFactory.Core().V1().Namespaces().Lister()
 
-	c.controller = newNamespaceController(c)
+	c.controller = newNamespaceController(c, syncCh)
 
 	return c, nil
 }

--- a/pkg/providers/k8s/namespace/namespace_provider.go
+++ b/pkg/providers/k8s/namespace/namespace_provider.go
@@ -45,6 +45,21 @@ type WatchingNamespaceProvider interface {
 	WatchingNamespaces() []string
 }
 
+type watchingProvider struct {
+	kube *kube.KubeClient
+	cfg  *config.Config
+
+	watchingNamespaces *sync.Map
+	watchingLabels     types.Labels
+
+	namespaceInformer cache.SharedIndexInformer
+	namespaceLister   listerscorev1.NamespaceLister
+
+	controller *namespaceController
+
+	enableLabelsWatching bool
+}
+
 func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cfg *config.Config) (WatchingNamespaceProvider, error) {
 	c := &watchingProvider{
 		kube: kube,
@@ -77,21 +92,6 @@ func NewWatchingNamespaceProvider(ctx context.Context, kube *kube.KubeClient, cf
 	c.controller = newNamespaceController(c)
 
 	return c, nil
-}
-
-type watchingProvider struct {
-	kube *kube.KubeClient
-	cfg  *config.Config
-
-	watchingNamespaces *sync.Map
-	watchingLabels     types.Labels
-
-	namespaceInformer cache.SharedIndexInformer
-	namespaceLister   listerscorev1.NamespaceLister
-
-	controller *namespaceController
-
-	enableLabelsWatching bool
 }
 
 func (c *watchingProvider) Init(ctx context.Context) error {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:


- [x ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

I deploy apisix with namespace_selector option. If I apply apisixroute in a namespace, and then label with that namespace. It does not work.

Example:

1. deploy apisix with namespace_selector option
```
kubernetes:
  namespace_selector:
  - apisix=true
 ```

2. deploy apisixroute
```
kubectl create ns test
kubectl apply -f  -  <<EOF
apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: nginx
  namespace: test
spec:
  http:
  - backends:
    - serviceName: nginx
      servicePort: 80
    match:
      hosts:
      - xx.com
      paths:
      - /*
    name: nginx
EOF
kubectl label ns test apisix=true
```
apisix-ingress-controller does not sync that apisixroute after I label that namespace.