### PR TITLE
fix: remove path validation

### DIFF
--- a/samples/deploy/crd/v1/ApisixRoute.yaml
+++ b/samples/deploy/crd/v1/ApisixRoute.yaml
@@ -104,7 +104,6 @@ spec:
                             minItems: 1
                             items:
                               type: string
-                              pattern: "^/[a-zA-Z0-9\\-._~%!$&'()+,;=:@/]*\\*?$"
                           hosts:
                             type: array
                             minItems: 1


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:
Fixes https://github.com/apache/apisix-ingress-controller/issues/1927

APISIX does not have this URI validation and allows for paths like `/abc/*/abc` whereas the schema validation in K8s CR makes rules where `*` cannot be added in the middle. This PR removes the `pattern` field to remove route string validation at this level and let APISIX handle it.

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
