### PR TITLE
fix: WaitControllerManagerLog dose not work in test framework

### DIFF
--- a/internal/controller/apisixroute_controller.go
+++ b/internal/controller/apisixroute_controller.go
@@ -607,14 +607,14 @@ func (r *ApisixRouteReconciler) filterEndpointSlicesBySubsetLabels(ctx context.C
 		in[i] = r.filterEndpointSliceByTargetPod(ctx, in[i], labels)
 	}
 
-	return utils.Filter(in, func(v discoveryv1.EndpointSlice) bool {
+	return pkgutils.Filter(in, func(v discoveryv1.EndpointSlice) bool {
 		return len(v.Endpoints) > 0
 	})
 }
 
 // filterEndpointSliceByTargetPod filters item.Endpoints which is not a subset of labels
 func (r *ApisixRouteReconciler) filterEndpointSliceByTargetPod(ctx context.Context, item discoveryv1.EndpointSlice, labels map[string]string) discoveryv1.EndpointSlice {
-	item.Endpoints = utils.Filter(item.Endpoints, func(v discoveryv1.Endpoint) bool {
+	item.Endpoints = pkgutils.Filter(item.Endpoints, func(v discoveryv1.Endpoint) bool {
 		if v.TargetRef == nil || v.TargetRef.Kind != KindPod {
 			return true
 		}

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -174,13 +174,14 @@ func Run(ctx context.Context, logger logr.Logger) error {
 
 	go func() {
 		setupLog.Info("starting provider sync")
-		initalSyncDelay := config.ControllerConfig.ProviderConfig.InitSyncDelay.Duration
-		time.AfterFunc(initalSyncDelay, func() {
+		initialSyncDelay := config.ControllerConfig.ProviderConfig.InitSyncDelay.Duration
+		time.AfterFunc(initialSyncDelay, func() {
 			setupLog.Info("trying to initialize provider")
 			if err := provider.Sync(ctx); err != nil {
 				setupLog.Error(err, "unable to sync resources to provider")
 				return
 			}
+			setupLog.Info("All cache synced successfully")
 		})
 
 		syncPeriod := config.ControllerConfig.ProviderConfig.SyncPeriod.Duration

--- a/internal/utils/k8s.go
+++ b/internal/utils/k8s.go
@@ -66,19 +66,6 @@ func MatchHostDef(host string) bool {
 	return hostDefRegex.MatchString(host)
 }
 
-func AppendFunc[T any](s []T, keep func(v T) bool, values ...T) []T {
-	for _, v := range values {
-		if keep(v) {
-			s = append(s, v)
-		}
-	}
-	return s
-}
-
-func Filter[T any](s []T, keep func(v T) bool) []T {
-	return AppendFunc(make([]T, 0), keep, s...)
-}
-
 func IsSubsetOf(a, b map[string]string) bool {
 	if len(a) == 0 {
 		// Empty labels matches everything.

--- a/pkg/utils/datastructure.go
+++ b/pkg/utils/datastructure.go
@@ -58,3 +58,16 @@ func DedupComparable[T comparable](s []T) []T {
 	}
 	return results
 }
+
+func AppendFunc[T any](s []T, keep func(v T) bool, values ...T) []T {
+	for _, v := range values {
+		if keep(v) {
+			s = append(s, v)
+		}
+	}
+	return s
+}
+
+func Filter[T any](s []T, keep func(v T) bool) []T {
+	return AppendFunc(make([]T, 0), keep, s...)
+}

--- a/test/e2e/crds/gatewayproxy.go
+++ b/test/e2e/crds/gatewayproxy.go
@@ -188,7 +188,7 @@ spec:
 			}
 
 			By(fmt.Sprintf("wait for keyword: %s", keyword))
-			s.WaitControllerManagerLog(keyword, 60, time.Minute)
+			s.WaitControllerManagerLog(s.Namespace(), keyword, 60, time.Minute)
 		})
 	})
 })

--- a/test/e2e/framework/ingress.go
+++ b/test/e2e/framework/ingress.go
@@ -67,5 +67,5 @@ func (f *Framework) DeployIngress(opts IngressDeployOpts) {
 		LabelSelector: "control-plane=controller-manager",
 	})
 	f.GomegaT.Expect(err).ToNot(HaveOccurred(), "waiting for controller-manager pod ready")
-	f.WaitControllerManagerLog("All cache synced successfully", 0, time.Minute)
+	f.WaitControllerManagerLog(opts.Namespace, "All cache synced successfully", 60, time.Minute)
 }

--- a/test/e2e/ingress/ingress.go
+++ b/test/e2e/ingress/ingress.go
@@ -746,7 +746,7 @@ spec:
 			err = s.DeleteResource("Ingress", "default")
 			Expect(err).NotTo(HaveOccurred(), "delete Ingress")
 
-			err = framework.PollUntilHTTPRoutePolicyHaveStatus(s.K8sClient, 8*time.Second,
+			err = framework.PollUntilHTTPRoutePolicyHaveStatus(s.K8sClient, 20*time.Second,
 				types.NamespacedName{Namespace: s.Namespace(), Name: "http-route-policy-0"},
 				func(hrp *v1alpha1.HTTPRoutePolicy) bool {
 					return len(hrp.Status.Ancestors) == 0


### PR DESCRIPTION
- Moved `AppendFunc` and `Filter` from `internal/utils/k8s.go` to `pkg/utils/datastructure.go`
- Updated `initialSyncDelay` variable name in `internal/manager/run.go`
- Increased polling timeout for HTTPRoutePolicy status in

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [x] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

WaitControllerManagerLog dose not work in test framework because it hard code namespace when get pods.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
