### PR TITLE
Update gke.md

### DIFF
--- a/docs/en/latest/deployments/gke.md
+++ b/docs/en/latest/deployments/gke.md
@@ -114,11 +114,11 @@ It is recommended to change the default keys for security:
 ```
 
 ```shell
---set admin.credentials.admin=ADMIN_KEY_GENERATED_BY_YOURSELF
+--set apisix.admin.credentials.admin=ADMIN_KEY_GENERATED_BY_YOURSELF
 ```
 
 ```shell
---set admin.credentials.viewer=VIEWER_KEY_GENERATED_BY_YOURSELF
+--set apisix.admin.credentials.viewer=VIEWER_KEY_GENERATED_BY_YOURSELF
 ```
 
 :::note


### PR DESCRIPTION
Missing apisix key for set variable

### Type of change:
- [x] Documentation


### What this PR does / why we need it:

Fixing missing keyword on apisix GKE documentation.
