### PR TITLE
docs: mention stream is currently not supported in the CRD doc

### DIFF
--- a/api/v2/apisixroute_types.go
+++ b/api/v2/apisixroute_types.go
@@ -39,6 +39,7 @@ type ApisixRouteSpec struct {
 	HTTP []ApisixRouteHTTP `json:"http,omitempty" yaml:"http,omitempty"`
 	// Stream defines a list of stream route rules.
 	// Each rule specifies conditions to match TCP/UDP traffic and how to forward them.
+	// Stream is currently not supported.
 	Stream []ApisixRouteStream `json:"stream,omitempty" yaml:"stream,omitempty"`
 }
 
@@ -106,7 +107,7 @@ type ApisixRouteHTTP struct {
 	Authentication ApisixRouteAuthentication `json:"authentication,omitempty" yaml:"authentication,omitempty"`
 }
 
-// ApisixRouteStream defines the configuration for a Layer 4 (TCP/UDP) route.
+// ApisixRouteStream defines the configuration for a Layer 4 (TCP/UDP) route. Currently not supported.
 type ApisixRouteStream struct {
 	// Name is a unique identifier for the route. This field must not be empty.
 	Name string `json:"name" yaml:"name"`

--- a/config/crd/bases/apisix.apache.org_apisixroutes.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixroutes.yaml
@@ -355,9 +355,10 @@ spec:
                 description: |-
                   Stream defines a list of stream route rules.
                   Each rule specifies conditions to match TCP/UDP traffic and how to forward them.
+                  Stream is currently not supported.
                 items:
                   description: ApisixRouteStream defines the configuration for a Layer
-                    4 (TCP/UDP) route.
+                    4 (TCP/UDP) route. Currently not supported.
                   properties:
                     backend:
                       description: Backend specifies the destination service to which

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -1177,7 +1177,7 @@ It defines routing rules for both HTTP and stream traffic.
 | --- | --- |
 | `ingressClassName` _string_ | IngressClassName is the name of the IngressClass this route belongs to. It allows multiple controllers to watch and reconcile different routes. |
 | `http` _[ApisixRouteHTTP](#apisixroutehttp) array_ | HTTP defines a list of HTTP route rules. Each rule specifies conditions to match HTTP requests and how to forward them. |
-| `stream` _[ApisixRouteStream](#apisixroutestream) array_ | Stream defines a list of stream route rules. Each rule specifies conditions to match TCP/UDP traffic and how to forward them. |
+| `stream` _[ApisixRouteStream](#apisixroutestream) array_ | Stream defines a list of stream route rules. Each rule specifies conditions to match TCP/UDP traffic and how to forward them. Stream is currently not supported. |
 
 
 _Appears in:_
@@ -1186,7 +1186,7 @@ _Appears in:_
 #### ApisixRouteStream
 
 
-ApisixRouteStream defines the configuration for a Layer 4 (TCP/UDP) route.
+ApisixRouteStream defines the configuration for a Layer 4 (TCP/UDP) route. Currently not supported.
 
 
 


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

Mention stream is currently not supported in the CRD doc.

Currently when using APISIX CRD (following the CRD doc) to configure stream routes, the synchronization will succeed but the resource is not applied to the gateway instance (cannot see the resource when checking `/apisix/admin/configs`). This could potentially lead to confusion.

Gateway API currently also does not support proxying L4 traffic.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
