### PR TITLE
fix: traffic-split weight distribution and add e2e tests

### DIFF
--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -744,7 +744,6 @@ spec:
 				Expect(code).Should(Equal(200))
 			}
 		})
-
 		It("valid backend is set even if other backend is invalid", func() {
 			const apisixRouteSpec = `
 apiVersion: apisix.apache.org/v2
@@ -781,6 +780,8 @@ spec:
 				code := verifyRequest()
 				Expect(code).Should(Equal(200))
 			}
+		})
+	})
 	Context("Test ApisixRoute sync during startup", func() {
 		const route = `
 apiVersion: apisix.apache.org/v2

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -688,7 +688,13 @@ spec:
 				failCount    int
 			)
 
-			time.Sleep(10 * time.Second)
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:  "GET",
+				Path:    "/get",
+				Host:    "httpbin.org",
+				Check:   scaffold.WithExpectedStatus(http.StatusOK),
+				Timeout: 10 * time.Second,
+			})
 			for range 90 {
 				code := verifyRequest()
 				if code == http.StatusOK {
@@ -737,7 +743,13 @@ spec:
 			}
 
 			By("wait for route to be ready")
-			time.Sleep(8 * time.Second)
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:  "GET",
+				Path:    "/get",
+				Host:    "httpbin.org",
+				Check:   scaffold.WithExpectedStatus(http.StatusOK),
+				Timeout: 10 * time.Second,
+			})
 			By("send requests to verify zero-weight behavior")
 			for range 30 {
 				code := verifyRequest()
@@ -774,7 +786,13 @@ spec:
 			}
 
 			By("wait for route to be ready")
-			time.Sleep(8 * time.Second)
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:  "GET",
+				Path:    "/get",
+				Host:    "httpbin.org",
+				Check:   scaffold.WithExpectedStatus(http.StatusOK),
+				Timeout: 10 * time.Second,
+			})
 			By("send requests to verify all requests routed to valid upstream")
 			for range 30 {
 				code := verifyRequest()

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"time"
@@ -648,6 +649,100 @@ spec:
 			// expect upstream host is "hello.httpbin.org" which is rewritten by the apisixupstream
 			err = wait.PollUntilContextTimeout(context.Background(), time.Second, 10*time.Second, true, expectUpstreamHostIs("hello.httpbin.org"))
 			Expect(err).ShouldNot(HaveOccurred(), "check apisixupstream is referenced")
+		})
+	})
+
+	Context("Test ApisixRoute Traffic Split", func() {
+		It("2:1 traffic split test", func() {
+			const apisixRouteSpec = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+ name: default
+spec:
+ ingressClassName: apisix
+ http:
+ - name: rule1
+   match:
+     hosts:
+     - httpbin.org
+     paths:
+       - /get
+   backends:
+   - serviceName: httpbin-service-e2e-test
+     servicePort: 80
+     weight: 10
+   - serviceName: %s
+     servicePort: 9180
+     weight: 5
+`
+			By("apply ApisixRoute with traffic split")
+			applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"}, new(apiv2.ApisixRoute),
+				fmt.Sprintf(apisixRouteSpec, s.Deployer.GetAdminServiceName()))
+			verifyRequest := func() int {
+				return s.NewAPISIXClient().GET("/get").WithHost("httpbin.org").Expect().Raw().StatusCode
+			}
+			By("send requests to verify traffic split")
+			var (
+				successCount int
+				failCount    int
+			)
+
+			time.Sleep(10 * time.Second)
+			for range 90 {
+				code := verifyRequest()
+				if code == http.StatusOK {
+					successCount++
+				} else {
+					failCount++
+				}
+			}
+
+			By("verify traffic distribution ratio")
+			ratio := float64(successCount) / float64(failCount)
+			expectedRatio := 10.0 / 5.0 // 2:1 ratio
+			deviation := math.Abs(ratio - expectedRatio)
+			Expect(deviation).Should(BeNumerically("<", 0.5),
+				"traffic distribution deviation too large (got %.2f, expected %.2f)", ratio, expectedRatio)
+		})
+
+		It("zero-weight test", func() {
+			const apisixRouteSpec = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+ name: default
+spec:
+ ingressClassName: apisix
+ http:
+ - name: rule1
+   match:
+     hosts:
+     - httpbin.org
+     paths:
+       - /get
+   backends:
+   - serviceName: httpbin-service-e2e-test
+     servicePort: 80
+     weight: 10
+   - serviceName: %s
+     servicePort: 9180
+     weight: 0
+`
+			By("apply ApisixRoute with zero-weight backend")
+			applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"}, new(apiv2.ApisixRoute),
+				fmt.Sprintf(apisixRouteSpec, s.Deployer.GetAdminServiceName()))
+			verifyRequest := func() int {
+				return s.NewAPISIXClient().GET("/get").WithHost("httpbin.org").Expect().Raw().StatusCode
+			}
+
+			By("wait for route to be ready")
+			time.Sleep(8 * time.Second)
+			By("send requests to verify zero-weight behavior")
+			for range 30 {
+				code := verifyRequest()
+				fmt.Println(code)
+			}
 		})
 	})
 })

--- a/test/e2e/scaffold/apisix_deployer.go
+++ b/test/e2e/scaffold/apisix_deployer.go
@@ -409,6 +409,9 @@ func (s *APISIXDeployer) GetAdminEndpoint(svc ...*corev1.Service) string {
 	return fmt.Sprintf("http://%s.%s:9180", svc[0].Name, svc[0].Namespace)
 }
 
+func (s *APISIXDeployer) GetAdminServiceName() string {
+	return s.dataplaneService.Name
+}
 func (s *APISIXDeployer) DefaultDataplaneResource() DataplaneResource {
 	return newADCDataplaneResource(
 		framework.ProviderType,

--- a/test/e2e/scaffold/deployer.go
+++ b/test/e2e/scaffold/deployer.go
@@ -32,6 +32,7 @@ type Deployer interface {
 	CreateAdditionalGateway(namePrefix string) (string, *corev1.Service, error)
 	CleanupAdditionalGateway(identifier string) error
 	GetAdminEndpoint(...*corev1.Service) string
+	GetAdminServiceName() string
 	DefaultDataplaneResource() DataplaneResource
 }
 


### PR DESCRIPTION
This PR solves two bugs and adds corresponding E2E tests:
1. `backendErr` is currently a shared variable due to which even if one backend is invalid, no backend is set causing 0 nodes to be set on upstream even when there are valid nodes. A test case confirming the fix for this has been added. The test `valid backend is set even if other backend is invalid` confirms this fix.
2. The weight from backend was not set in the upstream  label which is used to set weight on `weightedUpstreams` due to which all nodes always get `100` as weight. The tests `2:1 traffic split test` and `zero-weight test` confirm this fix.
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
3. Test is required for the feat/fix PR, unless you have a good reason
4. Doc is required for the feat PR
5. Use a new commit to resolve review instead of `push -f`
6. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
