### PR TITLE
fix: the sync_period of the provider should not be 0s

### DIFF
--- a/.github/workflows/apisix-conformance-test.yml
+++ b/.github/workflows/apisix-conformance-test.yml
@@ -108,7 +108,6 @@ jobs:
       - name: Get Logs from apisix-ingress-controller
         shell: bash
         run: |
-          export KUBECONFIG=/tmp/apisix-ingress-cluster.kubeconfig
           kubectl logs -n apisix-conformance-test -l app=apisix-ingress-controller
 
       - name: Upload Gateway API Conformance Report

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ CRD_REF_DOCS_VERSION ?= v0.1.0
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 CRD_DOCS_CONFIG ?= docs/crd/config.yaml
 CRD_DOCS_OUTPUT ?= docs/crd/api.md
-# 
+
 # go 
 VERSYM="github.com/apache/apisix-ingress-controller/internal/version._buildVersion"
 GITSHASYM="github.com/apache/apisix-ingress-controller/internal/version._buildGitRevision"

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,7 @@ CRD_REF_DOCS_VERSION ?= v0.1.0
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 CRD_DOCS_CONFIG ?= docs/crd/config.yaml
 CRD_DOCS_OUTPUT ?= docs/crd/api.md
-
-export KUBECONFIG = /tmp/$(KIND_NAME).kubeconfig
-
+# 
 # go 
 VERSYM="github.com/apache/apisix-ingress-controller/internal/version._buildVersion"
 GITSHASYM="github.com/apache/apisix-ingress-controller/internal/version._buildGitRevision"
@@ -126,7 +124,6 @@ kind-e2e-test: kind-up build-image kind-load-images e2e-test
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: e2e-test
 e2e-test:
-	@kind get kubeconfig --name $(KIND_NAME) > $$KUBECONFIG
 	go test $(TEST_DIR) -test.timeout=$(TEST_TIMEOUT) -v -ginkgo.v -ginkgo.focus="$(TEST_FOCUS)" -ginkgo.label-filter="$(TEST_LABEL)"
 
 .PHONY: conformance-test
@@ -135,7 +132,6 @@ conformance-test:
 
 .PHONY: conformance-test-standalone
 conformance-test-standalone:
-	@kind get kubeconfig --name $(KIND_NAME) > $$KUBECONFIG
 	go test -v ./test/conformance/apisix -tags=conformance -timeout 60m
 
 .PHONY: lint
@@ -151,7 +147,6 @@ kind-up:
 	@kind get clusters 2>&1 | grep -v $(KIND_NAME) \
 		&& kind create cluster --name $(KIND_NAME) \
 		|| echo "kind cluster already exists"
-	@kind get kubeconfig --name $(KIND_NAME) > $$KUBECONFIG
 	kubectl wait --for=condition=Ready nodes --all
 
 .PHONY: kind-down
@@ -432,6 +427,7 @@ release-src:
 	--exclude .DS_Store \
 	--exclude docs \
 	--exclude examples \
+	--exclude scripts \
 	--exclude samples \
 	--exclude test \
 	--exclude release \

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -34,9 +34,9 @@ exec_adc_timeout: 15s                   # The timeout for the ADC to execute.
 provider:
   type: "apisix"
 
-  sync_period: 0s
+  sync_period: 1s
                                         # The period between two consecutive syncs.
-                                        # The default value is 0 seconds, which means the controller will not sync.
+                                        # The default value is 1 seconds, which means the controller will not sync.
                                         # If you want to enable the sync, set it to a positive value.
   init_sync_delay: 20m                # The initial delay before the first sync, only used when the controller is started.
                                         # The default value is 20 minutes.

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -52,7 +52,7 @@ func NewDefaultConfig() *Config {
 		ExecADCTimeout:   types.TimeDuration{Duration: 15 * time.Second},
 		ProviderConfig: ProviderConfig{
 			Type:          ProviderTypeAPISIX,
-			SyncPeriod:    types.TimeDuration{Duration: 0},
+			SyncPeriod:    types.TimeDuration{Duration: 1 * time.Second},
 			InitSyncDelay: types.TimeDuration{Duration: 20 * time.Minute},
 		},
 	}


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->



### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

failed to run:

```shell
$ ./bin/apisix-ingress-controller_amd64
Error: sync_period must be greater than 0 for standalone provider
Usage:
  apisix-ingress-controller [command] [flags]
  apisix-ingress-controller [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  version     version for apisix-ingress-controller
```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
