### PR TITLE
fix: make regex for hosts consistent with APISIX

### DIFF
--- a/samples/deploy/crd/v1/ApisixRoute.yaml
+++ b/samples/deploy/crd/v1/ApisixRoute.yaml
@@ -110,7 +110,7 @@ spec:
                             minItems: 1
                             items:
                               type: string
-                              pattern: "^\\*?[0-9a-zA-Z-._]+$"
+                              pattern: "^\*?[0-9a-zA-Z-._\[\]:]+$"
                           methods:
                             type: array
                             minItems: 1


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:
Fixes #2064 
Currently there is a mismatch between the regex that APISIX allowed[1] and what ApisixRoute CRD allowed. This PR makes sure that both are consistent.
More specifically - Both `1.2.3.4` and `1.2.3.4:443` should be considered valid `hosts` field

1. https://github.com/apache/apisix-ingress-controller/blob/ea6fbc95d774d9517aded455b59ce238c06c1edf/conf/apisix-schema.json#L961 
<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
