### PR TITLE
fix: improve annotation extraction by trimming whitespace

### DIFF
--- a/internal/adc/translator/annotations/types.go
+++ b/internal/adc/translator/annotations/types.go
@@ -122,20 +122,33 @@ type extractor struct {
 	annotations map[string]string
 }
 
-func (e *extractor) GetStringAnnotation(name string) string {
-	return e.annotations[name]
+func (ex *extractor) GetStringAnnotation(key string) string {
+	return strings.TrimSpace(ex.annotations[key])
 }
 
-func (e *extractor) GetStringsAnnotation(name string) []string {
-	value := e.GetStringAnnotation(name)
-	if value == "" {
+func (ex *extractor) GetStringsAnnotation(key string) []string {
+	raw := ex.GetStringAnnotation(key)
+	if raw == "" {
 		return nil
 	}
-	return strings.Split(value, ",")
+	items := strings.Split(raw, ",")
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		trimmedItem := strings.TrimSpace(item)
+		if trimmedItem == "" {
+			continue
+		}
+		result = append(result, trimmedItem)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
-func (e *extractor) GetBoolAnnotation(name string) bool {
-	return e.annotations[name] == "true"
+func (ex *extractor) GetBoolAnnotation(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(ex.annotations[key]))
+	return normalized == "true"
 }
 
 // NewExtractor creates an annotation extractor.


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] Bugfix
- [x] Refactor
- [x] Chore

### What this PR does / why we need it:

Fixes: #2723

Currently, annotations that accept comma-separated lists (such as whitelist-source-range and blacklist-source-range) are not trimmed, so any spaces after commas are preserved. This results in IP entries starting with a space, which breaks the whitelist and blacklist functionality.

This PR trims whitespace from each annotation item before processing, ensuring that spaces after commas do not cause parsing errors.

Behavior Before / After:

Aspect: Annotation parsing
Before: "1.2.3.4, 5.6.7.8" -> ["1.2.3.4", " 5.6.7.8"]
After:  "1.2.3.4, 5.6.7.8" -> ["1.2.3.4", "5.6.7.8"]

Aspect: Whitelist/Blacklist enforcement
Before: Fails for entries with leading spaces
After:  Works correctly for all entries

### Related issues, if any:

- #2723

### Pre-submission checklist:

- [x] Did you explain what problem this PR solves? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? If it is not backward compatible, please discuss on the mailing list first