### PR TITLE
fix: full sync during restart results in loss of dataplane traffic

### DIFF
--- a/internal/controller/apisixconsumer_controller.go
+++ b/internal/controller/apisixconsumer_controller.go
@@ -39,6 +39,7 @@ import (
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -51,11 +52,13 @@ type ApisixConsumerReconciler struct {
 
 	Provider provider.Provider
 	Updater  status.Updater
+	Readier  readiness.ReadinessManager
 }
 
 // Reconcile FIXME: implement the reconcile logic (For now, it dose nothing other than directly accepting)
 func (r *ApisixConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("reconcile", "request", req.NamespacedName)
+	r.Readier.Done(&apiv2.ApisixConsumer{}, req.NamespacedName)
 
 	ac := &apiv2.ApisixConsumer{}
 	if err := r.Get(ctx, req.NamespacedName, ac); err != nil {

--- a/internal/controller/apisixconsumer_controller.go
+++ b/internal/controller/apisixconsumer_controller.go
@@ -57,8 +57,8 @@ type ApisixConsumerReconciler struct {
 
 // Reconcile FIXME: implement the reconcile logic (For now, it dose nothing other than directly accepting)
 func (r *ApisixConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer r.Readier.Done(&apiv2.ApisixConsumer{}, req.NamespacedName)
 	r.Log.Info("reconcile", "request", req.NamespacedName)
-	r.Readier.Done(&apiv2.ApisixConsumer{}, req.NamespacedName)
 
 	ac := &apiv2.ApisixConsumer{}
 	if err := r.Get(ctx, req.NamespacedName, ac); err != nil {

--- a/internal/controller/apisixglobalrule_controller.go
+++ b/internal/controller/apisixglobalrule_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -49,10 +50,13 @@ type ApisixGlobalRuleReconciler struct {
 	Log      logr.Logger
 	Provider provider.Provider
 	Updater  status.Updater
+
+	Readier readiness.ReadinessManager
 }
 
 // Reconcile implements the reconciliation logic for ApisixGlobalRule
 func (r *ApisixGlobalRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Readier.Done(&apiv2.ApisixGlobalRule{}, req.NamespacedName)
 	var globalRule apiv2.ApisixGlobalRule
 	if err := r.Get(ctx, req.NamespacedName, &globalRule); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/apisixglobalrule_controller.go
+++ b/internal/controller/apisixglobalrule_controller.go
@@ -56,7 +56,7 @@ type ApisixGlobalRuleReconciler struct {
 
 // Reconcile implements the reconciliation logic for ApisixGlobalRule
 func (r *ApisixGlobalRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Readier.Done(&apiv2.ApisixGlobalRule{}, req.NamespacedName)
+	defer r.Readier.Done(&apiv2.ApisixGlobalRule{}, req.NamespacedName)
 	var globalRule apiv2.ApisixGlobalRule
 	if err := r.Get(ctx, req.NamespacedName, &globalRule); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/apisixroute_controller.go
+++ b/internal/controller/apisixroute_controller.go
@@ -99,7 +99,7 @@ func (r *ApisixRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ApisixRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Readier.Done(&apiv2.ApisixRoute{}, req.NamespacedName)
+	defer r.Readier.Done(&apiv2.ApisixRoute{}, req.NamespacedName)
 	var ar apiv2.ApisixRoute
 	if err := r.Get(ctx, req.NamespacedName, &ar); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/apisixroute_controller.go
+++ b/internal/controller/apisixroute_controller.go
@@ -44,6 +44,7 @@ import (
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
@@ -57,6 +58,7 @@ type ApisixRouteReconciler struct {
 	Log      logr.Logger
 	Provider provider.Provider
 	Updater  status.Updater
+	Readier  readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -97,6 +99,7 @@ func (r *ApisixRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ApisixRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Readier.Done(&apiv2.ApisixRoute{}, req.NamespacedName)
 	var ar apiv2.ApisixRoute
 	if err := r.Get(ctx, req.NamespacedName, &ar); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/apisixtls_controller.go
+++ b/internal/controller/apisixtls_controller.go
@@ -87,7 +87,7 @@ func (r *ApisixTlsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile implements the reconciliation logic for ApisixTls
 func (r *ApisixTlsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Readier.Done(&apiv2.ApisixTls{}, req.NamespacedName)
+	defer r.Readier.Done(&apiv2.ApisixTls{}, req.NamespacedName)
 	var tls apiv2.ApisixTls
 	if err := r.Get(ctx, req.NamespacedName, &tls); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/apisixtls_controller.go
+++ b/internal/controller/apisixtls_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -50,6 +51,7 @@ type ApisixTlsReconciler struct {
 	Log      logr.Logger
 	Provider provider.Provider
 	Updater  status.Updater
+	Readier  readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -85,6 +87,7 @@ func (r *ApisixTlsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile implements the reconciliation logic for ApisixTls
 func (r *ApisixTlsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Readier.Done(&apiv2.ApisixTls{}, req.NamespacedName)
 	var tls apiv2.ApisixTls
 	if err := r.Get(ctx, req.NamespacedName, &tls); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -183,7 +183,7 @@ func (r *ConsumerReconciler) listConsumersForGatewayProxy(ctx context.Context, o
 }
 
 func (r *ConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Readier.Done(&v1alpha1.Consumer{}, req.NamespacedName)
+	defer r.Readier.Done(&v1alpha1.Consumer{}, req.NamespacedName)
 	consumer := new(v1alpha1.Consumer)
 	if err := r.Get(ctx, req.NamespacedName, consumer); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -306,31 +306,5 @@ func (r *ConsumerReconciler) checkGatewayRef(object client.Object) bool {
 	if !ok {
 		return false
 	}
-	if consumer.Spec.GatewayRef.Name == "" {
-		return false
-	}
-	if consumer.Spec.GatewayRef.Kind != nil && *consumer.Spec.GatewayRef.Kind != KindGateway {
-		return false
-	}
-	if consumer.Spec.GatewayRef.Group != nil && *consumer.Spec.GatewayRef.Group != gatewayv1.GroupName {
-		return false
-	}
-	ns := consumer.GetNamespace()
-	if consumer.Spec.GatewayRef.Namespace != nil {
-		ns = *consumer.Spec.GatewayRef.Namespace
-	}
-	gateway := &gatewayv1.Gateway{}
-	if err := r.Get(context.Background(), client.ObjectKey{
-		Name:      consumer.Spec.GatewayRef.Name,
-		Namespace: ns,
-	}, gateway); err != nil {
-		r.Log.Error(err, "failed to get gateway", "gateway", consumer.Spec.GatewayRef.Name)
-		return false
-	}
-	gatewayClass := &gatewayv1.GatewayClass{}
-	if err := r.Get(context.Background(), client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
-		r.Log.Error(err, "failed to get gateway class", "gateway", gateway.GetName(), "gatewayclass", gateway.Spec.GatewayClassName)
-		return false
-	}
-	return matchesController(string(gatewayClass.Spec.ControllerName))
+	return MatchConsumerGatewayRef(context.Background(), r.Client, r.Log, consumer)
 }

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -51,6 +52,7 @@ type ConsumerReconciler struct { //nolint:revive
 	Provider provider.Provider
 
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -181,6 +183,7 @@ func (r *ConsumerReconciler) listConsumersForGatewayProxy(ctx context.Context, o
 }
 
 func (r *ConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Readier.Done(&v1alpha1.Consumer{}, req.NamespacedName)
 	consumer := new(v1alpha1.Consumer)
 	if err := r.Get(ctx, req.NamespacedName, consumer); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
@@ -65,6 +66,7 @@ type HTTPRouteReconciler struct { //nolint:revive
 	genericEvent chan event.GenericEvent
 
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -130,6 +132,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Readier.Done(&gatewayv1.HTTPRoute{}, req.NamespacedName)
 	hr := new(gatewayv1.HTTPRoute)
 	if err := r.Get(ctx, req.NamespacedName, hr); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -132,7 +132,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Readier.Done(&gatewayv1.HTTPRoute{}, req.NamespacedName)
+	defer r.Readier.Done(&gatewayv1.HTTPRoute{}, req.NamespacedName)
 	hr := new(gatewayv1.HTTPRoute)
 	if err := r.Get(ctx, req.NamespacedName, hr); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -119,7 +119,7 @@ func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile handles the reconciliation of Ingress resources
 func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Readier.Done(&networkingv1.Ingress{}, req.NamespacedName)
+	defer r.Readier.Done(&networkingv1.Ingress{}, req.NamespacedName)
 	ingress := new(networkingv1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, ingress); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -45,6 +45,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -59,6 +60,7 @@ type IngressReconciler struct { //nolint:revive
 	genericEvent chan event.GenericEvent
 
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -117,6 +119,7 @@ func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile handles the reconciliation of Ingress resources
 func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Readier.Done(&networkingv1.Ingress{}, req.NamespacedName)
 	ingress := new(networkingv1.Ingress)
 	if err := r.Get(ctx, req.NamespacedName, ingress); err != nil {
 		if client.IgnoreNotFound(err) == nil {

--- a/internal/controller/status/updater.go
+++ b/internal/controller/status/updater.go
@@ -150,6 +150,10 @@ func (u *UpdateHandler) Start(ctx context.Context) error {
 	}
 }
 
+func (u *UpdateHandler) NeedsLeaderElection() bool {
+	return true
+}
+
 func (u *UpdateHandler) Writer() Updater {
 	return &UpdateWriter{
 		updateChannel: u.updateChannel,

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -126,6 +126,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Ingress"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.ConsumerReconciler{
 			Client:   mgr.GetClient(),

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -20,13 +20,24 @@ package manager
 import (
 	"context"
 
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller"
+	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
+	types "github.com/apache/apisix-ingress-controller/internal/types"
 )
 
 // K8s
@@ -83,7 +94,7 @@ type Controller interface {
 	SetupWithManager(mgr manager.Manager) error
 }
 
-func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Provider, updater status.Updater) ([]Controller, error) {
+func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Provider, updater status.Updater, readier readiness.ReadinessManager) ([]Controller, error) {
 	if err := indexer.SetupIndexer(mgr); err != nil {
 		return nil, err
 	}
@@ -107,6 +118,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("HTTPRoute"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.IngressReconciler{
 			Client:   mgr.GetClient(),
@@ -121,6 +133,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Consumer"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.IngressClassReconciler{
 			Client:   mgr.GetClient(),
@@ -134,6 +147,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("ApisixGlobalRule"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.ApisixRouteReconciler{
 			Client:   mgr.GetClient(),
@@ -141,6 +155,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("ApisixRoute"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.ApisixConsumerReconciler{
 			Client:   mgr.GetClient(),
@@ -148,6 +163,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("ApisixConsumer"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.ApisixPluginConfigReconciler{
 			Client:  mgr.GetClient(),
@@ -161,6 +177,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("ApisixTls"),
 			Provider: pro,
 			Updater:  updater,
+			Readier:  readier,
 		},
 		&controller.ApisixUpstreamReconciler{
 			Client:  mgr.GetClient(),
@@ -175,4 +192,88 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Provider: pro,
 		},
 	}, nil
+}
+
+func registerReadinessGVK(c client.Client, readier readiness.ReadinessManager) {
+	readier.RegisterGVK([]readiness.GVKConfig{
+		{
+			GVKs: []schema.GroupVersionKind{
+				types.GvkOf(&gatewayv1.HTTPRoute{}),
+			},
+		},
+		{
+			GVKs: []schema.GroupVersionKind{
+				types.GvkOf(&netv1.Ingress{}),
+				types.GvkOf(&apiv2.ApisixRoute{}),
+				types.GvkOf(&apiv2.ApisixGlobalRule{}),
+				types.GvkOf(&apiv2.ApisixPluginConfig{}),
+				types.GvkOf(&apiv2.ApisixTls{}),
+				types.GvkOf(&apiv2.ApisixConsumer{}),
+			},
+			Filter: readiness.GVKFilter(func(obj *unstructured.Unstructured) bool {
+				icName, _, _ := unstructured.NestedString(obj.Object, "spec", "ingressClassName")
+				if icName == "" {
+					insList := &netv1.IngressClassList{}
+					if err := c.List(context.Background(), insList, client.MatchingFields{
+						indexer.IngressClass: config.GetControllerName(),
+					}); err != nil {
+						return false
+					}
+					for _, ic := range insList.Items {
+						if ic.Annotations[types.DefaultIngressClassAnnotation] == "true" {
+							return true
+						}
+					}
+					return false
+				} else {
+					var ingressClass netv1.IngressClass
+					if err := c.Get(context.Background(), client.ObjectKey{
+						Name: icName,
+					}, &ingressClass); err != nil {
+						return false
+					}
+					return true
+				}
+			}),
+		},
+		{
+			GVKs: []schema.GroupVersionKind{
+				types.GvkOf(&v1alpha1.Consumer{}),
+			},
+			Filter: readiness.GVKFilter(func(obj *unstructured.Unstructured) bool {
+				consumer := &v1alpha1.Consumer{}
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, consumer); err != nil {
+					return false
+				}
+
+				if consumer.Spec.GatewayRef.Name == "" {
+					return false
+				}
+				if consumer.Spec.GatewayRef.Kind != nil && *consumer.Spec.GatewayRef.Kind != types.KindGateway {
+					return false
+				}
+				if consumer.Spec.GatewayRef.Group != nil && *consumer.Spec.GatewayRef.Group != gatewayv1.GroupName {
+					return false
+				}
+
+				ns := consumer.GetNamespace()
+				if consumer.Spec.GatewayRef.Namespace != nil {
+					ns = *consumer.Spec.GatewayRef.Namespace
+				}
+
+				ctx := context.Background()
+
+				gateway := &gatewayv1.Gateway{}
+				if err := c.Get(ctx, client.ObjectKey{Name: consumer.Spec.GatewayRef.Name, Namespace: ns}, gateway); err != nil {
+					return false
+				}
+
+				gatewayClass := &gatewayv1.GatewayClass{}
+				if err := c.Get(ctx, client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
+					return false
+				}
+				return string(gatewayClass.Spec.ControllerName) == config.GetControllerName()
+			}),
+		},
+	}...)
 }

--- a/internal/manager/readiness/manager.go
+++ b/internal/manager/readiness/manager.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/api7/gopkg/pkg/log"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	types "github.com/apache/apisix-ingress-controller/internal/types"
-	"github.com/api7/gopkg/pkg/log"
 )
 
 // Filter defines an interface to match unstructured Kubernetes objects.
@@ -121,7 +121,7 @@ func (r *readinessManager) Start(ctx context.Context) error {
 					})
 				}
 				if len(expected) > 0 {
-					log.Warnw("registering readiness state", zap.Any("gvk", gvk), zap.Any("expected", expected))
+					log.Debugw("registering readiness state", zap.Any("gvk", gvk), zap.Any("expected", expected))
 					r.registerState(gvk, expected)
 				}
 			}

--- a/internal/manager/readiness/manager.go
+++ b/internal/manager/readiness/manager.go
@@ -1,0 +1,177 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readiness
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	types "github.com/apache/apisix-ingress-controller/internal/types"
+	"github.com/api7/gopkg/pkg/log"
+)
+
+type Filter interface {
+	Match(obj *unstructured.Unstructured) bool
+}
+
+type GVKFilter func(obj *unstructured.Unstructured) bool
+
+func (f GVKFilter) Match(obj *unstructured.Unstructured) bool {
+	return f(obj)
+}
+
+type GVKConfig struct {
+	GVKs   []schema.GroupVersionKind
+	Filter Filter
+}
+
+type ReadinessManager interface {
+	RegisterGVK(configs ...GVKConfig)
+	Start(ctx context.Context) error
+	IsReady() bool
+	WaitReady(ctx context.Context, timeout time.Duration) bool
+	Done(obj client.Object, namespacedName k8stypes.NamespacedName)
+}
+
+type readinessManager struct {
+	client    client.Client
+	configs   []GVKConfig
+	state     map[schema.GroupVersionKind]map[k8stypes.NamespacedName]struct{}
+	mu        sync.RWMutex
+	startOnce sync.Once
+	started   chan struct{}
+	done      chan struct{}
+
+	isReady bool
+}
+
+func NewReadinessManager(client client.Client) ReadinessManager {
+	return &readinessManager{
+		client:  client,
+		state:   make(map[schema.GroupVersionKind]map[k8stypes.NamespacedName]struct{}),
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+func (r *readinessManager) RegisterGVK(configs ...GVKConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.configs = append(r.configs, configs...)
+}
+
+// Start should be called **after** cache is started and synced.
+func (r *readinessManager) Start(ctx context.Context) error {
+	var err error
+	r.startOnce.Do(func() {
+		for _, cfg := range r.configs {
+			for _, gvk := range cfg.GVKs {
+				uList := &unstructured.UnstructuredList{}
+				uList.SetGroupVersionKind(gvk)
+				if listErr := r.client.List(ctx, uList); listErr != nil {
+					err = fmt.Errorf("list %s failed: %w", gvk.String(), listErr)
+					return
+				}
+				var expected []k8stypes.NamespacedName
+				for _, item := range uList.Items {
+					if cfg.Filter != nil && !cfg.Filter.Match(&item) {
+						continue
+					}
+					expected = append(expected, k8stypes.NamespacedName{
+						Namespace: item.GetNamespace(),
+						Name:      item.GetName(),
+					})
+				}
+				if len(expected) > 0 {
+					log.Warnw("registering readiness state", zap.Any("gvk", gvk), zap.Any("expected", expected))
+					r.registerState(gvk, expected)
+				}
+			}
+		}
+		close(r.started)
+		if len(r.state) == 0 && !r.isReady {
+			r.isReady = true
+			close(r.done)
+		}
+	})
+	return err
+}
+
+func (r *readinessManager) registerState(gvk schema.GroupVersionKind, list []k8stypes.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.state[gvk]; !ok {
+		r.state[gvk] = make(map[k8stypes.NamespacedName]struct{})
+	}
+	for _, name := range list {
+		r.state[gvk][name] = struct{}{}
+	}
+}
+
+func (r *readinessManager) Done(obj client.Object, nn k8stypes.NamespacedName) {
+	if r.IsReady() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	gvk := types.GvkOf(obj)
+	if _, ok := r.state[gvk]; !ok {
+		return
+	}
+	delete(r.state[gvk], nn)
+	if len(r.state[gvk]) == 0 {
+		delete(r.state, gvk)
+	}
+	if len(r.state) == 0 && !r.isReady {
+		r.isReady = true
+		close(r.done)
+	}
+}
+
+func (r *readinessManager) IsReady() bool {
+	return r.isReady
+}
+
+func (r *readinessManager) WaitReady(ctx context.Context, timeout time.Duration) bool {
+	if r.IsReady() {
+		return true
+	}
+
+	select {
+	case <-r.started:
+	case <-ctx.Done():
+		return false
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(timeout):
+		return true
+	case <-r.done:
+		return true
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,6 +37,7 @@ type Provider interface {
 	Delete(context.Context, client.Object) error
 	Sync(context.Context) error
 	Start(context.Context) error
+	NeedLeaderElection() bool
 }
 
 type TranslateContext struct {

--- a/internal/types/k8s.go
+++ b/internal/types/k8s.go
@@ -21,7 +21,9 @@ import (
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	v2 "github.com/apache/apisix-ingress-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -88,5 +90,79 @@ func KindOf(obj any) string {
 		return KindPluginConfig
 	default:
 		return "Unknown"
+	}
+}
+
+func GvkOf(obj any) schema.GroupVersionKind {
+	kind := KindOf(obj)
+	switch obj.(type) {
+	case *gatewayv1.Gateway, *gatewayv1.HTTPRoute, *gatewayv1.GatewayClass:
+		return gatewayv1.SchemeGroupVersion.WithKind(kind)
+	case *netv1.Ingress, *netv1.IngressClass:
+		return netv1.SchemeGroupVersion.WithKind(kind)
+	case *corev1.Secret, *corev1.Service:
+		return corev1.SchemeGroupVersion.WithKind(kind)
+	case *v2.ApisixRoute:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v2",
+			Kind:    KindApisixRoute,
+		}
+	case *v2.ApisixGlobalRule:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v2",
+			Kind:    KindApisixGlobalRule,
+		}
+	case *v2.ApisixPluginConfig:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v2",
+			Kind:    KindApisixPluginConfig,
+		}
+	case *v2.ApisixTls:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v2",
+			Kind:    KindApisixTls,
+		}
+	case *v2.ApisixConsumer:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v2",
+			Kind:    KindApisixConsumer,
+		}
+	case *v1alpha1.HTTPRoutePolicy:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v1alpha1",
+			Kind:    KindHTTPRoutePolicy,
+		}
+	case *v1alpha1.BackendTrafficPolicy:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v1alpha1",
+			Kind:    KindBackendTrafficPolicy,
+		}
+	case *v1alpha1.GatewayProxy:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v1alpha1",
+			Kind:    KindGatewayProxy,
+		}
+	case *v1alpha1.Consumer:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v1alpha1",
+			Kind:    KindConsumer,
+		}
+	case *v1alpha1.PluginConfig:
+		return schema.GroupVersionKind{
+			Group:   "apisix.apache.org",
+			Version: "v1alpha1",
+			Kind:    KindPluginConfig,
+		}
+	default:
+		return schema.GroupVersionKind{}
 	}
 }

--- a/internal/types/k8s.go
+++ b/internal/types/k8s.go
@@ -18,12 +18,13 @@
 package types
 
 import (
-	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
-	v2 "github.com/apache/apisix-ingress-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
+	v2 "github.com/apache/apisix-ingress-controller/api/v2"
 )
 
 const DefaultIngressClassAnnotation = "ingressclass.kubernetes.io/is-default-class"

--- a/internal/types/k8s.go
+++ b/internal/types/k8s.go
@@ -22,7 +22,6 @@ import (
 	v2 "github.com/apache/apisix-ingress-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
-	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -58,9 +57,9 @@ func KindOf(obj any) string {
 		return KindHTTPRoute
 	case *gatewayv1.GatewayClass:
 		return KindGatewayClass
-	case *v1.Ingress:
+	case *netv1.Ingress:
 		return KindIngress
-	case *v1.IngressClass:
+	case *netv1.IngressClass:
 		return KindIngressClass
 	case *corev1.Secret:
 		return KindSecret

--- a/test/e2e/apisix/route.go
+++ b/test/e2e/apisix/route.go
@@ -635,4 +635,111 @@ spec:
 			Expect(err).ShouldNot(HaveOccurred(), "check apisixupstream is referenced")
 		})
 	})
+
+	Context("Test ApisixRoute sync during startup", func() {
+		const route = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: default
+spec:
+  ingressClassName: apisix
+  http:
+  - name: rule0
+    match:
+      hosts:
+      - httpbin
+      paths:
+      - /get
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+
+		const route2 = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: route2
+spec:
+  ingressClassName: apisix-nonexistent
+  http:
+  - name: rule0
+    match:
+      hosts:
+      - httpbin2
+      paths:
+      - /get
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+		const route3 = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: route3
+spec:
+  http:
+  - name: rule0
+    match:
+      hosts:
+      - httpbin3
+      paths:
+      - /get
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+		It("Should sync ApisixRoute during startup", func() {
+			By("apply ApisixRoute")
+			Expect(s.CreateResourceFromString(route2)).ShouldNot(HaveOccurred(), "apply ApisixRoute with nonexistent ingressClassName")
+			Expect(s.CreateResourceFromString(route3)).ShouldNot(HaveOccurred(), "apply ApisixRoute without ingressClassName")
+			applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"}, &apiv2.ApisixRoute{}, route)
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin",
+				Check:  scaffold.WithExpectedStatus(http.StatusOK),
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin2",
+				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin3",
+				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+			})
+
+			By("restart controller and dataplane")
+			s.Deployer.ScaleIngress(0)
+			s.Deployer.ScaleDataplane(0)
+			s.Deployer.ScaleDataplane(1)
+			s.Deployer.ScaleIngress(1)
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin",
+				Check:  scaffold.WithExpectedStatus(http.StatusOK),
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin2",
+				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin3",
+				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+			})
+		})
+	})
 })

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -1900,4 +1900,85 @@ spec:
 			}
 		})
 	})
+
+	Context("Test HTTPRoute sync during startup", func() {
+		BeforeEach(beforeEachHTTP)
+		var route = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+spec:
+  parentRefs:
+  - name: apisix
+  hostnames:
+  - httpbin
+  rules:
+  - matches: 
+    - path:
+        type: Exact
+        value: /get
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
+`
+
+		var route2 = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin2
+spec:
+  parentRefs:
+  - name: apisix-nonexistent
+  hostnames:
+  - httpbin2
+  rules:
+  - matches: 
+    - path:
+        type: Exact
+        value: /get
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
+`
+		It("Should sync ApisixRoute during startup", func() {
+			By("apply ApisixRoute")
+			Expect(s.CreateResourceFromString(route2)).ShouldNot(HaveOccurred(), "applying HTTPRoute with non-existent parent")
+			s.ResourceApplied("HTTPRoute", "httpbin", route, 1)
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin",
+				Check:  scaffold.WithExpectedStatus(http.StatusOK),
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin2",
+				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+			})
+
+			By("restart controller and dataplane")
+			s.Deployer.ScaleIngress(0)
+			s.Deployer.ScaleDataplane(0)
+			s.Deployer.ScaleDataplane(1)
+			s.Deployer.ScaleIngress(1)
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin",
+				Check:  scaffold.WithExpectedStatus(http.StatusOK),
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin2",
+				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+			})
+		})
+
+	})
 })


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

#### background

The controller watches CRDs and incrementally builds an in-memory cache of dataplane resources. It periodically performs a full (asynchronous) sync from this cache to the dataplane, without waiting for the cache to be fully populated.

On startup, if the number of CRDs is large, the first full sync may happen before all resources are processed, resulting in partial configuration being pushed to the dataplane. This can cause temporary 404 errors and traffic disruption.


#### Reproduction Steps:

1. Apply 5,000 ApisixRoute to the kubernetes cluster.

2. Restart the Ingress controller.

3. While the Ingress controller is starting, attempt to access all routes via the data plane. Some routes will return 404 Not Found errors.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
