### PR TITLE
fix: incorrect parameters in log message

### DIFF
--- a/internal/controller/apisixconsumer_controller.go
+++ b/internal/controller/apisixconsumer_controller.go
@@ -209,10 +209,10 @@ func (r *ApisixConsumerReconciler) processSpec(ctx context.Context, tctx *provid
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, namespacedName, secret); err != nil {
 		if k8serrors.IsNotFound(err) {
-			r.Log.Info("secret not found", "secret", namespacedName.String())
+			r.Log.Info("secret not found", "secret", namespacedName)
 			return nil
 		} else {
-			r.Log.Error(err, "failed to get secret", "secret", namespacedName.String())
+			r.Log.Error(err, "failed to get secret", "secret", namespacedName)
 			return err
 		}
 	}

--- a/internal/controller/apisixroute_controller.go
+++ b/internal/controller/apisixroute_controller.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -399,10 +400,11 @@ func (r *ApisixRouteReconciler) validateHTTPBackend(tctx *provider.TranslateCont
 	)
 
 	if err := r.Get(tctx, serviceNN, &service); err != nil {
-		if err = client.IgnoreNotFound(err); err == nil {
-			r.Log.Error(errors.New("service not found"), "Service", serviceNN)
+		if k8serrors.IsNotFound(err) {
+			r.Log.Info("service not found", "Service", serviceNN)
 			return nil
 		}
+		r.Log.Error(err, "failed to get service", "Service", serviceNN)
 		return err
 	}
 
@@ -426,7 +428,11 @@ func (r *ApisixRouteReconciler) validateHTTPBackend(tctx *provider.TranslateCont
 	}
 
 	if backend.ResolveGranularity == apiv2.ResolveGranularityService && service.Spec.ClusterIP == "" {
-		r.Log.Error(errors.New("service has no ClusterIP"), "Service", serviceNN, "ResolveGranularity", backend.ResolveGranularity)
+		r.Log.Error(errors.New("service has no ClusterIP"),
+			"service missing ClusterIP",
+			"Service", serviceNN,
+			"ResolveGranularity", backend.ResolveGranularity,
+		)
 		return nil
 	}
 
@@ -440,11 +446,11 @@ func (r *ApisixRouteReconciler) validateHTTPBackend(tctx *provider.TranslateCont
 		}
 		return false
 	}) {
-		if backend.ServicePort.Type == intstr.Int {
-			r.Log.Error(errors.New("port not found in service"), "Service", serviceNN, "port", backend.ServicePort.IntValue())
-		} else {
-			r.Log.Error(errors.New("named port not found in service"), "Service", serviceNN, "port", backend.ServicePort.StrVal)
-		}
+		r.Log.Error(errors.New("service port not found"),
+			"failed to match service port",
+			"Service", serviceNN,
+			"ServicePort", backend.ServicePort,
+		)
 		return nil
 	}
 	tctx.Services[serviceNN] = &service

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -408,7 +408,10 @@ func (r *HTTPRouteReconciler) listHTTPRouteByHTTPRoutePolicy(ctx context.Context
 
 		var httpRoute gatewayv1.HTTPRoute
 		if err := r.Get(ctx, key, &httpRoute); err != nil {
-			r.Log.Error(err, "failed to get HTTPRoute by HTTPRoutePolicy targetRef", "namespace", key.Namespace, "name", key.Name)
+			r.Log.Error(errors.New("httproute not found"),
+				"failed to get HTTPRoute rule for HTTPRoutePolicy targetRef",
+				"httproute", key,
+			)
 			continue
 		}
 		if ref.SectionName != nil {
@@ -420,7 +423,11 @@ func (r *HTTPRouteReconciler) listHTTPRouteByHTTPRoutePolicy(ctx context.Context
 				}
 			}
 			if !matchRuleName {
-				r.Log.Error(errors.Errorf("failed to get HTTPRoute rule by HTTPRoutePolicy targetRef"), "namespace", key.Namespace, "name", key.Name, "sectionName", *ref.SectionName)
+				r.Log.Error(errors.New("httproute section name not found"),
+					"failed to get HTTPRoute rule by HTTPRoutePolicy targetRef",
+					"httproute", key,
+					"sectionName", *ref.SectionName,
+				)
 				continue
 			}
 		}


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

log painc:

```log
2025-10-22T03:36:31.153Z	DPANIC	controllers.ApisixRoute	controller/apisixroute_controller.go:437	odd number of arguments passed as key-value pairs for logging	{"ignored key": {"name":"dmp-new-file-service-prod","namespace":"data-platform-dmp"}}
```

Correct parameter list:
```go
func (l logr.Logger) Error(err error, msg string, keysAndValues ...any)
```


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
