### PR TITLE
fix: config not provided should not be retried

### DIFF
--- a/internal/provider/adc/adc.go
+++ b/internal/provider/adc/adc.go
@@ -341,8 +341,8 @@ func (d *adcClient) sync(ctx context.Context, task Task) error {
 	log.Debugw("syncing resources", zap.Any("task", task))
 
 	if len(task.configs) == 0 {
-		log.Errorw("no adc configs provided", zap.Any("task", task))
-		return errors.New("no adc configs provided")
+		log.Warnw("no adc configs provided", zap.Any("task", task))
+		return nil
 	}
 
 	syncFilePath, cleanup, err := prepareSyncFile(task.Resources)


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

```txt
2025-07-04T06:25:04Z        [31merror[0m        adc/adc.go:344        no adc configs provided        {"task": {"Name":"apisix","Resources":{},"Labels":null,"ResourceTypes":null}}
2025-07-04T06:25:04.168Z        ERROR        controller-runtime        controller/controller.go:316        Reconciler error        {"controller": "gateway", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "Gateway", "Gateway": {"name":"apisix","namespace":"api7-ee-e2e"}, "namespace": "api7-ee-e2e", "name": "apisix", "reconcileID": "e924b63b-25b9-46bb-925c-3131cd8726b6", "error": "no adc configs provided", "errorVerbose": "no adc configs provided\ngithub.com/apache/apisix-ingress-controller/internal/provider/adc.(*adcClient).sync\n\t/home/runner/work/apisix-ingress-controller/apisix-ingress-controller/internal/provider/adc/adc.go:345\ngithub.com/apache/apisix-ingress-controller/internal/provider/adc.(*adcClient).Delete\n\t/home/runner/work/apisix-ingress-controller/apisix-ingress-controller/internal/provider/adc/adc.go:264\ngithub.com/apache/apisix-ingress-controller/internal/controller.(*GatewayReconciler).Reconcile\n\t/home/runner/work/apisix-ingress-controller/apisix-ingress-controller/internal/controller/gateway_controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224\nruntime.goexit\n\t/opt/hostedtoolcache/go/1.23.10/x64/src/runtime/asm_amd64.s:1700"}
```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
