### PR TITLE
fix: responseHeaderModifier fails to synchronize

### DIFF
--- a/api/adc/types.go
+++ b/api/adc/types.go
@@ -635,9 +635,9 @@ type ResponseRewriteConfig struct {
 }
 
 type ResponseHeaders struct {
-	Set    map[string]string `json:"set" yaml:"set"`
-	Add    []string          `json:"add" yaml:"add"`
-	Remove []string          `json:"remove" yaml:"remove"`
+	Set    map[string]string `json:"set,omitempty" yaml:"set,omitempty"`
+	Add    []string          `json:"add,omitempty" yaml:"add,omitempty"`
+	Remove []string          `json:"remove,omitempty" yaml:"remove,omitempty"`
 }
 
 // RequestMirror is the rule config for proxy-mirror plugin.

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -1444,6 +1444,82 @@ spec:
       port: 80
 `
 
+		var respHeaderModifyWithAdd = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: add
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - httpbin.example.resp-header-modify.add
+  rules:
+  - matches: 
+    - path:
+        type: Exact
+        value: /headers
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        add:
+        - name: X-Resp-Add
+          value: "resp-add"
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
+`
+
+		var respHeaderModifyWithSet = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: set
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - httpbin.example.resp-header-modify.set
+  rules:
+  - matches: 
+    - path:
+        type: Exact
+        value: /headers
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Resp-Set
+          value: "resp-set"
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
+`
+
+		var respHeaderModifyWithRemove = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: remove
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - httpbin.example.resp-header-modify.remove
+  rules:
+  - matches: 
+    - path:
+        type: Exact
+        value: /headers
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        remove:
+        - Server
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
+`
 		var respHeaderModifyByHeaders = `
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -1655,6 +1731,9 @@ spec:
 		It("HTTPRoute ResponseHeaderModifier", func() {
 			By("create HTTPRoute")
 			s.ResourceApplied("HTTPRoute", "httpbin", fmt.Sprintf(respHeaderModifyByHeaders, s.Namespace(), s.Namespace()), 1)
+			s.ResourceApplied("HTTPRoute", "add", fmt.Sprintf(respHeaderModifyWithAdd, s.Namespace()), 1)
+			s.ResourceApplied("HTTPRoute", "set", fmt.Sprintf(respHeaderModifyWithSet, s.Namespace()), 1)
+			s.ResourceApplied("HTTPRoute", "remove", fmt.Sprintf(respHeaderModifyWithRemove, s.Namespace()), 1)
 
 			By("access daataplane to check the HTTPRoute")
 			s.RequestAssert(&scaffold.RequestAssert{
@@ -1666,12 +1745,40 @@ spec:
 					scaffold.WithExpectedHeaders(map[string]string{
 						"X-Resp-Add": "add",
 						"X-Resp-Set": "set",
-						"Server":     "",
 					}),
+					scaffold.WithExpectedNotHeader("Server"),
 					scaffold.WithExpectedBodyNotContains(`"X-Resp-Add": "add"`, `"X-Resp-Set": "set"`, `"Server"`),
 				},
-				Timeout:  time.Second * 30,
-				Interval: time.Second * 2,
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/headers",
+				Host:   "httpbin.example.resp-header-modify.add",
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(http.StatusOK),
+					scaffold.WithExpectedHeader("X-Resp-Add", "resp-add"),
+					scaffold.WithExpectedBodyNotContains(`"X-Resp-Add": "resp-add"`),
+				},
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/headers",
+				Host:   "httpbin.example.resp-header-modify.set",
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(http.StatusOK),
+					scaffold.WithExpectedHeader("X-Resp-Set", "resp-set"),
+					scaffold.WithExpectedBodyNotContains(`"Server"`),
+				},
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/headers",
+				Host:   "httpbin.example.resp-header-modify.remove",
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(http.StatusOK),
+					scaffold.WithExpectedNotHeader("Server"),
+					scaffold.WithExpectedBodyNotContains(`"Server"`),
+				},
 			})
 		})
 

--- a/test/e2e/scaffold/assertion.go
+++ b/test/e2e/scaffold/assertion.go
@@ -149,6 +149,28 @@ func WithExpectedHeaders(expectedHeaders map[string]string) ResponseCheckFunc {
 	}
 }
 
+func WithExpectedNotHeader(key string) ResponseCheckFunc {
+	return func(resp *HTTPResponse) error {
+		if resp.Header.Get(key) != "" {
+			return fmt.Errorf("expected header %q to be empty, but got %q",
+				key, resp.Header.Get(key))
+		}
+		return nil
+	}
+}
+
+func WithExpectedNotHeaders(unexpectedHeaders []string) ResponseCheckFunc {
+	return func(resp *HTTPResponse) error {
+		for _, key := range unexpectedHeaders {
+			if resp.Header.Get(key) != "" {
+				return fmt.Errorf("expected header %q to be empty, but got %q",
+					key, resp.Header.Get(key))
+			}
+		}
+		return nil
+	}
+}
+
 func (s *Scaffold) RequestAssert(r *RequestAssert) bool {
 	if r.Client == nil {
 		r.Client = s.NewAPISIXClient()


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<img width="2666" height="790" alt="image" src="https://github.com/user-attachments/assets/5b0de024-20d9-4848-9ae1-46e361a50d8e" />


In the type definition, they are mandatory. If only add is set, the other two will be empty arrays and empty objects, respectively:

https://github.com/apache/apisix-ingress-controller/blob/ec8624b11d5c71d6904c6f9b292b260794db3e5f/api/adc/types.go#L637-L641

When only one of add, set, or remove is defined, schema validation (e.g., minItems=1) cannot be guaranteed by the data plane.

https://github.com/apache/apisix/blob/9e34661e7edb57fa76a215333b92c6d086e80076/apisix/plugins/response-rewrite.lua#L59-L80




<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
