### PR TITLE
fix: forget should be changed to addratelimited

### DIFF
--- a/pkg/providers/apisix/apisix_plugin_config.go
+++ b/pkg/providers/apisix/apisix_plugin_config.go
@@ -284,7 +284,7 @@ func (c *apisixPluginConfigController) handleSyncErr(obj interface{}, errOrigin 
 		zap.Any("object", obj),
 		zap.Error(errOrigin),
 	)
-	c.workqueue.Forget(obj)
+	c.workqueue.AddRateLimited(obj)
 	c.MetricsCollector.IncrSyncOperation("PluginConfig", "failure")
 }
 


### PR DESCRIPTION
### Type of change:

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

> I am new to programming and not familiar with golang and apisix-ingress-controller, so I am just trying to fix the bugs in the code as per the changes mentioned in the https://github.com/apache/apisix-ingress-controller/issues/2348.

The previous line of log code mentions the need for `retry`, but the next line of code `c.workqueue.forget(obj)` performs a `forget` operation, which as mentioned in the issue should be changed to `addratelimited`. 
<br>

Regarding the test case, since I'm not familiar with golang and apisix-ingress-controller, I can only offer a bit of a beginner's idea: 
When the function parameter `errorigin` is null, 
* `c.workqueue.forget` will be called;
* `"pluginconfig" "success"` in `MetricsCollector` corresponding tag count + 1.

When `errorigin` is not found in `k8serror` and `types.event` is not equal to `eventdelete` ,
* log mentions `ignore` ;
* `c.workqueue.forget` will be called.
 
When other cases are encountered, 
* record the log and the log should mention that `retry` ;
* `c.workqueue.addratelimited` should be called;
* `"pluginconfig" "failure"` in `MetricsCollector` corresponding tag count + 1.
 <br>
Is there a better bug fix? Maybe we can try: <br>
1. record the number of times adding an item to the workqueue, when the number of times reaches a certain threshold, give up the retry, and trigger the alarm mechanism; <br>
2. introduce a fallback mechanism, gradually increase the retry interval, to avoid frequent failures bring too much load.
<br><br>
Closely linked to issue https://github.com/apache/apisix-ingress-controller/issues/2348.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
4. Doc is required for the feat PR
5. Use a new commit to resolve review instead of `push -f`
6. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
