### PR TITLE
docs: specify namespace in metadata explicitly

### DIFF
--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -63,6 +63,7 @@ The following example demonstrates how to configure an HTTPRoute resource to rou
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"
@@ -72,6 +73,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  namespace: apisix
   name: apisix
   namespace: default
 spec:
@@ -86,6 +88,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   parentRefs:

--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -63,7 +63,7 @@ The following example demonstrates how to configure an HTTPRoute resource to rou
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"
@@ -73,7 +73,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
   namespace: default
 spec:
@@ -88,7 +88,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   parentRefs:

--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -75,7 +75,6 @@ kind: Gateway
 metadata:
   namespace: ingress-apisix
   name: apisix
-  namespace: default
 spec:
   gatewayClassName: apisix
   listeners:

--- a/docs/en/latest/configure.md
+++ b/docs/en/latest/configure.md
@@ -50,6 +50,7 @@ The `controller_name` field is used to identify the `controllerName` in the Gate
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"

--- a/docs/en/latest/configure.md
+++ b/docs/en/latest/configure.md
@@ -50,7 +50,7 @@ The `controller_name` field is used to identify the `controllerName` in the Gate
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"

--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -63,7 +63,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -71,7 +71,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -109,7 +109,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -132,7 +132,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix
@@ -156,7 +156,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -63,6 +63,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -70,6 +71,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -107,6 +109,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -129,6 +132,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix
@@ -152,6 +156,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/key-authentication.md
+++ b/docs/en/latest/getting-started/key-authentication.md
@@ -53,6 +53,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -60,6 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -96,6 +98,7 @@ Create a Kubernetes manifest file to configure a consumer:
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
+  namespace: apisix
   name: tom
 spec:
   gatewayRef:
@@ -113,6 +116,7 @@ Create a Kubernetes manifest file to configure a route and enable key authentica
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -121,6 +125,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
+  namespace: apisix
   name: auth-plugin-config
 spec:
   plugins:
@@ -132,6 +137,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -168,6 +174,7 @@ Create a Kubernetes manifest file to configure a consumer:
 apiVersion: apisix.apache.org/v2
 kind: ApisixConsumer
 metadata:
+  namespace: apisix
   name: tom
 spec:
   ingressClassName: apisix
@@ -183,6 +190,7 @@ Create a Kubernetes manifest file to configure a route and enable key authentica
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   externalNodes:
@@ -192,6 +200,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/key-authentication.md
+++ b/docs/en/latest/getting-started/key-authentication.md
@@ -53,7 +53,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -61,7 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -98,7 +98,7 @@ Create a Kubernetes manifest file to configure a consumer:
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: tom
 spec:
   gatewayRef:
@@ -116,7 +116,7 @@ Create a Kubernetes manifest file to configure a route and enable key authentica
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -125,7 +125,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: auth-plugin-config
 spec:
   plugins:
@@ -137,7 +137,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -174,7 +174,7 @@ Create a Kubernetes manifest file to configure a consumer:
 apiVersion: apisix.apache.org/v2
 kind: ApisixConsumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: tom
 spec:
   ingressClassName: apisix
@@ -190,7 +190,7 @@ Create a Kubernetes manifest file to configure a route and enable key authentica
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   externalNodes:
@@ -200,7 +200,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -53,7 +53,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -61,7 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -98,7 +98,7 @@ values={[
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -107,7 +107,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: mockapi7-external-domain
 spec:
   type: ExternalName
@@ -116,7 +116,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: passhost-node
 spec:
   targetRefs:
@@ -132,7 +132,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: lb-route
 spec:
   parentRefs:
@@ -159,7 +159,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   scheme: https
@@ -173,7 +173,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: mockapi7-external-domain
 spec:
   scheme: https
@@ -187,7 +187,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: lb-route
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -53,6 +53,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -60,6 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -96,6 +98,7 @@ values={[
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -104,6 +107,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: apisix
   name: mockapi7-external-domain
 spec:
   type: ExternalName
@@ -112,6 +116,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
+  namespace: apisix
   name: passhost-node
 spec:
   targetRefs:
@@ -127,6 +132,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: lb-route
 spec:
   parentRefs:
@@ -153,6 +159,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   scheme: https
@@ -166,6 +173,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
+  namespace: apisix
   name: mockapi7-external-domain
 spec:
   scheme: https
@@ -179,6 +187,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: lb-route
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -53,7 +53,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -61,7 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -98,7 +98,7 @@ values={[
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -107,7 +107,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: limit-count-plugin-config
 spec:
   plugins:
@@ -120,7 +120,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -149,7 +149,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   externalNodes:
@@ -159,7 +159,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -53,6 +53,7 @@ If you are using Gateway API, you should first configure the GatewayClass and Ga
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: apisix.apache.org/apisix-ingress-controller
@@ -60,6 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -96,6 +98,7 @@ values={[
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -104,6 +107,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
+  namespace: apisix
   name: limit-count-plugin-config
 spec:
   plugins:
@@ -116,6 +120,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -144,6 +149,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   externalNodes:
@@ -153,6 +159,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -19,6 +19,7 @@ To update the Control Plane endpoint and admin key for connectivity between APIS
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-config
   namespace: apisix-ingress
 spec:
@@ -52,6 +53,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"
@@ -59,6 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -81,6 +84,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controller: apisix.apache.org/apisix-ingress-controller
@@ -100,6 +104,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controller: apisix.apache.org/apisix-ingress-controller
@@ -134,6 +139,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   parentRefs:
@@ -156,6 +162,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -179,6 +186,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -215,6 +223,7 @@ values={[
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -223,6 +232,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: get-ip
 spec:
   parentRefs:
@@ -245,6 +255,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -253,6 +264,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  namespace: apisix
   name: get-ip
 spec:
   rules:
@@ -275,6 +287,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
+  namespace: apisix
   name: httpbin-external-domain
 spec:
   externalNodes:
@@ -284,6 +297,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: get-ip
 spec:
   ingressClassName: apisix
@@ -318,6 +332,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   parentRefs:
@@ -344,6 +359,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -385,6 +401,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   targetRefs:
@@ -411,6 +428,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -448,6 +466,7 @@ To create a consumer and configure the authentication credentials directly on th
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
+  namespace: apisix
   name: alice
 spec:
   gatewayRef:
@@ -465,6 +484,7 @@ You can also use the secret CRD, where the credential should be base64 encoded:
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: apisix
   name: key-auth-primary
 data:
   key: YWxpY2UtcHJpbWFyeS1rZXk=
@@ -472,6 +492,7 @@ data:
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
+  namespace: apisix
   name: alice
 spec:
   gatewayRef:
@@ -493,6 +514,7 @@ To create a consumer and configure the authentication credentials directly on th
 apiVersion: apisix.apache.org/v2
 kind: ApisixConsumer
 metadata:
+  namespace: apisix
   name: alice
 spec:
   ingressClassName: apisix
@@ -508,6 +530,7 @@ You can also use the secret CRD, where the credential should be base64 encoded:
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: apisix
   name: key-auth-primary
 data:
   key: YWxpY2UtcHJpbWFyeS1rZXk=
@@ -515,6 +538,7 @@ data:
 apiVersion: apisix.apache.org/v2
 kind: ApisixConsumer
 metadata:
+  namespace: apisix
   name: alice
 spec:
   ingressClassName: apisix
@@ -546,6 +570,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
+  namespace: apisix
   name: alice
 spec:
   gatewayRef:
@@ -597,6 +622,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
+  namespace: apisix
   name: http-route-policy
 spec:
   targetRefs:
@@ -621,6 +647,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -667,6 +694,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
+  namespace: apisix
   name: auth-plugin-config
 spec:
   plugins:
@@ -678,6 +706,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: get-ip
 spec:
   parentRefs:
@@ -708,6 +737,7 @@ To enable `basic-auth`, `key-auth`, `wolf-rbac`, `jwt-auth`, `ldap-auth`, or `hm
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: get-ip
 spec:
   ingressClassName: apisix
@@ -730,6 +760,7 @@ To enable other plugins:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: get-ip
 spec:
   ingressClassName: apisix
@@ -772,6 +803,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-config
 spec:
   plugins:
@@ -792,6 +824,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixGlobalRule
 metadata:
+  namespace: apisix
   name: apisix-global-rule-logging
 spec:
   ingressClassName: apisix
@@ -828,6 +861,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-config
 spec:
   pluginMetadata:
@@ -882,6 +916,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
+  namespace: apisix
   name: example-plugin-config
 spec:
   plugins:
@@ -895,6 +930,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   parentRefs:
@@ -923,6 +959,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixPluginConfig
 metadata:
+  namespace: apisix
   name: example-plugin-config
 spec:
   ingressClassName: apisix
@@ -937,6 +974,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
+  namespace: apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -976,6 +1014,7 @@ To configure the `statusAddress`:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-config
 spec:
   statusAddress:
@@ -994,6 +1033,7 @@ To configure the `statusAddress`:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-config
 spec:
   statusAddress:
@@ -1006,6 +1046,7 @@ To configure the `publishService`:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-config
 spec:
   publishService: apisix-ee-3-gateway-gateway

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -19,9 +19,9 @@ To update the Control Plane endpoint and admin key for connectivity between APIS
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-config
-  namespace: apisix-ingress
+  namespace: ingress-apisix-ingress
 spec:
   provider:
     type: ControlPlane
@@ -53,7 +53,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"
@@ -61,7 +61,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   gatewayClassName: apisix
@@ -84,7 +84,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controller: apisix.apache.org/apisix-ingress-controller
@@ -92,7 +92,7 @@ spec:
     apiGroup: apisix.apache.org
     kind: GatewayProxy
     name: apisix-config
-    namespace: apisix-ingress
+    namespace: ingress-apisix-ingress
     scope: Namespace
 ```
 
@@ -104,7 +104,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controller: apisix.apache.org/apisix-ingress-controller
@@ -112,7 +112,7 @@ spec:
     apiGroup: apisix.apache.org
     kind: GatewayProxy
     name: apisix-config
-    namespace: apisix-ingress
+    namespace: ingress-apisix-ingress
     scope: Namespace
 ```
 
@@ -139,7 +139,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   parentRefs:
@@ -162,7 +162,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -186,7 +186,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -223,7 +223,7 @@ values={[
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -232,7 +232,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: get-ip
 spec:
   parentRefs:
@@ -255,7 +255,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   type: ExternalName
@@ -264,7 +264,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: get-ip
 spec:
   rules:
@@ -287,7 +287,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
   externalNodes:
@@ -297,7 +297,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: get-ip
 spec:
   ingressClassName: apisix
@@ -332,7 +332,7 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   parentRefs:
@@ -359,7 +359,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -401,7 +401,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   targetRefs:
@@ -428,7 +428,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixUpstream
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -466,7 +466,7 @@ To create a consumer and configure the authentication credentials directly on th
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: alice
 spec:
   gatewayRef:
@@ -484,7 +484,7 @@ You can also use the secret CRD, where the credential should be base64 encoded:
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: key-auth-primary
 data:
   key: YWxpY2UtcHJpbWFyeS1rZXk=
@@ -492,7 +492,7 @@ data:
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: alice
 spec:
   gatewayRef:
@@ -514,7 +514,7 @@ To create a consumer and configure the authentication credentials directly on th
 apiVersion: apisix.apache.org/v2
 kind: ApisixConsumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: alice
 spec:
   ingressClassName: apisix
@@ -530,7 +530,7 @@ You can also use the secret CRD, where the credential should be base64 encoded:
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: key-auth-primary
 data:
   key: YWxpY2UtcHJpbWFyeS1rZXk=
@@ -538,7 +538,7 @@ data:
 apiVersion: apisix.apache.org/v2
 kind: ApisixConsumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: alice
 spec:
   ingressClassName: apisix
@@ -570,7 +570,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: alice
 spec:
   gatewayRef:
@@ -622,7 +622,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: http-route-policy
 spec:
   targetRefs:
@@ -647,7 +647,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -694,7 +694,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: auth-plugin-config
 spec:
   plugins:
@@ -706,7 +706,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: get-ip
 spec:
   parentRefs:
@@ -737,7 +737,7 @@ To enable `basic-auth`, `key-auth`, `wolf-rbac`, `jwt-auth`, `ldap-auth`, or `hm
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: get-ip
 spec:
   ingressClassName: apisix
@@ -760,7 +760,7 @@ To enable other plugins:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: get-ip
 spec:
   ingressClassName: apisix
@@ -803,7 +803,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-config
 spec:
   plugins:
@@ -824,7 +824,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixGlobalRule
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-global-rule-logging
 spec:
   ingressClassName: apisix
@@ -861,7 +861,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-config
 spec:
   pluginMetadata:
@@ -916,7 +916,7 @@ values={[
 apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: example-plugin-config
 spec:
   plugins:
@@ -930,7 +930,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   parentRefs:
@@ -959,7 +959,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixPluginConfig
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: example-plugin-config
 spec:
   ingressClassName: apisix
@@ -974,7 +974,7 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: httpbin
 spec:
   ingressClassName: apisix
@@ -1014,7 +1014,7 @@ To configure the `statusAddress`:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-config
 spec:
   statusAddress:
@@ -1033,7 +1033,7 @@ To configure the `statusAddress`:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-config
 spec:
   statusAddress:
@@ -1046,7 +1046,7 @@ To configure the `publishService`:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-config
 spec:
   publishService: apisix-ee-3-gateway-gateway

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -21,7 +21,7 @@ kind: GatewayProxy
 metadata:
   namespace: ingress-apisix
   name: apisix-config
-  namespace: ingress-apisix-ingress
+  namespace: ingress-apisix
 spec:
   provider:
     type: ControlPlane
@@ -92,7 +92,7 @@ spec:
     apiGroup: apisix.apache.org
     kind: GatewayProxy
     name: apisix-config
-    namespace: ingress-apisix-ingress
+    namespace: ingress-apisix
     scope: Namespace
 ```
 
@@ -112,7 +112,7 @@ spec:
     apiGroup: apisix.apache.org
     kind: GatewayProxy
     name: apisix-config
-    namespace: ingress-apisix-ingress
+    namespace: ingress-apisix
     scope: Namespace
 ```
 

--- a/docs/en/latest/upgrade-guide.md
+++ b/docs/en/latest/upgrade-guide.md
@@ -108,6 +108,7 @@ From version 2.0.0, the data plane must be connected via the `GatewayProxy` CRD:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
+  namespace: apisix
   name: apisix
 spec:
   controller: "apisix.apache.org/apisix-ingress-controller"
@@ -121,8 +122,8 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
+  namespace: apisix
   name: apisix-proxy-config
-  namespace: default
 spec:
   provider:
     type: ControlPlane

--- a/docs/en/latest/upgrade-guide.md
+++ b/docs/en/latest/upgrade-guide.md
@@ -108,7 +108,7 @@ From version 2.0.0, the data plane must be connected via the `GatewayProxy` CRD:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix
 spec:
   controller: "apisix.apache.org/apisix-ingress-controller"
@@ -122,7 +122,7 @@ spec:
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
-  namespace: apisix
+  namespace: ingress-apisix
   name: apisix-proxy-config
 spec:
   provider:


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

Currently the doc explicitly sets the preferred namespace with `kubectl config set-context --current --namespace=ingress-apisix` and leaves out the namespace specification in manifest file. However if users did not read the docs sequentially and set the preferred namespace, resources could be applied to the wrong namespace, leading to downstream issues.

This PR explicitly sets namespace in metadata.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
