### PR TITLE
perf: support concurrent running of ADC

### DIFF
--- a/internal/provider/adc/adc.go
+++ b/internal/provider/adc/adc.go
@@ -113,7 +113,7 @@ func New(updater status.Updater, opts ...Option) (provider.Provider, error) {
 		parentRefs: make(map[types.NamespacedNameKind][]types.NamespacedNameKind),
 		store:      NewStore(),
 		executor: &DefaultADCExecutor{
-			Concurrency: 2,
+			Concurrency: 4,
 		},
 		updater: updater,
 	}, nil

--- a/internal/provider/adc/adc.go
+++ b/internal/provider/adc/adc.go
@@ -111,8 +111,10 @@ func New(updater status.Updater, opts ...Option) (provider.Provider, error) {
 		configs:    make(map[types.NamespacedNameKind]adcConfig),
 		parentRefs: make(map[types.NamespacedNameKind][]types.NamespacedNameKind),
 		store:      NewStore(),
-		executor:   &DefaultADCExecutor{},
-		updater:    updater,
+		executor: &DefaultADCExecutor{
+			Concurrency: 2,
+		},
+		updater: updater,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

In the apisix standalone mode, the controller performs synchronization once for each pod.
 As the current synchronization operation is serial, the time consumption will increase as the number of pods increases.
Therefore, increasing concurrency can improve synchronization efficiency.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
