### PR TITLE
fix(leader-election): exit after Leader status is lost

### DIFF
--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -231,6 +231,9 @@ func (c *Controller) setupLeaderElection() error {
 					zap.String("namespace", c.namespace),
 					zap.String("pod", c.name),
 				)
+				// rootCancel might be to slow, and controllers may have bugs that cause them to not yield
+				// the safest way to step down is to simply cause a pod restart
+				os.Exit(0)
 			},
 		},
 		ReleaseOnCancel: true,

--- a/pkg/providers/controller.go
+++ b/pkg/providers/controller.go
@@ -185,6 +185,9 @@ func (c *Controller) Run(ctx context.Context) error {
 
 	c.run(rootCtx)
 
+	// c.run should never be returning when there's no error or the context is cancelled
+	rootCancel()
+
 	wg.Wait()
 	return nil
 }


### PR DESCRIPTION
This PR is a subset of @acuteaura's PR #2152
The current problem (v1.8.2) is that whenever a controller loses it's `leader` status, it does not exit gracefully, thus it fails silently. In order to prevent this, an `os.exit` has been implemented to shut itself down, and depend on Kubernetes to bring it back up.

### Type of change:
- [x] Bugfix

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
ingress-controller doesn't recover from failed sync
#1980

### Pre-submission checklist:


- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
