### PR TITLE
fix: use https_verify_certificate for standalone active health checks

### DIFF
--- a/api/adc/types.go
+++ b/api/adc/types.go
@@ -198,16 +198,16 @@ type ClientTLS struct {
 // UpstreamActiveHealthCheck defines the active upstream health check configuration.
 // +k8s:deepcopy-gen=true
 type UpstreamActiveHealthCheck struct {
-	Type               string                             `json:"type,omitempty" yaml:"type,omitempty"`
-	Timeout            int                                `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	Concurrency        int                                `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`
-	Host               string                             `json:"host,omitempty" yaml:"host,omitempty"`
-	Port               int32                              `json:"port,omitempty" yaml:"port,omitempty"`
-	HTTPPath           string                             `json:"http_path,omitempty" yaml:"http_path,omitempty"`
-	HTTPSVerifyCert    bool                               `json:"https_verify_cert,omitempty" yaml:"https_verify_cert,omitempty"`
-	HTTPRequestHeaders []string                           `json:"req_headers,omitempty" yaml:"req_headers,omitempty"`
-	Healthy            UpstreamActiveHealthCheckHealthy   `json:"healthy,omitempty" yaml:"healthy,omitempty"`
-	Unhealthy          UpstreamActiveHealthCheckUnhealthy `json:"unhealthy,omitempty" yaml:"unhealthy,omitempty"`
+	Type                   string                             `json:"type,omitempty" yaml:"type,omitempty"`
+	Timeout                int                                `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Concurrency            int                                `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`
+	Host                   string                             `json:"host,omitempty" yaml:"host,omitempty"`
+	Port                   int32                              `json:"port,omitempty" yaml:"port,omitempty"`
+	HTTPPath               string                             `json:"http_path,omitempty" yaml:"http_path,omitempty"`
+	HTTPSVerifyCertificate bool                               `json:"https_verify_certificate,omitempty" yaml:"https_verify_certificate,omitempty"`
+	HTTPRequestHeaders     []string                           `json:"req_headers,omitempty" yaml:"req_headers,omitempty"`
+	Healthy                UpstreamActiveHealthCheckHealthy   `json:"healthy,omitempty" yaml:"healthy,omitempty"`
+	Unhealthy              UpstreamActiveHealthCheckUnhealthy `json:"unhealthy,omitempty" yaml:"unhealthy,omitempty"`
 }
 
 // UpstreamPassiveHealthCheck defines the passive health check configuration for an upstream.

--- a/internal/adc/translator/apisixupstream.go
+++ b/internal/adc/translator/apisixupstream.go
@@ -323,7 +323,7 @@ func translateUpstreamActiveHealthCheck(config *apiv2.ActiveHealthCheck) (*adc.U
 	active.HTTPRequestHeaders = config.RequestHeaders
 
 	if config.StrictTLS == nil || *config.StrictTLS {
-		active.HTTPSVerifyCert = true
+		active.HTTPSVerifyCertificate = true
 	}
 
 	if config.Healthy != nil {


### PR DESCRIPTION
## Summary
- rename the active health check verify field sent by the ingress controller to `https_verify_certificate`
- align the standalone payload with the schema change from api7/adc#438

## Why
The standalone dataplane rejects `https_verify_cert` in active health checks, which prevents the generated service config from syncing and leaves the upstream list empty in the affected e2e case.