### PR TITLE
docs: update plugin metadata APISIX CRD example

### DIFF
--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -916,6 +916,18 @@ values={[
 
 <TabItem value="gateway">
 
+<!-- leave this section empty -->
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+<!-- leave this section empty -->
+
+</TabItem>
+
+</Tabs>
+
 ```yaml
 apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
@@ -951,16 +963,6 @@ spec:
       "set_ngx_var": true
     }
 ```
-
-</TabItem>
-
-<TabItem value="apisix-crd">
-
-Not currently supported.
-
-</TabItem>
-
-</Tabs>
 
 ## Configure Plugin Config
 


### PR DESCRIPTION
### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

The example reference previously said that the configuration of plugin metadata when working with APISIX CRD was not supported - this is incorrect. It can also be configured through GatewayProxy. This PR updates the docs.

Related to https://github.com/apache/apisix-ingress-controller/issues/2685

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
