### PR TITLE
fix(conformance-test): HTTPRouteRewriteHost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ GO_LDFLAGS ?= "-X=$(VERSYM)=$(VERSION) -X=$(GITSHASYM)=$(GITSHA) -X=$(BUILDOSSYM
 # gateway-api
 GATEAY_API_VERSION ?= v1.3.0
 ## https://github.com/kubernetes-sigs/gateway-api/blob/v1.3.0/pkg/features/httproute.go
-SUPPORTED_EXTENDED_FEATURES = "HTTPRouteDestinationPortMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteRequestMirror,HTTPRouteSchemeRedirect,GatewayAddressEmpty,HTTPRouteResponseHeaderModification,GatewayPort8080"
+SUPPORTED_EXTENDED_FEATURES = "HTTPRouteDestinationPortMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteRequestMirror,HTTPRouteSchemeRedirect,GatewayAddressEmpty,HTTPRouteResponseHeaderModification,GatewayPort8080,HTTPRouteHostRewrite"
 CONFORMANCE_TEST_REPORT_OUTPUT ?= $(DIR)/apisix-ingress-controller-conformance-report.yaml
 ## https://github.com/kubernetes-sigs/gateway-api/blob/v1.3.0/conformance/utils/suite/profiles.go
 CONFORMANCE_PROFILES ?= GATEWAY-HTTP,GATEWAY-GRPC

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -179,17 +179,19 @@ func (t *Translator) fillPluginFromHTTPRequestHeaderFilter(plugins adctypes.Plug
 	obj := plugins[pluginName]
 	var plugin *adctypes.RewriteConfig
 	if obj == nil {
-		plugin = &adctypes.RewriteConfig{
-			Headers: &adctypes.Headers{
-				Add:    make(map[string]string, len(reqHeaderModifier.Add)),
-				Set:    make(map[string]string, len(reqHeaderModifier.Set)),
-				Remove: make([]string, 0, len(reqHeaderModifier.Remove)),
-			},
-		}
+		plugin = &adctypes.RewriteConfig{}
 		plugins[pluginName] = plugin
 	} else {
 		plugin = obj.(*adctypes.RewriteConfig)
 	}
+	if plugin.Headers == nil {
+		plugin.Headers = &adctypes.Headers{
+			Add:    make(map[string]string, len(reqHeaderModifier.Add)),
+			Set:    make(map[string]string, len(reqHeaderModifier.Set)),
+			Remove: make([]string, 0, len(reqHeaderModifier.Remove)),
+		}
+	}
+
 	for _, header := range reqHeaderModifier.Add {
 		val := plugin.Headers.Add[string(header.Name)]
 		if val != "" {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

The RewriteConfig plugin will be shared by multiple filters, resulting in headers not being initialized and causing panic.

```log
{"controller": "httproute", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "HTTPRoute", "HTTPRoute": {"name":"rewrite-host","namespace":"gateway-conformance-infra"}, "namespace": "gateway-conformance-infra", "name": "rewrite-host", "reconcileID": "7f56d988-738f-4f3c-b697-dc8c8c8119bd", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 998 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x254dcf8, 0xc000ef3ad0}, {0x1e93ea0, 0x378c500})
    /Users/rong/go/pkg/mod/k8s.io/apimachinery@v0.32.3/pkg/util/runtime/runtime.go:107 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
    /Users/rong/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:108 +0x112
panic({0x1e93ea0?, 0x378c500?})
    /usr/local/Cellar/go/1.24.5/libexec/src/runtime/panic.go:792 +0x132
github.com/apache/apisix-ingress-controller/internal/adc/translator.(*Translator).fillPluginFromHTTPRequestHeaderFilter(0x8?, 0xc000e3a690, 0xc0001ca050)
    /Users/rong/workspace/apisix-ingress-controller/internal/adc/translator/httproute.go:194 +0x232
github.com/apache/apisix-ingress-controller/internal/adc/translator.(*Translator).fillPluginsFromHTTPRouteFilters(0xc00000f488, 0xc000e3a690, {0xc0011a60e0, 0x19}, {0xc0009f18c0?, 0xc00063fe88?, 0xc00063fe88?}, {0xc000459dc0, 0x1, 0x1}, ...)
    /Users/rong/workspace/apisix-ingress-controller/internal/adc/translator/httproute.go:51 +0x451
github.com/apache/apisix-ingress-controller/internal/adc/translator.(*Translator).TranslateHTTPRoute(0xc00000f488, 0xc000e12240, 0xc000da9980)
    /Users/rong/workspace/apisix-ingress-controller/internal/adc/translator/httproute.go:638 +0x978
github.com/apache/apisix-ingress-controller/internal/provider/apisix.(*apisixProvider).Update(0xc000749e60, {0xc0007d81e0?, 0x19?}, 0xc000e12240, {0x25769e8, 0xc000da9680})
    /Users/rong/workspace/apisix-ingress-controller/internal/provider/apisix/provider.go:111 +0xe97
github.com/apache/apisix-ingress-controller/internal/controller.(*HTTPRouteReconciler).Reconcile(0xc0004a3110, {0x254dcf8, 0xc000ef3ad0}, {{{0xc001098f80?, 0x21c9778?}, {0xc000d723c0?, 0x100?}}})
    /Users/rong/workspace/apisix-ingress-controller/internal/controller/httproute_controller.go:254 +0x15bb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc000ef3a40?, {0x254dcf8?, 0xc000ef3ad0?}, {{{0xc001098f80?, 0x0?}, {0xc000d723c0?, 0x0?}}})
    /Users/rong/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119 +0xbf
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x25716c0, {0x254dd30, 0xc0005e4910}, {{{0xc001098f80, 0x19}, {0xc000d723c0, 0xc}}}, 0x0)
    /Users/rong/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334 +0x3ad
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x25716c0, {0x254dd30, 0xc0005e4910})
    /Users/rong/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294 +0x21b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
    /Users/rong/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 358
    /Users/rong/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:251 +0x6b5
"}
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
