### PR TITLE
feat: support consumer labels from metadata labels

### DIFF
--- a/internal/adc/translator/apisixconsumer.go
+++ b/internal/adc/translator/apisixconsumer.go
@@ -98,7 +98,7 @@ func (t *Translator) TranslateApisixConsumer(tctx *provider.TranslateContext, ac
 		Username: username,
 	}
 	consumer.Plugins = plugins
-	consumer.Labels = label.GenLabel(ac)
+	consumer.Labels = label.GenLabelWithObjectLabels(ac)
 	result.Consumers = append(result.Consumers, consumer)
 	return result, nil
 }

--- a/internal/adc/translator/apisixconsumer_test.go
+++ b/internal/adc/translator/apisixconsumer_test.go
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	"github.com/apache/apisix-ingress-controller/internal/controller/label"
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+func TestTranslateApisixConsumer_UsesMetadataLabelsWithoutOverwritingControllerLabels(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+	tctx := provider.NewDefaultTranslateContext(context.Background())
+
+	consumer := &apiv2.ApisixConsumer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ApisixConsumer",
+			APIVersion: apiv2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			Labels: map[string]string{
+				"team":               "payments",
+				label.LabelName:      "user-value",
+				label.LabelManagedBy: "user-manager",
+			},
+		},
+		Spec: apiv2.ApisixConsumerSpec{
+			AuthParameter: apiv2.ApisixConsumerAuthParameter{
+				BasicAuth: &apiv2.ApisixConsumerBasicAuth{
+					Value: &apiv2.ApisixConsumerBasicAuthValue{
+						Username: "demo",
+						Password: "secret",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := translator.TranslateApisixConsumer(tctx, consumer)
+	require.NoError(t, err)
+	require.Len(t, result.Consumers, 1)
+
+	translated := result.Consumers[0]
+	require.Equal(t, "payments", translated.Labels["team"])
+	require.Equal(t, consumer.Name, translated.Labels[label.LabelName])
+	require.Equal(t, "apisix-ingress-controller", translated.Labels[label.LabelManagedBy])
+}

--- a/internal/adc/translator/apisixroute.go
+++ b/internal/adc/translator/apisixroute.go
@@ -184,7 +184,7 @@ func (t *Translator) buildRoute(ar *apiv2.ApisixRoute, service *adc.Service, rul
 	route.Name = adc.ComposeRouteName(ar.Namespace, ar.Name, rule.Name)
 	route.ID = id.GenID(route.Name)
 	route.Desc = "Created by apisix-ingress-controller, DO NOT modify it manually"
-	route.Labels = label.GenLabel(ar)
+	route.Labels = label.GenLabelWithObjectLabels(ar)
 	route.EnableWebsocket = rule.Websocket
 	if route.EnableWebsocket == nil && *enableWebsocket != nil {
 		route.EnableWebsocket = *enableWebsocket
@@ -197,9 +197,6 @@ func (t *Translator) buildRoute(ar *apiv2.ApisixRoute, service *adc.Service, rul
 	route.Timeout = timeout
 	route.Uris = rule.Match.Paths
 	route.Vars = vars
-	for key, value := range ar.GetObjectMeta().GetLabels() {
-		route.Labels[key] = value
-	}
 
 	service.Routes = []*adc.Route{route}
 }

--- a/internal/adc/translator/apisixroute_test.go
+++ b/internal/adc/translator/apisixroute_test.go
@@ -82,3 +82,42 @@ func TestBuildService_HostsSet(t *testing.T) {
 	// service.Hosts SHOULD be set — this is the canonical location for hosts.
 	assert.Equal(t, []string{"example.com", "foo.com"}, service.Hosts)
 }
+
+func TestBuildRoute_MetadataLabelsDoNotOverwriteControllerLabels(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+
+	ar := &apiv2.ApisixRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ApisixRoute",
+			APIVersion: apiv2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+			Labels: map[string]string{
+				"team":          "payments",
+				"k8s/name":      "user-value",
+				"manager-by":    "user-manager",
+				"k8s/namespace": "user-namespace",
+			},
+		},
+	}
+
+	service := &adc.Service{}
+	rule := apiv2.ApisixRouteHTTP{
+		Name: "rule1",
+		Match: apiv2.ApisixRouteHTTPMatch{
+			Paths: []string{"/api/*"},
+		},
+	}
+
+	var enableWebsocket *bool
+	translator.buildRoute(ar, service, rule, nil, nil, nil, &enableWebsocket)
+
+	assert.Len(t, service.Routes, 1)
+	route := service.Routes[0]
+	assert.Equal(t, "payments", route.Labels["team"])
+	assert.Equal(t, ar.Name, route.Labels["k8s/name"])
+	assert.Equal(t, ar.Namespace, route.Labels["k8s/namespace"])
+	assert.Equal(t, "apisix-ingress-controller", route.Labels["manager-by"])
+}

--- a/internal/adc/translator/consumer.go
+++ b/internal/adc/translator/consumer.go
@@ -71,7 +71,7 @@ func (t *Translator) TranslateConsumerV1alpha1(tctx *provider.TranslateContext, 
 		credentials = append(credentials, credential)
 	}
 	consumer.Credentials = credentials
-	consumer.Labels = label.GenLabel(consumerV)
+	consumer.Labels = label.GenLabelWithObjectLabels(consumerV)
 	plugins := adctypes.Plugins{}
 	for _, plugin := range consumerV.Spec.Plugins {
 		pluginName := plugin.Name

--- a/internal/adc/translator/consumer_test.go
+++ b/internal/adc/translator/consumer_test.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
+	"github.com/apache/apisix-ingress-controller/internal/controller/label"
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+func TestTranslateConsumerV1alpha1_UsesMetadataLabelsWithoutOverwritingControllerLabels(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+	tctx := provider.NewDefaultTranslateContext(context.Background())
+
+	consumer := &v1alpha1.Consumer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Consumer",
+			APIVersion: v1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			Labels: map[string]string{
+				"team":               "payments",
+				label.LabelName:      "user-value",
+				label.LabelManagedBy: "user-manager",
+			},
+		},
+	}
+
+	result, err := translator.TranslateConsumerV1alpha1(tctx, consumer)
+	require.NoError(t, err)
+	require.Len(t, result.Consumers, 1)
+
+	translated := result.Consumers[0]
+	require.Equal(t, "payments", translated.Labels["team"])
+	require.Equal(t, consumer.Name, translated.Labels[label.LabelName])
+	require.Equal(t, "apisix-ingress-controller", translated.Labels[label.LabelManagedBy])
+}

--- a/internal/controller/label/label.go
+++ b/internal/controller/label/label.go
@@ -40,7 +40,7 @@ func GenLabel(client client.Object, args ...string) Label {
 	label[LabelName] = client.GetName()
 	label[LabelControllerName] = config.ControllerConfig.ControllerName
 	label[LabelManagedBy] = "apisix-ingress-controller"
-	for i := 0; i < len(args); i += 2 {
+	for i := 0; i+1 < len(args); i += 2 {
 		label[args[i]] = args[i+1]
 	}
 	return label

--- a/internal/controller/label/label.go
+++ b/internal/controller/label/label.go
@@ -45,3 +45,14 @@ func GenLabel(client client.Object, args ...string) Label {
 	}
 	return label
 }
+
+func GenLabelWithObjectLabels(obj client.Object, args ...string) Label {
+	label := make(Label)
+	for key, value := range obj.GetLabels() {
+		label[key] = value
+	}
+	for key, value := range GenLabel(obj, args...) {
+		label[key] = value
+	}
+	return label
+}

--- a/internal/controller/label/label_test.go
+++ b/internal/controller/label/label_test.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package label
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	"github.com/apache/apisix-ingress-controller/internal/controller/config"
+)
+
+func TestGenLabelWithObjectLabels(t *testing.T) {
+	consumer := &apiv2.ApisixConsumer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ApisixConsumer",
+			APIVersion: apiv2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			Labels: map[string]string{
+				"team":              "payments",
+				LabelName:           "user-value",
+				LabelManagedBy:      "user-manager",
+				LabelNamespace:      "user-namespace",
+				LabelControllerName: "user-controller",
+				LabelKind:           "user-kind",
+			},
+		},
+	}
+
+	labels := GenLabelWithObjectLabels(consumer)
+
+	require.Equal(t, "payments", labels["team"])
+	require.Equal(t, consumer.Name, labels[LabelName])
+	require.Equal(t, consumer.Namespace, labels[LabelNamespace])
+	require.Equal(t, "ApisixConsumer", labels[LabelKind])
+	require.Equal(t, config.ControllerConfig.ControllerName, labels[LabelControllerName])
+	require.Equal(t, "apisix-ingress-controller", labels[LabelManagedBy])
+}

--- a/internal/controller/label/label_test.go
+++ b/internal/controller/label/label_test.go
@@ -56,3 +56,21 @@ func TestGenLabelWithObjectLabels(t *testing.T) {
 	require.Equal(t, config.ControllerConfig.ControllerName, labels[LabelControllerName])
 	require.Equal(t, "apisix-ingress-controller", labels[LabelManagedBy])
 }
+
+func TestGenLabel_IgnoresDanglingKeyArg(t *testing.T) {
+	consumer := &apiv2.ApisixConsumer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ApisixConsumer",
+			APIVersion: apiv2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+		},
+	}
+
+	labels := GenLabel(consumer, "team", "payments", "dangling")
+
+	require.Equal(t, "payments", labels["team"])
+	require.NotContains(t, labels, "dangling")
+}


### PR DESCRIPTION
## Summary
- reuse `ApisixConsumer.metadata.labels` and `Consumer.metadata.labels` as consumer labels
- add a shared label helper so controller-generated labels always win on conflicts
- align `ApisixRoute` with the same merge behavior and add coverage

## Consumer labels
This change is mainly for propagating CRD labels into data plane resource labels.

Both `ApisixConsumer.metadata.labels` and `Consumer.metadata.labels` are propagated to the generated APISIX consumer as custom labels, so users can inject business metadata such as tenant, team, or plan from the Kubernetes CRD into the data plane resource.

If a user-defined label key conflicts with a controller-generated reserved label, the controller-generated value is preserved.

### ApisixConsumer CRD example
```yaml
apiVersion: apisix.apache.org/v2
kind: ApisixConsumer
metadata:
  namespace: ingress-apisix
  name: alice
  labels:
    team: payments
    plan: gold
spec:
  ingressClassName: apisix
  authParameter:
    keyAuth:
      value:
        key: alice-primary-key
```

### Consumer CRD example
```yaml
apiVersion: apisix.apache.org/v1alpha1
kind: Consumer
metadata:
  namespace: ingress-apisix
  name: bob
  labels:
    team: platform
    tenant: internal
spec:
  gatewayRef:
    name: apisix
  credentials:
  - type: key-auth
    name: bob-key
    config:
      key: bob-primary-key
```

### Data plane result example
The generated APISIX consumer will carry the injected labels together with controller-managed labels, for example:

```json
{
  "username": "ingress-apisix_alice",
  "labels": {
    "team": "payments",
    "plan": "gold",
    "k8s/name": "alice",
    "k8s/namespace": "ingress-apisix",
    "k8s/kind": "ApisixConsumer",
    "k8s/controller-name": "apisix.apache.org/apisix-ingress-controller",
    "manager-by": "apisix-ingress-controller"
  }
}
```

The same merge behavior also applies to `Consumer` resources, so labels defined on either CRD can be consumed directly on the data plane side.

## Testing
- `go test ./internal/controller/label ./internal/adc/translator`
- `go test $(go list ./... | grep -v /e2e | grep -v /conformance)` *(the benchmark package still requires a live Kubernetes endpoint in this environment)*