### PR TITLE
refactor: simplify leader election

### DIFF
--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -213,7 +213,7 @@ func (c *Controller) Run(ctx context.Context) error {
 					zap.String("pod", c.name),
 				)
 				// rootCancel might be to slow, and controllers may have bugs that cause them to not yield
-				// the safest way to step down is to simply cause a pod restart, making
+				// the safest way to step down is to simply cause a pod restart
 				os.Exit(0)
 			},
 		},
@@ -226,7 +226,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	if leaderElectionConfig.WatchDog != nil {
 		leaderElectionConfig.WatchDog.SetLeaderElection(leaderElector)
 	}
-	// todo: this should never be neccessary
+	// todo: this should never be necessary if only one controller runs
 	c.elector = leaderElector
 
 	leaderElector.Run(rootCtx)

--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -408,12 +408,12 @@ func (c *Controller) run(ctx context.Context) error {
 
 	c.namespaceProvider, err = namespace.NewWatchingNamespaceProvider(ctx, c.kubeClient, c.cfg, c.resourceSyncCh)
 	if err != nil {
-		return
+		return err
 	}
 
 	c.podProvider, err = pod.NewProvider(common, c.namespaceProvider)
 	if err != nil {
-		return
+		return err
 	}
 
 	c.translator = translation.NewTranslator(&translation.TranslatorOptions{


### PR DESCRIPTION
mostly based on the upstream example:
https://github.com/kubernetes/client-go/blob/master/examples/leader-election/main.go

this also incidentally fixes bugs where `run` returns nil (i.e. when failing to reach the Admin API) by causing the context to cancel via defer.

- [x] Bugfix
- [x] Refactor

