### PR TITLE
test: failing flaky unit test

### DIFF
--- a/pkg/types/labels_test.go
+++ b/pkg/types/labels_test.go
@@ -61,5 +61,5 @@ func TestBuildQuery(t *testing.T) {
 		"a": []string{"a1", "a2"},
 		"b": []string{"b1", "b2"},
 	}
-	assert.Equal(t, []string{"a in (a1,a2)", "b in (b1,b2)"}, l.BuildQuery())
+	assert.Subset(t, l.BuildQuery(), []string{"a in (a1,a2)", "b in (b1,b2)"})
 }

--- a/pkg/types/labels_test.go
+++ b/pkg/types/labels_test.go
@@ -61,5 +61,5 @@ func TestBuildQuery(t *testing.T) {
 		"a": []string{"a1", "a2"},
 		"b": []string{"b1", "b2"},
 	}
-	assert.Subset(t, l.BuildQuery(), []string{"a in (a1,a2)", "b in (b1,b2)"})
+	assert.ElementsMatch(t, l.BuildQuery(), []string{"a in (a1,a2)", "b in (b1,b2)"})
 }

--- a/samples/deploy/crd/v1/ApisixRoute.yaml
+++ b/samples/deploy/crd/v1/ApisixRoute.yaml
@@ -104,7 +104,6 @@ spec:
                             minItems: 1
                             items:
                               type: string
-                              pattern: "^/[a-zA-Z0-9\\-._~%!$&'()+,;=:@/]*\\*?$"
                           hosts:
                             type: array
                             minItems: 1


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:
the test relied on wrong type of array assertions which assumed consistent order preservation. this commit uses assert.Subset instead
Example of failure https://github.com/apache/apisix-ingress-controller/actions/runs/7725975728/job/21061338039?pr=2148
<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
