### PR TITLE
fix: wire readiness manager into ApisixPluginConfig and ApisixUpstream controllers

### DIFF
--- a/internal/controller/apisixpluginconfig_controller.go
+++ b/internal/controller/apisixpluginconfig_controller.go
@@ -29,6 +29,7 @@ import (
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -39,6 +40,7 @@ type ApisixPluginConfigReconciler struct {
 	Scheme  *runtime.Scheme
 	Log     logr.Logger
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -51,6 +53,7 @@ func (r *ApisixPluginConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 func (r *ApisixPluginConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer r.Readier.Done(&apiv2.ApisixPluginConfig{}, req.NamespacedName)
 	var pc apiv2.ApisixPluginConfig
 	if err := r.Get(ctx, req.NamespacedName, &pc); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controller/apisixupstream_controller.go
+++ b/internal/controller/apisixupstream_controller.go
@@ -28,6 +28,7 @@ import (
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -38,6 +39,7 @@ type ApisixUpstreamReconciler struct {
 	Scheme  *runtime.Scheme
 	Log     logr.Logger
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -50,6 +52,7 @@ func (r *ApisixUpstreamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ApisixUpstreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer r.Readier.Done(&apiv2.ApisixUpstream{}, req.NamespacedName)
 	var au apiv2.ApisixUpstream
 	if err := r.Get(ctx, req.NamespacedName, &au); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -269,6 +269,7 @@ func setupAPIv2Controllers(ctx context.Context, mgr manager.Manager, pro provide
 			Scheme:  mgr.GetScheme(),
 			Log:     ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindApisixPluginConfig),
 			Updater: updater,
+			Readier: readier,
 		},
 		&apiv2.ApisixTls{}: &controller.ApisixTlsReconciler{
 			Client:   mgr.GetClient(),
@@ -283,6 +284,7 @@ func setupAPIv2Controllers(ctx context.Context, mgr manager.Manager, pro provide
 			Scheme:  mgr.GetScheme(),
 			Log:     ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindApisixUpstream),
 			Updater: updater,
+			Readier: readier,
 		},
 	} {
 		if utils.HasAPIResource(mgr, resource) {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Fixes #2725

`ApisixPluginConfig` and `ApisixUpstream` controllers were missing the `Readier` field and never called `Done()` on the readiness manager. This caused the provider to always wait the full 5-minute hardcoded timeout before starting the sync loop on every restart.

**Root cause:** When `registerAPIv2ForReadiness()` registers these CRD types with the readiness manager, it adds all existing resources to a pending state. The `ApisixRouteReconciler` correctly calls `defer r.Readier.Done()` in its `Reconcile()` to mark resources as done, but `ApisixPluginConfigReconciler` and `ApisixUpstreamReconciler` were never wired up with the readiness manager — missing both the struct field and the `Done()` call.

**Fix:**
- Add `Readier readiness.ReadinessManager` field to both controller structs
- Add `defer r.Readier.Done()` at the start of both `Reconcile()` methods
- Pass `Readier: readier` when initializing both controllers in `controllers.go`

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**