### PR TITLE
refactor(cmd/ingress): invert signal ctx logic

### DIFF
--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -50,6 +50,7 @@ func contextWithSignalCancel(ctx context.Context, signals ...os.Signal) context.
 
 		sig := <-sigCh
 		log.Infof("signal %d (%s) received", sig, sig.String())
+		signal.Stop(sigCh)
 		close(sigCh)
 		cancel()
 	}()

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -43,7 +43,7 @@ func dief(template string, args ...interface{}) {
 }
 
 func contextWithSignalCancel(ctx context.Context, signals ...os.Signal) context.Context {
-	newCtx, cancel := context.WithCancel(context.Background())
+	newCtx, cancel := context.WithCancel(ctx)
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, signals...)

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -15,12 +15,12 @@
 package ingress
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -42,13 +42,18 @@ func dief(template string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func waitForSignal(stopCh chan struct{}) {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+func contextWithSignalCancel(ctx context.Context, signals ...os.Signal) context.Context {
+	newCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, signals...)
 
-	sig := <-sigCh
-	log.Infof("signal %d (%s) received", sig, sig.String())
-	close(stopCh)
+		sig := <-sigCh
+		log.Infof("signal %d (%s) received", sig, sig.String())
+		close(sigCh)
+		cancel()
+	}()
+	return newCtx
 }
 
 // NewIngressCommand creates the ingress sub command for apisix-ingress-controller.
@@ -118,8 +123,8 @@ the apisix cluster and others are created`,
 				dief("failed to initialize logging: %s", err)
 			}
 			log.DefaultLogger = logger
-			log.Info("init apisix ingress controller")
 
+			log.Info("init apisix ingress controller")
 			log.Info("version:\n", version.Long())
 
 			// We should make sure that the cfg that's logged out is sanitized.
@@ -132,25 +137,17 @@ the apisix cluster and others are created`,
 			}
 			log.Info("use configuration\n", string(data))
 
-			stop := make(chan struct{})
+			ctx := contextWithSignalCancel(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+
 			ingress, err := controller.NewController(cfg)
 			if err != nil {
 				dief("failed to create ingress controller: %s", err)
 			}
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
 
-				log.Info("start ingress controller")
+			if err := ingress.Run(ctx); err != nil {
+				dief("failed to run ingress controller: %s", err)
+			}
 
-				if err := ingress.Run(stop); err != nil {
-					dief("failed to run ingress controller: %s", err)
-				}
-			}()
-
-			waitForSignal(stop)
-			wg.Wait()
 			log.Info("apisix ingress controller exited")
 		},
 	}

--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -144,13 +144,10 @@ func (c *Controller) Eventf(_ runtime.Object, eventType string, reason string, m
 }
 
 // Run launches the controller.
-func (c *Controller) Run(stop chan struct{}) error {
-	rootCtx, rootCancel := context.WithCancel(context.Background())
+func (c *Controller) Run(ctx context.Context) error {
+	rootCtx, rootCancel := context.WithCancel(ctx)
 	defer rootCancel()
-	go func() {
-		<-stop
-		rootCancel()
-	}()
+
 	c.MetricsCollector.ResetLeader(false)
 
 	go func() {


### PR DESCRIPTION
### Type of change:

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [x] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

(verbatin commit message)

this commit changes the signal handling in cmd/ingress to be wrapped in a context, and inverts which goroutine runs the controller and which watches for the context to be cancelled, which allows some scaffolding (`sync.WaitGroup`) to be removed and now properly handles the controller exiting with `nil` (as it does when leader election fails)
