### PR TITLE
fix: route names with the same prefix were mistakenly deleted

### DIFF
--- a/internal/provider/adc/cache/indexer.go
+++ b/internal/provider/adc/cache/indexer.go
@@ -56,6 +56,12 @@ type LabelIndexer struct {
 	GetLabels func(obj any) map[string]string
 }
 
+// ref: https://pkg.go.dev/github.com/hashicorp/go-memdb#Txn.Get
+// by adding suffixes to avoid prefix matching
+func (emi *LabelIndexer) genKey(labelValues []string) []byte {
+	return []byte(strings.Join(labelValues, "/") + "\x00")
+}
+
 func (emi *LabelIndexer) FromObject(obj any) (bool, []byte, error) {
 	labels := emi.GetLabels(obj)
 	var labelValues []string
@@ -69,7 +75,7 @@ func (emi *LabelIndexer) FromObject(obj any) (bool, []byte, error) {
 		return false, nil, nil
 	}
 
-	return true, []byte(strings.Join(labelValues, "/")), nil
+	return true, emi.genKey(labelValues), nil
 }
 
 func (emi *LabelIndexer) FromArgs(args ...any) ([]byte, error) {
@@ -86,5 +92,5 @@ func (emi *LabelIndexer) FromArgs(args ...any) ([]byte, error) {
 		labelValues = append(labelValues, value)
 	}
 
-	return []byte(strings.Join(labelValues, "/")), nil
+	return emi.genKey(labelValues), nil
 }


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

For the following set of resources, it will only take effect for the last resource.





```yaml
apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: route-11111
spec:
  ingressClassName: apisix
  http:
  - name: rule0
    match:
      hosts:
      - httpbin-11111
      paths:
      - /*
    backends:
    - serviceName: httpbin
      servicePort: 80
---
apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: route-1111
spec:
  ingressClassName: apisix
  http:
  - name: rule0
    match:
      hosts:
      - httpbin-1111
      paths:
      - /*
    backends:
    - serviceName: httpbin
      servicePort: 80
---
apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: route-111
spec:
  ingressClassName: apisix
  http:
  - name: rule0
    match:
      hosts:
      - httpbin-111
      paths:
      - /*
    backends:
    - serviceName: httpbin
      servicePort: 80
---
apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: route-11
spec:
  ingressClassName: apisix
  http:
  - name: rule0
    match:
      hosts:
      - httpbin-11
      paths:
      - /*
    backends:
    - serviceName: httpbin
      servicePort: 80
---

apiVersion: apisix.apache.org/v2
kind: ApisixRoute
metadata:
  name: route-1
spec:
  ingressClassName: apisix
  http:
  - name: rule0
    match:
      hosts:
      - httpbin-1
      paths:
      - /*
    backends:
    - serviceName: httpbin
      servicePort: 80
```

When the above resources were sequentially applied, the following result was obtained by requesting access to them:

```bash
# expect 200
curl http://127.0.0.1:9080/get -H "Host: httpbin-1111"
> 404

# expect 200
curl http://127.0.0.1:9080/get -H "Host: httpbin-1111"
> 404

# expect 200
curl http://127.0.0.1:9080/get -H "Host: httpbin-111"
> 404

# expect 200
curl http://127.0.0.1:9080/get -H "Host: httpbin-11"
> 404

# expect 200
curl http://127.0.0.1:9080/get -H "Host: httpbin-1"
> 200
```


This is due to prefix matching causing cached routes to be deleted.

https://github.com/apache/apisix-ingress-controller/blob/2b9b787a9397ed9348ccfa9eb8d568acc671f6fd/internal/provider/adc/store.go#L68-L73

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
