### PR TITLE
docs: mismatched namespace example of gatewayproxy

### DIFF
--- a/docs/en/latest/upgrade-guide.md
+++ b/docs/en/latest/upgrade-guide.md
@@ -108,7 +108,6 @@ From version 2.0.0, the data plane must be connected via the `GatewayProxy` CRD:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  namespace: ingress-apisix
   name: apisix
 spec:
   controller: "apisix.apache.org/apisix-ingress-controller"
@@ -116,7 +115,7 @@ spec:
     apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "apisix-proxy-config"
-    namespace: "default"
+    namespace: "ingress-apisix"
     scope: "Namespace"
 ---
 apiVersion: apisix.apache.org/v1alpha1


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

1. IngressClass is cluster-scoped.
2. The GatewayProxy reference points to the wrong namespace.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
3. Test is required for the feat/fix PR, unless you have a good reason
4. Doc is required for the feat PR
5. Use a new commit to resolve review instead of `push -f`
6. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
