### PR TITLE
docs: fix indentation in reference doc

### DIFF
--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -716,12 +716,12 @@ spec:
       match:
         paths:
           - /ip
-    authentication:
-      enable: true
-      type: keyAuth
-    backends:
-    - serviceName: httpbin
-      servicePort: 80
+      authentication:
+        enable: true
+        type: keyAuth
+      backends:
+      - serviceName: httpbin
+        servicePort: 80
 ```
 
 To enable other plugins:
@@ -745,9 +745,9 @@ spec:
           count: 2
           time_window: 10
           rejected_code: 429
-    backends:
-    - serviceName: httpbin
-      servicePort: 80
+      backends:
+      - serviceName: httpbin
+        servicePort: 80
 ```
 
 </TabItem>


### PR DESCRIPTION
### Type of change:

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

Fix indentation in reference doc. The configuration previously will lead to `error: error parsing test.yaml: error converting YAML to JSON: yaml: line xx: did not find expected '-' indicator`

https://github.com/apache/apisix-ingress-controller/issues/2510

Will open a PR for master as well.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
