### PR TITLE
[cherry-pick] fix: plugin_metadata not populating to the correct etcd key (#2012)

### DIFF
--- a/pkg/apisix/plugin_metadata.go
+++ b/pkg/apisix/plugin_metadata.go
@@ -178,8 +178,8 @@ type pluginMetadataMem struct {
 
 func newPluginMetadataMem(c *cluster) PluginMetadata {
 	return &pluginMetadataMem{
-		url:      c.baseURL + "/plugin_metadatas",
-		resource: "plugin_metadatas",
+		url:      c.baseURL + "/plugin_metadata",
+		resource: "plugin_metadata",
 		cluster:  c,
 	}
 }


### PR DESCRIPTION
Bugfix #2012 port to 1.7

(cherry picked from commit 4d004e1a5a824bc48383e37ef7755b9aafb6aaac)

