### PR TITLE
fix: use force=true to hard delete the apisix resource

### DIFF
--- a/pkg/apisix/cluster.go
+++ b/pkg/apisix/cluster.go
@@ -849,6 +849,7 @@ func (c *cluster) updateResource(ctx context.Context, url, resource string, body
 }
 
 func (c *cluster) deleteResource(ctx context.Context, url, resource string) error {
+	url = url + "?force=true"
 	log.Debugw("deleting resource in cluster",
 		zap.String("cluster_name", c.name),
 		zap.String("name", resource),


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:
Because apisix uses local cache for reference checking, deleting may fail due to slow cache synchronization. Apisix has already provided a parameter（force） in the deletion of API to address this issue. Ingress controllers should use this parameter to delete resources and avoid resource leakage.
<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
