### PR TITLE
fix: deletion of references

### DIFF
--- a/pkg/apisix/cache/cache.go
+++ b/pkg/apisix/cache/cache.go
@@ -97,5 +97,7 @@ type Cache interface {
 	// DeletePluginConfig deletes the specified plugin_config in cache.
 	DeletePluginConfig(*v1.PluginConfig) error
 
+	CheckUpstreamReference(*v1.Upstream) error
+	CheckPluginConfigReference(*v1.PluginConfig) error
 	DeleteUpstreamServiceRelation(*v1.UpstreamServiceRelation) error
 }

--- a/pkg/apisix/cache/memdb.go
+++ b/pkg/apisix/cache/memdb.go
@@ -311,7 +311,7 @@ func (c *dbCache) DeleteSSL(ssl *v1.Ssl) error {
 }
 
 func (c *dbCache) DeleteUpstream(u *v1.Upstream) error {
-	if err := c.checkUpstreamReference(u); err != nil {
+	if err := c.CheckUpstreamReference(u); err != nil {
 		return err
 	}
 	return c.delete("upstream", u)
@@ -334,7 +334,7 @@ func (c *dbCache) DeleteSchema(schema *v1.Schema) error {
 }
 
 func (c *dbCache) DeletePluginConfig(pc *v1.PluginConfig) error {
-	if err := c.checkPluginConfigReference(pc); err != nil {
+	if err := c.CheckPluginConfigReference(pc); err != nil {
 		return err
 	}
 	return c.delete("plugin_config", pc)
@@ -357,7 +357,7 @@ func (c *dbCache) delete(table string, obj interface{}) error {
 	return nil
 }
 
-func (c *dbCache) checkUpstreamReference(u *v1.Upstream) error {
+func (c *dbCache) CheckUpstreamReference(u *v1.Upstream) error {
 	// Upstream is referenced by Route.
 	txn := c.db.Txn(false)
 	defer txn.Abort()
@@ -379,7 +379,7 @@ func (c *dbCache) checkUpstreamReference(u *v1.Upstream) error {
 	return nil
 }
 
-func (c *dbCache) checkPluginConfigReference(u *v1.PluginConfig) error {
+func (c *dbCache) CheckPluginConfigReference(u *v1.PluginConfig) error {
 	// PluginConfig is referenced by Route.
 	txn := c.db.Txn(false)
 	defer txn.Abort()

--- a/pkg/apisix/cache/noop_db.go
+++ b/pkg/apisix/cache/noop_db.go
@@ -172,3 +172,11 @@ func (c *noopCache) DeletePluginConfig(pc *v1.PluginConfig) error {
 func (c *noopCache) DeleteUpstreamServiceRelation(us *v1.UpstreamServiceRelation) error {
 	return nil
 }
+
+func (c *noopCache) CheckUpstreamReference(u *v1.Upstream) error {
+	return nil
+}
+
+func (c *noopCache) CheckPluginConfigReference(pc *v1.PluginConfig) error {
+	return nil
+}

--- a/pkg/apisix/nonexistentclient.go
+++ b/pkg/apisix/nonexistentclient.go
@@ -400,3 +400,5 @@ func (c *dummyCache) DeleteConsumer(_ *v1.Consumer) error                       
 func (c *dummyCache) DeleteSchema(_ *v1.Schema) error                                   { return nil }
 func (c *dummyCache) DeletePluginConfig(_ *v1.PluginConfig) error                       { return nil }
 func (c *dummyCache) DeleteUpstreamServiceRelation(_ *v1.UpstreamServiceRelation) error { return nil }
+func (c *dummyCache) CheckUpstreamReference(_ *v1.Upstream) error                       { return nil }
+func (c *dummyCache) CheckPluginConfigReference(_ *v1.PluginConfig) error               { return nil }

--- a/pkg/apisix/pluginconfig.go
+++ b/pkg/apisix/pluginconfig.go
@@ -162,7 +162,11 @@ func (pc *pluginConfigClient) Delete(ctx context.Context, obj *v1.PluginConfig) 
 		zap.String("cluster", pc.cluster.name),
 		zap.String("url", pc.url),
 	)
-
+	err := pc.cluster.cache.CheckPluginConfigReference(obj)
+	if err != nil {
+		log.Warnw("deletion for plugin config: " + obj.Name + " aborted as it is still in use.")
+		return err
+	}
 	if err := pc.cluster.HasSynced(ctx); err != nil {
 		return err
 	}

--- a/pkg/apisix/upstream.go
+++ b/pkg/apisix/upstream.go
@@ -158,7 +158,11 @@ func (u *upstreamClient) Delete(ctx context.Context, obj *v1.Upstream) error {
 		zap.String("cluster", u.cluster.name),
 		zap.String("url", u.url),
 	)
-
+	err := u.cluster.cache.CheckUpstreamReference(obj)
+	if err != nil {
+		log.Warnw("deletion for upstream: " + obj.Name + " aborted as it is still in use.")
+		return err
+	}
 	if err := u.cluster.HasSynced(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
After adding the force=true flag in requests to apisix, we cant rely on apisix reference counting to not delete resources and will have to check it at ingress level before sending request to apisix.

<!-- Please answer these questions before submitting a pull request -->
![Screenshot 2024-04-15 at 3 21 32 PM](https://github.com/apache/apisix-ingress-controller/assets/43276904/7f295107-510c-4a0e-82c7-bebababcd91f)
## How to test
1. Create a route1 referencing a service
2. Check that an upstream is created in APISIX.
3. Create another route, route2 referencing the same service.
4. Delete route1.
5. Check APISIX to see that the upstream is not deleted.
6. Delete route2
7. Upstream is deleted.
### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
8. Test is required for the feat/fix PR, unless you have a good reason
9. Doc is required for the feat PR
10. Use a new commit to resolve review instead of `push -f`
11. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
