### PR TITLE
chore: upgrade actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/e2e-test-ci-v2-cron-dev.yml
+++ b/.github/workflows/e2e-test-ci-v2-cron-dev.yml
@@ -120,7 +120,7 @@ jobs:
             | pigz > docker-dev.tar.gz
 
       - name: cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-dev.tar.gz
           path: docker-dev.tar.gz
@@ -173,7 +173,7 @@ jobs:
           sudo cp ~/go/bin/ginkgo /usr/local/bin
 
       - name: cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-dev.tar.gz
 

--- a/.github/workflows/e2e-test-ci-v2-cron.yml
+++ b/.github/workflows/e2e-test-ci-v2-cron.yml
@@ -119,7 +119,7 @@ jobs:
             | pigz > docker-v2.tar.gz
 
       - name: cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-v2.tar.gz
           path: docker-v2.tar.gz
@@ -172,7 +172,7 @@ jobs:
           sudo cp ~/go/bin/ginkgo /usr/local/bin
 
       - name: cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-v2.tar.gz
 

--- a/.github/workflows/e2e-test-ci.yml
+++ b/.github/workflows/e2e-test-ci.yml
@@ -120,7 +120,7 @@ jobs:
             | pigz > docker.tar.gz
 
       - name: cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker.tar.gz
           path: docker.tar.gz
@@ -175,7 +175,7 @@ jobs:
           sudo cp ~/go/bin/ginkgo /usr/local/bin
 
       - name: cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker.tar.gz
 

--- a/.github/workflows/k8s-timer-ci.yml
+++ b/.github/workflows/k8s-timer-ci.yml
@@ -109,7 +109,7 @@ jobs:
             | pigz > docker.tar.gz
 
       - name: cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker.tar.gz
           path: docker.tar.gz
@@ -157,7 +157,7 @@ jobs:
           sudo cp ~/go/bin/ginkgo /usr/local/bin
 
       - name: cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker.tar.gz
 


### PR DESCRIPTION

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
