### PR TITLE
fix: namespace controller memory leak

### DIFF
--- a/pkg/providers/k8s/namespace/namespace.go
+++ b/pkg/providers/k8s/namespace/namespace.go
@@ -68,6 +68,8 @@ func (c *namespaceController) run(ctx context.Context) {
 	}
 	log.Info("namespace controller started")
 	defer log.Info("namespace controller exited")
+	defer c.workqueue.ShutDown()
+
 	for i := 0; i < c.workers; i++ {
 		go c.runWorker(ctx)
 	}


### PR DESCRIPTION
### Type of change:


- [ ] Bugfix


### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

namespaceController.runWorker()  does not quit while leader election was changed

![image](https://github.com/user-attachments/assets/e16d5060-6e90-4fba-89db-c6241b3fc307)



### Pre-submission checklist:


