### PR TITLE
feat: Add load test for 2000 ApisixRoutes

### DIFF
--- a/test/e2e/framework/manifests/ingress.yaml
+++ b/test/e2e/framework/manifests/ingress.yaml
@@ -409,10 +409,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 1024Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 100m
+            memory: 1024Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test/e2e/load-test/e2e_test.go
+++ b/test/e2e/load-test/e2e_test.go
@@ -1,0 +1,44 @@
+package load_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/api7/gopkg/pkg/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
+	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
+)
+
+var closer io.Closer
+
+func init() {
+	// save log locally
+	file, err := os.Create(time.Now().Format("load_test_200601021504.log"))
+	if err != nil {
+		log.Fatalf("failed to create log file, err: %v", err)
+	}
+	closer = file
+	GinkgoWriter.TeeTo(file)
+}
+
+// Run long-term-stability tests using Ginkgo runner.
+func TestLongTermStability(t *testing.T) {
+	defer func() { _ = closer.Close() }()
+
+	RegisterFailHandler(Fail)
+	var f = framework.NewFramework()
+	_ = f
+
+	scaffold.NewDeployer = func(s *scaffold.Scaffold) scaffold.Deployer {
+		return scaffold.NewAPISIXDeployer(s)
+	}
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting load-test suite\n")
+	RunSpecs(t, "long-term-stability suite")
+}

--- a/test/e2e/load-test/spec_subject.go
+++ b/test/e2e/load-test/spec_subject.go
@@ -1,0 +1,160 @@
+package load
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
+	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
+)
+
+const gatewayProxyYaml = `
+apiVersion: apisix.apache.org/v1alpha1
+kind: GatewayProxy
+metadata:
+  name: apisix-proxy-config
+spec:
+  provider:
+    type: ControlPlane
+    controlPlane:
+      service:
+        name: %s
+        port: 9180
+      auth:
+        type: AdminKey
+        adminKey:
+          value: "%s"
+`
+
+const ingressClassYaml = `
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: apisix
+spec:
+  controller: "apisix.apache.org/apisix-ingress-controller"
+  parameters:
+    apiGroup: "apisix.apache.org"
+    kind: "GatewayProxy"
+    name: "apisix-proxy-config"
+    namespace: %s
+    scope: "Namespace"
+`
+
+var _ = Describe("Load Test", func() {
+	var (
+		s = scaffold.NewScaffold(&scaffold.Options{
+			ControllerName: "apisix.apache.org/apisix-ingress-controller",
+		})
+	)
+
+	BeforeEach(func() {
+		By("create GatewayProxy")
+		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.ProviderType, s.AdminKey())
+		err := s.CreateResourceFromStringWithNamespace(gatewayProxy, s.Namespace())
+		Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
+		time.Sleep(5 * time.Second)
+
+		By("create IngressClass")
+		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(ingressClassYaml, s.Namespace()), "")
+		Expect(err).NotTo(HaveOccurred(), "creating IngressClass")
+		time.Sleep(5 * time.Second)
+	})
+
+	Context("Load Test 2000 ApisixRoute", func() {
+		It("test 2000 ApisixRoute", func() {
+			const total = 1000
+
+			const apisixRouteSpec = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: %s
+spec:
+  ingressClassName: apisix
+  http:
+  - name: rule0
+    match:
+      paths:
+      - /*
+      exprs:
+      - subject:
+          scope: Header
+          name: X-Route-Name
+        op: Equal
+        value: %s
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+
+			By(fmt.Sprintf("prepare %d ApisixRoutes", total))
+			var text = bytes.NewBuffer(nil)
+			for i := range total {
+				name := getRouteName(i)
+				text.WriteString(fmt.Sprintf(apisixRouteSpec, name, name))
+				text.WriteString("\n---\n")
+			}
+
+			err := s.CreateResourceFromString(text.String())
+			Expect(err).NotTo(HaveOccurred(), "creating ApisixRoutes")
+
+			By("count time")
+			now := time.Now()
+			time.Sleep(30 * time.Second)
+
+			var c = make(chan int, total)
+			for i := range total {
+				c <- i
+			}
+
+			var totalWorks = 0
+			for {
+				if len(c) == 0 {
+					close(c)
+					break
+				}
+				i := <-c
+				name := getRouteName(i)
+				By(fmt.Sprintf("[%d/%d]try to verify %s", totalWorks, total, name))
+				if s.NewAPISIXClient().GET("/get").WithHeader("X-Route-Name", name).Expect().Raw().StatusCode == http.StatusOK {
+					totalWorks++
+					By(fmt.Sprintf("[%d/%d]%s works", totalWorks, total, name))
+					continue
+				}
+				time.Sleep(100 * time.Millisecond)
+				c <- i
+			}
+
+			// w := sync.WaitGroup{}
+			// for i := range total {
+			// 	time.Sleep(100 * time.Millisecond)
+			// 	name := getRouteName(i)
+			// 	w.Add(1)
+			// 	task := func(name string) {
+			// 		defer w.Done()
+			// 		By(fmt.Sprintf("to check ApisixRoute %s works", name))
+			// 		err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			// 			resp := s.NewAPISIXClient().GET("/get").WithHeader("X-Route-Name", name).Expect().Raw()
+			// 			return resp.StatusCode == http.StatusOK, nil
+			// 		})
+			// 		Expect(err).NotTo(HaveOccurred())
+			// 		By(fmt.Sprintf("ApisixRoute %s works", name))
+			// 	}
+			// 	go task(name)
+			// }
+			//
+			// w.Wait()
+			fmt.Printf("======2000 ApisixRoutes 生效时间为: %s =========", time.Since(now))
+		})
+	})
+})
+
+func getRouteName(i int) string {
+	return fmt.Sprintf("test-route-%04d", i)
+}

--- a/test/e2e/load-test/spec_subject.go
+++ b/test/e2e/load-test/spec_subject.go
@@ -58,7 +58,7 @@ var _ = Describe("Load Test", func() {
 		s.DeployIngress(framework.IngressDeployOpts{
 			ControllerName:     s.GetControllerName(),
 			ProviderType:       framework.ProviderType,
-			ProviderSyncPeriod: 1 * time.Second,
+			ProviderSyncPeriod: 5 * time.Second,
 			Namespace:          s.Namespace(),
 			Replicas:           1,
 		})
@@ -163,7 +163,7 @@ spec:
 			// }
 			// w.Wait()
 
-			fmt.Printf("======%d ApisixRoutes takes effect for: %s =========\n", total, time.Since(now))
+			fmt.Printf("======Apply %d ApisixRoutes takes effect for: %s =========\n", total, time.Since(now))
 
 			By("Test the time required for an ApisixRoute update to take effect")
 			var apisixRouteSpec0 = `
@@ -195,7 +195,7 @@ spec:
 			Eventually(func() int {
 				return s.NewAPISIXClient().GET("/headers").WithHeader("X-Route-Name", name).Expect().Raw().StatusCode
 			}).WithTimeout(time.Minute).ProbeEvery(100 * time.Millisecond).Should(Equal(http.StatusOK))
-			fmt.Printf("====== 更新 ApisixRoute 生效时间为: %s =========\n", time.Since(now))
+			fmt.Printf("====== Update a ApisixRoute takes effect for: %s =========\n", time.Since(now))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

对 Ingress Controller 进行压力测试。

Case 测试了批量 Apply 2000 个 ApisixRoutes 在不同 ProviderSyncPeriod 下所需的时间，以及在 2000 个 ApisixRoutes 基础上，更新一个 ApisixRoute 生效所需的时间。

![20250711151801_rec_](https://github.com/user-attachments/assets/2726d394-79eb-442e-84e9-7e9dd8ee4250)


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
