### PR TITLE
docs: remove redundant namespace from HTTPRoute, Ingress, and ApisixRoute examples in configure-routes.md

### DIFF
--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -134,7 +134,6 @@ values={[
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   parentRefs:
@@ -157,7 +156,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix
@@ -181,7 +179,6 @@ spec:
 apiVersion: apisix.apache.org/v2
 kind: ApisixRoute
 metadata:
-  namespace: ingress-apisix
   name: getting-started-ip
 spec:
   ingressClassName: apisix


### PR DESCRIPTION


<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This pull request makes minor updates to the documentation in `docs/en/latest/getting-started/configure-routes.md` by removing the `namespace: ingress-apisix` field from several Kubernetes resource examples. 
https://github.com/apache/apisix-ingress-controller/blob/878e5015bda978cb2f4231511c835420d8769a2f/examples/httpbin/deployment.yaml#L60-L63

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
