### PR TITLE
fix: plugin_metadata not populating to the correct etcd key

### DIFF
--- a/pkg/apisix/plugin_metadata.go
+++ b/pkg/apisix/plugin_metadata.go
@@ -178,7 +178,7 @@ type pluginMetadataMem struct {
 
 func newPluginMetadataMem(c *cluster) PluginMetadata {
 	return &pluginMetadataMem{
-		url:      c.baseURL + "/plugin_metadatas",
+		url:      c.baseURL + "/plugin_metadata",
 		resource: "plugin_metadata",
 		cluster:  c,
 	}

--- a/pkg/apisix/plugin_metadata.go
+++ b/pkg/apisix/plugin_metadata.go
@@ -179,7 +179,7 @@ type pluginMetadataMem struct {
 func newPluginMetadataMem(c *cluster) PluginMetadata {
 	return &pluginMetadataMem{
 		url:      c.baseURL + "/plugin_metadatas",
-		resource: "plugin_metadatas",
+		resource: "plugin_metadata",
 		cluster:  c,
 	}
 }


### PR DESCRIPTION
### Type of change:
- [x] Bugfix

### What this PR does / why we need it:
Fix `plugin_metadata_cm` not working due to populating to wrong etcd key
Before this fix, this can be seen in the debug log
```
2023-10-18T11:31:03+08:00	[35mdebug[0m	apisix/cluster.go:1225	push event to adapter	{"event": "create", "key": "/apisix/plugin_metadatas/datadog", "value": "{\"host\":\"datadog.datadog\",\"namespace\":\"apisix\",\"port\":8125}"}
```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
