### PR TITLE
chore: add reference nix package and flake

### DIFF
--- a/apisix-ingress-controller.nix
+++ b/apisix-ingress-controller.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+  buildGoModule rec {
+    pname = "apisix-ingress-controller";
+    version = "1.7.1";
+    rev = "ceefeb1e2547100679556a1763d9820ec04f6381";
+
+    src = fetchFromGitHub {
+      owner = "apache";
+      repo = "apisix-ingress-controller";
+      rev = "${version}";
+      hash = "sha256-C77ps1rVVGGRLnQdfNdyWISL5iWtLPKAiTfY2EYMmjM=";
+    };
+
+    subPackages = ["."];
+
+    ldflags = [
+      "-X github.com/apache/apisix-ingress-controller/pkg/version._buildVersion=${version}"
+      "-X github.com/apache/apisix-ingress-controller/pkg/version._buildGitRevision=${rev}"
+      "-X github.com/apache/apisix-ingress-controller/pkg/version._buildOS=unknown"
+    ];
+
+    vendorHash = "sha256-kyU8izqI9kweiXsDxlEfZTiWKODnaccq1xC5nV06+/c=";
+
+    CGO_ENABLED = 0;
+
+    meta = with lib; {
+      description = " APISIX Ingress Controller for Kubernetes";
+      homepage = "https://github.com/apache/apisix-ingress-controller";
+      license = licenses.asl20;
+    };
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "APISIX ingress controller";
+
+  inputs = {};
+  
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.default = let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+    in
+      pkgs.callPackage ./apisix-ingress-controller.nix {};
+  };
+}


### PR DESCRIPTION
### Type of change:

- [x] CI/CD or Tests

### What this PR does / why we need it:

Allows for use in the Nix/NixOS ecosystem, for instance when building a custom [container image](https://nix.dev/tutorials/nixos/building-and-running-docker-images.html).

### Remarks

I left "build OS" set to unknown, since this piece of information is not easily exposed and should be irrelevant.

### Updating

I'm happy to keep this in sync with current versions, but the process for updating the package is as follows:

1. Update "version" and "rev".
2. Set `hash` and `vendorHash` to `lib.fakeSha256`
3. `nix build`
4. Grab the hashes from error messages and place them where appropriate until the build succeeds.
