### PR TITLE
fix: status updater prints the kind of ApisixUpstream as unknown

### DIFF
--- a/internal/types/k8s.go
+++ b/internal/types/k8s.go
@@ -104,6 +104,8 @@ func KindOf(obj any) string {
 		return KindApisixTls
 	case *v2.ApisixConsumer:
 		return KindApisixConsumer
+	case *v2.ApisixUpstream:
+		return KindApisixUpstream
 	case *v1alpha1.HTTPRoutePolicy:
 		return KindHTTPRoutePolicy
 	case *v1alpha1.BackendTrafficPolicy:


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

https://the-asf.slack.com/archives/CUC5MN17A/p1763019082783669

https://github.com/apache/apisix-ingress-controller/blob/master/internal/controller/status/updater.go#L124

The `types.KindOf` function does not include the `ApisixUpstream` type, causing the state updater's logs to print its kind as `Unknown`.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
