### PR TITLE
feat: support auth-type for ingress annotations

### DIFF
--- a/internal/adc/translator/annotations/plugins/authorization.go
+++ b/internal/adc/translator/annotations/plugins/authorization.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
+	"github.com/apache/apisix-ingress-controller/internal/adc/translator/annotations"
+)
+
+type basicAuth struct{}
+
+// NewkeyBasicHandler creates a handler to convert
+// annotations about basicAuth control to APISIX basic-auth plugin.
+func NewBasicAuthHandler() PluginAnnotationsHandler {
+	return &basicAuth{}
+}
+
+func (b *basicAuth) PluginName() string {
+	return "basic-auth"
+}
+
+func (b *basicAuth) Handle(e annotations.Extractor) (interface{}, error) {
+	if e.GetStringAnnotation(annotations.AnnotationsAuthType) != "basicAuth" {
+		return nil, nil
+	}
+	plugin := adctypes.BasicAuthConfig{}
+	return &plugin, nil
+}
+
+type keyAuth struct{}
+
+// NewkeyAuthHandler creates a handler to convert
+// annotations about keyAuth control to APISIX key-auth plugin.
+func NewKeyAuthHandler() PluginAnnotationsHandler {
+	return &keyAuth{}
+}
+
+func (k *keyAuth) PluginName() string {
+	return "key-auth"
+}
+
+func (k *keyAuth) Handle(e annotations.Extractor) (interface{}, error) {
+	if e.GetStringAnnotation(annotations.AnnotationsAuthType) != "keyAuth" {
+		return nil, nil
+	}
+	plugin := adctypes.KeyAuthConfig{}
+	return &plugin, nil
+}

--- a/internal/adc/translator/annotations/plugins/plugins.go
+++ b/internal/adc/translator/annotations/plugins/plugins.go
@@ -40,6 +40,8 @@ var (
 		NewCorsHandler(),
 		NewCSRFHandler(),
 		NewFaultInjectionHandler(),
+		NewBasicAuthHandler(),
+		NewKeyAuthHandler(),
 	}
 )
 

--- a/internal/adc/translator/annotations_test.go
+++ b/internal/adc/translator/annotations_test.go
@@ -257,6 +257,28 @@ func TestTranslateIngressAnnotations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "auth type basicAuth",
+			anno: map[string]string{
+				annotations.AnnotationsAuthType: "basicAuth",
+			},
+			expected: &IngressConfig{
+				Plugins: adctypes.Plugins{
+					"basic-auth": &adctypes.BasicAuthConfig{},
+				},
+			},
+		},
+		{
+			name: "auth type keyAuth",
+			anno: map[string]string{
+				annotations.AnnotationsAuthType: "keyAuth",
+			},
+			expected: &IngressConfig{
+				Plugins: adctypes.Plugins{
+					"key-auth": &adctypes.KeyAuthConfig{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

ingress annotations support:
* k8s.apisix.apache.org/auth-type: "keyAuth"
* k8s.apisix.apache.org/auth-type: "basicAuth"

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
