### PR TITLE
feat: add Body scope to ApisixRoute match expressions for request body matching

### DIFF
--- a/api/v2/apisixconsumer_validation_test.go
+++ b/api/v2/apisixconsumer_validation_test.go
@@ -16,93 +16,22 @@
 package v2_test
 
 import (
-	"context"
-	"encoding/json"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
-	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
-	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
-	celconfig "k8s.io/apiserver/pkg/apis/cel"
-	sigsyaml "sigs.k8s.io/yaml"
 
 	apisixv2 "github.com/apache/apisix-ingress-controller/api/v2"
 )
 
-// consumerSchemaValidator holds the parsed CRD schema for ApisixConsumer
-// and provides a Validate method for use in tests.
-type consumerSchemaValidator struct {
-	structural *structuralschema.Structural
-	internal   *apiextensions.JSONSchemaProps
-}
-
-func (v *consumerSchemaValidator) Validate(t *testing.T, ac *apisixv2.ApisixConsumer) error {
+func loadApisixConsumerSchema(t *testing.T) *crdSchemaValidator {
 	t.Helper()
-
-	data, err := json.Marshal(ac)
-	require.NoError(t, err, "failed to marshal ApisixConsumer")
-
-	var obj map[string]interface{}
-	require.NoError(t, json.Unmarshal(data, &obj), "failed to unmarshal to map")
-
-	schemaValidator, _, err := validation.NewSchemaValidator(v.internal)
-	require.NoError(t, err, "failed to build schema validator")
-
-	if errs := validation.ValidateCustomResource(nil, obj, schemaValidator); len(errs) > 0 {
-		return errs.ToAggregate()
-	}
-
-	celValidator := cel.NewValidator(v.structural, false, celconfig.PerCallLimit)
-	celErrs, _ := celValidator.Validate(context.Background(), nil, v.structural, obj, nil, celconfig.RuntimeCELCostBudget)
-	if len(celErrs) > 0 {
-		return celErrs.ToAggregate()
-	}
-	return nil
-}
-
-// loadApisixConsumerSchema reads the ApisixConsumer CRD YAML and returns a
-// validator backed by the real generated schema.
-func loadApisixConsumerSchema(t *testing.T) *consumerSchemaValidator {
-	t.Helper()
-
 	_, thisFile, _, _ := runtime.Caller(0)
 	crdPath := filepath.Join(filepath.Dir(thisFile), "..", "..",
 		"config", "crd", "bases", "apisix.apache.org_apisixconsumers.yaml")
-
-	data, err := os.ReadFile(crdPath)
-	require.NoError(t, err, "failed to read CRD file: %s", crdPath)
-
-	jsonData, err := sigsyaml.YAMLToJSON(data)
-	require.NoError(t, err, "failed to convert CRD YAML to JSON")
-
-	var crd apiextensionsv1.CustomResourceDefinition
-	require.NoError(t, json.Unmarshal(jsonData, &crd), "failed to unmarshal CRD")
-
-	var v1Schema *apiextensionsv1.JSONSchemaProps
-	for _, v := range crd.Spec.Versions {
-		if v.Name == "v2" {
-			v1Schema = v.Schema.OpenAPIV3Schema
-			break
-		}
-	}
-	require.NotNil(t, v1Schema, "v2 schema not found in CRD")
-
-	var internal apiextensions.JSONSchemaProps
-	require.NoError(t,
-		apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(v1Schema, &internal, nil),
-		"failed to convert v1 schema to internal",
-	)
-
-	structural, err := structuralschema.NewStructural(&internal)
-	require.NoError(t, err, "failed to build structural schema")
-	return &consumerSchemaValidator{structural: structural, internal: &internal}
+	return loadCRDSchema(t, crdPath)
 }
 
 func TestApisixConsumer_JwtAuth_SymmetricHS256(t *testing.T) {
@@ -120,7 +49,7 @@ func TestApisixConsumer_JwtAuth_SymmetricHS256(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }
 
 // TestApisixConsumer_JwtAuth_AsymmetricWithWhitespaceOnlyPublicKey verifies
@@ -141,7 +70,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricWithWhitespaceOnlyPublicKey(t *testing
 			},
 		},
 	}
-	err := v.Validate(t, ac)
+	err := v.validateObject(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -161,7 +90,7 @@ func TestApisixConsumer_JwtAuth_SymmetricHS512(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_NoAlgorithmDefaultsToSymmetric(t *testing.T) {
@@ -178,7 +107,7 @@ func TestApisixConsumer_JwtAuth_NoAlgorithmDefaultsToSymmetric(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPublicKey(t *testing.T) {
@@ -196,7 +125,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPublicKey(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPrivateKey(t *testing.T) {
@@ -214,7 +143,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPrivateKey(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithBothKeys(t *testing.T) {
@@ -233,7 +162,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithBothKeys(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithoutAnyKey(t *testing.T) {
@@ -250,7 +179,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithoutAnyKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.Validate(t, ac)
+	err := v.validateObject(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -269,7 +198,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricES256WithoutAnyKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.Validate(t, ac)
+	err := v.validateObject(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -288,7 +217,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricEdDSAWithoutAnyKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.Validate(t, ac)
+	err := v.validateObject(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -309,7 +238,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricWithEmptyPublicKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.Validate(t, ac)
+	err := v.validateObject(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -333,5 +262,5 @@ func TestApisixConsumer_JwtAuth_EmptyAlgorithmTreatedAsSymmetric(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ac))
+	assert.NoError(t, v.validateObject(t, ac))
 }

--- a/api/v2/apisixconsumer_validation_test.go
+++ b/api/v2/apisixconsumer_validation_test.go
@@ -49,7 +49,7 @@ func TestApisixConsumer_JwtAuth_SymmetricHS256(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }
 
 // TestApisixConsumer_JwtAuth_AsymmetricWithWhitespaceOnlyPublicKey verifies
@@ -70,7 +70,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricWithWhitespaceOnlyPublicKey(t *testing
 			},
 		},
 	}
-	err := v.validateObject(t, ac)
+	err := v.Validate(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -90,7 +90,7 @@ func TestApisixConsumer_JwtAuth_SymmetricHS512(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_NoAlgorithmDefaultsToSymmetric(t *testing.T) {
@@ -107,7 +107,7 @@ func TestApisixConsumer_JwtAuth_NoAlgorithmDefaultsToSymmetric(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPublicKey(t *testing.T) {
@@ -125,7 +125,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPublicKey(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPrivateKey(t *testing.T) {
@@ -143,7 +143,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithPrivateKey(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithBothKeys(t *testing.T) {
@@ -162,7 +162,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithBothKeys(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }
 
 func TestApisixConsumer_JwtAuth_AsymmetricRS256WithoutAnyKey(t *testing.T) {
@@ -179,7 +179,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricRS256WithoutAnyKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.validateObject(t, ac)
+	err := v.Validate(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -198,7 +198,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricES256WithoutAnyKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.validateObject(t, ac)
+	err := v.Validate(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -217,7 +217,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricEdDSAWithoutAnyKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.validateObject(t, ac)
+	err := v.Validate(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -238,7 +238,7 @@ func TestApisixConsumer_JwtAuth_AsymmetricWithEmptyPublicKey(t *testing.T) {
 			},
 		},
 	}
-	err := v.validateObject(t, ac)
+	err := v.Validate(t, ac)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "algorithms other than HS256/HS384/HS512")
 }
@@ -262,5 +262,5 @@ func TestApisixConsumer_JwtAuth_EmptyAlgorithmTreatedAsSymmetric(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ac))
+	assert.NoError(t, v.Validate(t, ac))
 }

--- a/api/v2/apisixroute_types.go
+++ b/api/v2/apisixroute_types.go
@@ -164,7 +164,6 @@ type ApisixRouteHTTPMatch struct {
 
 	// FilterFunc is a user-defined function for advanced request filtering.
 	// The function can use Nginx variables through the `vars` parameter.
-	// This field is supported in APISIX but not in API7 Enterprise.
 	FilterFunc string `json:"filter_func,omitempty" yaml:"filter_func,omitempty"`
 }
 

--- a/api/v2/apisixroute_types.go
+++ b/api/v2/apisixroute_types.go
@@ -265,7 +265,7 @@ type ApisixRouteStreamBackend struct {
 // ApisixRouteHTTPMatchExpr represents a binary expression used to match requests based on Nginx variables.
 type ApisixRouteHTTPMatchExpr struct {
 	// Subject defines the left-hand side of the expression.
-	// It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal.
+	// It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal.
 	Subject ApisixRouteHTTPMatchExprSubject `json:"subject" yaml:"subject"`
 
 	// Op specifies the operator used in the expression.

--- a/api/v2/apisixroute_types.go
+++ b/api/v2/apisixroute_types.go
@@ -164,6 +164,7 @@ type ApisixRouteHTTPMatch struct {
 
 	// FilterFunc is a user-defined function for advanced request filtering.
 	// The function can use Nginx variables through the `vars` parameter.
+	// This field is supported in APISIX but not in API7 Enterprise.
 	FilterFunc string `json:"filter_func,omitempty" yaml:"filter_func,omitempty"`
 }
 
@@ -265,7 +266,7 @@ type ApisixRouteStreamBackend struct {
 // ApisixRouteHTTPMatchExpr represents a binary expression used to match requests based on Nginx variables.
 type ApisixRouteHTTPMatchExpr struct {
 	// Subject defines the left-hand side of the expression.
-	// It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal.
+	// It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal.
 	Subject ApisixRouteHTTPMatchExprSubject `json:"subject" yaml:"subject"`
 
 	// Op specifies the operator used in the expression.
@@ -309,8 +310,10 @@ func (exprs ApisixRouteHTTPMatchExprs) ToVars() (result adc.Vars, err error) {
 			subj = "uri"
 		case ScopeVariable:
 			subj = expr.Subject.Name
+		case ScopeBody:
+			subj = "post_arg." + expr.Subject.Name
 		default:
-			return result, errors.New("invalid http match expr: subject.scope should be one of [query, header, cookie, path, variable]")
+			return result, errors.New("invalid http match expr: subject.scope should be one of [Query, Header, Cookie, Path, Variable, Body]")
 		}
 		this.SliceVal = append(this.SliceVal, adc.StringOrSlice{StrVal: subj})
 
@@ -409,12 +412,21 @@ type ApisixRouteAuthenticationLDAPAuth struct {
 }
 
 // ApisixRouteHTTPMatchExprSubject describes the subject of a route matching expression.
+// +kubebuilder:validation:XValidation:rule="self.scope == 'Path' || size(self.name) > 0",message="name is required when scope is not Path"
 type ApisixRouteHTTPMatchExprSubject struct {
-	// Scope specifies the subject scope and can be `Header`, `Query`, or `Path`.
+	// Scope specifies the subject scope.
+	// Supported values: `Header`, `Query`, `Path`, `Cookie`, `Variable`, `Body`.
 	// When Scope is `Path`, Name will be ignored.
+	// When Scope is `Body`, Name supports dot-notation JSON path (e.g., "model.version",
+	// "messages[*].role") and maps to APISIX's `post_arg.<name>` variable, which works with
+	// application/json, application/x-www-form-urlencoded, and multipart/form-data.
+	// +kubebuilder:validation:Enum=Header;Query;Path;Cookie;Variable;Body
 	Scope string `json:"scope" yaml:"scope"`
-	// Name is the name of the header or query parameter.
-	Name string `json:"name" yaml:"name"`
+	// Name is the name of the subject within the given scope: the header name, query
+	// parameter name, cookie name, Nginx variable name, or body field name (dot-notation
+	// JSON path supported for Body scope). Optional when Scope is Path.
+	// +kubebuilder:validation:Optional
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 func init() {

--- a/api/v2/apisixroute_types_test.go
+++ b/api/v2/apisixroute_types_test.go
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func strPtr(s string) *string { return &s }
+
+// celSubjectRule is the CEL expression used in the +kubebuilder:validation:XValidation
+// marker on ApisixRouteHTTPMatchExprSubject.
+const celSubjectRule = `self.scope == 'Path' || size(self.name) > 0`
+
+func evalCELSubjectRule(t *testing.T, scope, name string) bool {
+	t.Helper()
+	env, err := cel.NewEnv(
+		cel.Variable("self", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+	ast, issues := env.Compile(celSubjectRule)
+	require.NoError(t, issues.Err())
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+	out, _, err := prg.Eval(map[string]any{
+		"self": map[string]any{"scope": scope, "name": name},
+	})
+	require.NoError(t, err)
+	return out.Value().(bool)
+}
+
+// TestCEL_SubjectRule_Logic verifies the CEL expression used in the XValidation marker.
+func TestCEL_SubjectRule_Logic(t *testing.T) {
+	// Non-Path scopes with a non-empty name must pass.
+	for _, scope := range []string{ScopeHeader, ScopeQuery, ScopeCookie, ScopeVariable, ScopeBody} {
+		assert.True(t, evalCELSubjectRule(t, scope, "field"), "scope=%s with name should pass", scope)
+	}
+	// Path scope with empty name must pass (name is ignored for Path).
+	assert.True(t, evalCELSubjectRule(t, ScopePath, ""), "Path with empty name should pass")
+	// Non-Path scopes with empty name must fail.
+	for _, scope := range []string{ScopeHeader, ScopeQuery, ScopeCookie, ScopeVariable, ScopeBody} {
+		assert.False(t, evalCELSubjectRule(t, scope, ""), "scope=%s with empty name should fail", scope)
+	}
+}
+
+// TestCEL_SubjectRule_InCRD verifies the generated CRD YAML contains the XValidation rule
+// with correct (ASCII) quote characters and not typographic quotes.
+func TestCEL_SubjectRule_InCRD(t *testing.T) {
+	const crdPath = "../../config/crd/bases/apisix.apache.org_apisixroutes.yaml"
+	data, err := os.ReadFile(crdPath)
+	require.NoError(t, err, "CRD file should exist; run 'make manifests' if missing")
+
+	var crd map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &crd))
+
+	// Ensure no typographic/smart quotes crept in anywhere in the file.
+	raw := string(data)
+	assert.NotContains(t, raw, "\u2018", "CRD must not contain left single quotation mark \u2018")
+	assert.NotContains(t, raw, "\u2019", "CRD must not contain right single quotation mark \u2019")
+	assert.NotContains(t, raw, "\u201c", "CRD must not contain left double quotation mark \u201c")
+	assert.NotContains(t, raw, "\u201d", "CRD must not contain right double quotation mark \u201d")
+
+	// Walk the parsed CRD to extract the x-kubernetes-validations rule string directly,
+	// which is more robust than substring matching against the raw YAML (line-wrapping safe).
+	rule := extractXValidationRule(t, crd)
+	assert.Equal(t, celSubjectRule, rule,
+		"XValidation rule in CRD must match the expected CEL expression")
+}
+
+// extractXValidationRule walks the parsed CRD map to find the first
+// x-kubernetes-validations rule on the subject property of HTTP match exprs.
+func extractXValidationRule(t *testing.T, crd map[string]any) string {
+	t.Helper()
+	// Path: spec.versions[0].schema.openAPIV3Schema
+	//   .properties.spec.properties.http.items
+	//   .properties.match.properties.exprs.items
+	//   .properties.subject.x-kubernetes-validations[0].rule
+	get := func(m map[string]any, key string) map[string]any {
+		v, ok := m[key]
+		require.True(t, ok, "key %q not found", key)
+		mv, ok := v.(map[string]any)
+		require.True(t, ok, "key %q is not a map", key)
+		return mv
+	}
+	spec := get(crd, "spec")
+	versions := spec["versions"].([]any)
+	require.NotEmpty(t, versions)
+	schema := get(versions[0].(map[string]any), "schema")
+	root := get(schema, "openAPIV3Schema")
+	props := get(root, "properties")
+	specProps := get(get(props, "spec"), "properties")
+	httpItems := get(get(specProps, "http"), "items")
+	matchProps := get(get(get(httpItems, "properties"), "match"), "properties")
+	exprsItems := get(get(matchProps, "exprs"), "items")
+	subject := get(get(exprsItems, "properties"), "subject")
+	validations, ok := subject["x-kubernetes-validations"].([]any)
+	require.True(t, ok, "x-kubernetes-validations not found or not a list")
+	require.NotEmpty(t, validations)
+	first := validations[0].(map[string]any)
+	rule, ok := first["rule"].(string)
+	require.True(t, ok, "rule field not found or not a string")
+	return rule
+}
+
+func TestToVars_ScopeBody_SimpleField(t *testing.T) {
+	exprs := ApisixRouteHTTPMatchExprs{
+		{
+			Subject: ApisixRouteHTTPMatchExprSubject{
+				Scope: ScopeBody,
+				Name:  "action",
+			},
+			Op:    OpEqual,
+			Value: strPtr("login"),
+		},
+	}
+
+	vars, err := exprs.ToVars()
+	require.NoError(t, err)
+	require.Len(t, vars, 1)
+
+	// vars[0] is []StringOrSlice: [subject, op, value]
+	// Should map to post_arg.action
+	assert.Equal(t, "post_arg.action", vars[0][0].StrVal)
+	assert.Equal(t, "==", vars[0][1].StrVal)
+	assert.Equal(t, "login", vars[0][2].StrVal)
+}
+
+func TestToVars_ScopeBody_NestedJSONPath(t *testing.T) {
+	exprs := ApisixRouteHTTPMatchExprs{
+		{
+			Subject: ApisixRouteHTTPMatchExprSubject{
+				Scope: ScopeBody,
+				Name:  "model.version",
+			},
+			Op:    OpEqual,
+			Value: strPtr("gpt-4"),
+		},
+	}
+
+	vars, err := exprs.ToVars()
+	require.NoError(t, err)
+	require.Len(t, vars, 1)
+
+	// Should map to post_arg.model.version (dot-notation passthrough)
+	assert.Equal(t, "post_arg.model.version", vars[0][0].StrVal)
+}
+
+func TestToVars_ScopeBody_EmptyName_ReturnsError(t *testing.T) {
+	exprs := ApisixRouteHTTPMatchExprs{
+		{
+			Subject: ApisixRouteHTTPMatchExprSubject{
+				Scope: ScopeBody,
+				Name:  "",
+			},
+			Op:    OpEqual,
+			Value: strPtr("login"),
+		},
+	}
+
+	_, err := exprs.ToVars()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty subject.name")
+}

--- a/api/v2/apisixroute_types_test.go
+++ b/api/v2/apisixroute_types_test.go
@@ -16,101 +16,30 @@
 package v2_test
 
 import (
-	"context"
-	"encoding/json"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
-	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
-	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	celconfig "k8s.io/apiserver/pkg/apis/cel"
-	sigsyaml "sigs.k8s.io/yaml"
 
 	apisixv2 "github.com/apache/apisix-ingress-controller/api/v2"
 )
 
-// routeSchemaValidator holds the parsed CRD schema for ApisixRoute
-// and provides a Validate method for use in tests.
-type routeSchemaValidator struct {
-	structural *structuralschema.Structural
-	internal   *apiextensions.JSONSchemaProps
-}
-
-func (v *routeSchemaValidator) Validate(t *testing.T, ar *apisixv2.ApisixRoute) error {
+func loadApisixRouteSchema(t *testing.T) *crdSchemaValidator {
 	t.Helper()
-
-	data, err := json.Marshal(ar)
-	require.NoError(t, err, "failed to marshal ApisixRoute")
-
-	var obj map[string]interface{}
-	require.NoError(t, json.Unmarshal(data, &obj), "failed to unmarshal to map")
-
-	schemaValidator, _, err := validation.NewSchemaValidator(v.internal)
-	require.NoError(t, err, "failed to build schema validator")
-
-	if errs := validation.ValidateCustomResource(nil, obj, schemaValidator); len(errs) > 0 {
-		return errs.ToAggregate()
-	}
-
-	celValidator := cel.NewValidator(v.structural, false, celconfig.PerCallLimit)
-	celErrs, _ := celValidator.Validate(context.Background(), nil, v.structural, obj, nil, celconfig.RuntimeCELCostBudget)
-	if len(celErrs) > 0 {
-		return celErrs.ToAggregate()
-	}
-	return nil
-}
-
-// loadApisixRouteSchema reads the ApisixRoute CRD YAML and returns a
-// validator backed by the real generated schema.
-func loadApisixRouteSchema(t *testing.T) *routeSchemaValidator {
-	t.Helper()
-
 	_, thisFile, _, _ := runtime.Caller(0)
 	crdPath := filepath.Join(filepath.Dir(thisFile), "..", "..",
 		"config", "crd", "bases", "apisix.apache.org_apisixroutes.yaml")
-
-	data, err := os.ReadFile(crdPath)
-	require.NoError(t, err, "failed to read CRD file: %s", crdPath)
-
-	jsonData, err := sigsyaml.YAMLToJSON(data)
-	require.NoError(t, err, "failed to convert CRD YAML to JSON")
-
-	var crd apiextensionsv1.CustomResourceDefinition
-	require.NoError(t, json.Unmarshal(jsonData, &crd), "failed to unmarshal CRD")
-
-	var v1Schema *apiextensionsv1.JSONSchemaProps
-	for _, v := range crd.Spec.Versions {
-		if v.Name == "v2" {
-			v1Schema = v.Schema.OpenAPIV3Schema
-			break
-		}
-	}
-	require.NotNil(t, v1Schema, "v2 schema not found in CRD")
-
-	var internal apiextensions.JSONSchemaProps
-	require.NoError(t,
-		apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(v1Schema, &internal, nil),
-		"failed to convert v1 schema to internal",
-	)
-
-	structural, err := structuralschema.NewStructural(&internal)
-	require.NoError(t, err, "failed to build structural schema")
-	return &routeSchemaValidator{structural: structural, internal: &internal}
+	return loadCRDSchema(t, crdPath)
 }
 
 func strPtr(s string) *string { return &s }
 func boolPtr(b bool) *bool    { return &b }
 func intPtr(i int) *int       { return &i }
 
-func newRouteWithBodyExpr(namespace, ingressClass, fieldName, value string) *apisixv2.ApisixRoute {
+func newRouteWithBodyExpr(ingressClass, fieldName, value string) *apisixv2.ApisixRoute {
 	return &apisixv2.ApisixRoute{
 		Spec: apisixv2.ApisixRouteSpec{
 			IngressClassName: ingressClass,
@@ -145,24 +74,21 @@ func newRouteWithBodyExpr(namespace, ingressClass, fieldName, value string) *api
 // simple field name passes CRD schema validation.
 func TestApisixRoute_BodyScope_SimpleField(t *testing.T) {
 	v := loadApisixRouteSchema(t)
-	ar := newRouteWithBodyExpr("default", "apisix", "action", "login")
-	assert.NoError(t, v.Validate(t, ar))
+	assert.NoError(t, v.validateObject(t, newRouteWithBodyExpr("apisix", "action", "login")))
 }
 
 // TestApisixRoute_BodyScope_NestedJSONPath verifies that a Body scope expr with
 // a dot-notation JSON path passes CRD schema validation.
 func TestApisixRoute_BodyScope_NestedJSONPath(t *testing.T) {
 	v := loadApisixRouteSchema(t)
-	ar := newRouteWithBodyExpr("default", "apisix", "model.version", "gpt-4")
-	assert.NoError(t, v.Validate(t, ar))
+	assert.NoError(t, v.validateObject(t, newRouteWithBodyExpr("apisix", "model.version", "gpt-4")))
 }
 
 // TestApisixRoute_BodyScope_EmptyName verifies that a Body scope expr with an
 // empty name is rejected by the CEL XValidation rule.
 func TestApisixRoute_BodyScope_EmptyName(t *testing.T) {
 	v := loadApisixRouteSchema(t)
-	ar := newRouteWithBodyExpr("default", "apisix", "", "login")
-	err := v.Validate(t, ar)
+	err := v.validateObject(t, newRouteWithBodyExpr("apisix", "", "login"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "name is required when scope is not Path")
 }
@@ -197,5 +123,5 @@ func TestApisixRoute_PathScope_EmptyName(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.Validate(t, ar))
+	assert.NoError(t, v.validateObject(t, ar))
 }

--- a/api/v2/apisixroute_types_test.go
+++ b/api/v2/apisixroute_types_test.go
@@ -74,21 +74,21 @@ func newRouteWithBodyExpr(ingressClass, fieldName, value string) *apisixv2.Apisi
 // simple field name passes CRD schema validation.
 func TestApisixRoute_BodyScope_SimpleField(t *testing.T) {
 	v := loadApisixRouteSchema(t)
-	assert.NoError(t, v.validateObject(t, newRouteWithBodyExpr("apisix", "action", "login")))
+	assert.NoError(t, v.Validate(t, newRouteWithBodyExpr("apisix", "action", "login")))
 }
 
 // TestApisixRoute_BodyScope_NestedJSONPath verifies that a Body scope expr with
 // a dot-notation JSON path passes CRD schema validation.
 func TestApisixRoute_BodyScope_NestedJSONPath(t *testing.T) {
 	v := loadApisixRouteSchema(t)
-	assert.NoError(t, v.validateObject(t, newRouteWithBodyExpr("apisix", "model.version", "gpt-4")))
+	assert.NoError(t, v.Validate(t, newRouteWithBodyExpr("apisix", "model.version", "gpt-4")))
 }
 
 // TestApisixRoute_BodyScope_EmptyName verifies that a Body scope expr with an
 // empty name is rejected by the CEL XValidation rule.
 func TestApisixRoute_BodyScope_EmptyName(t *testing.T) {
 	v := loadApisixRouteSchema(t)
-	err := v.validateObject(t, newRouteWithBodyExpr("apisix", "", "login"))
+	err := v.Validate(t, newRouteWithBodyExpr("apisix", "", "login"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "name is required when scope is not Path")
 }
@@ -123,5 +123,5 @@ func TestApisixRoute_PathScope_EmptyName(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, v.validateObject(t, ar))
+	assert.NoError(t, v.Validate(t, ar))
 }

--- a/api/v2/apisixroute_types_test.go
+++ b/api/v2/apisixroute_types_test.go
@@ -1,184 +1,201 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-package v2
+package v2_test
 
 import (
+	"context"
+	"encoding/json"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
-	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	apisixv2 "github.com/apache/apisix-ingress-controller/api/v2"
 )
 
-func strPtr(s string) *string { return &s }
+// routeSchemaValidator holds the parsed CRD schema for ApisixRoute
+// and provides a Validate method for use in tests.
+type routeSchemaValidator struct {
+	structural *structuralschema.Structural
+	internal   *apiextensions.JSONSchemaProps
+}
 
-// celSubjectRule is the CEL expression used in the +kubebuilder:validation:XValidation
-// marker on ApisixRouteHTTPMatchExprSubject.
-const celSubjectRule = `self.scope == 'Path' || size(self.name) > 0`
-
-func evalCELSubjectRule(t *testing.T, scope, name string) bool {
+func (v *routeSchemaValidator) Validate(t *testing.T, ar *apisixv2.ApisixRoute) error {
 	t.Helper()
-	env, err := cel.NewEnv(
-		cel.Variable("self", cel.MapType(cel.StringType, cel.StringType)),
-	)
-	require.NoError(t, err)
-	ast, issues := env.Compile(celSubjectRule)
-	require.NoError(t, issues.Err())
-	prg, err := env.Program(ast)
-	require.NoError(t, err)
-	out, _, err := prg.Eval(map[string]any{
-		"self": map[string]any{"scope": scope, "name": name},
-	})
-	require.NoError(t, err)
-	return out.Value().(bool)
+
+	data, err := json.Marshal(ar)
+	require.NoError(t, err, "failed to marshal ApisixRoute")
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &obj), "failed to unmarshal to map")
+
+	schemaValidator, _, err := validation.NewSchemaValidator(v.internal)
+	require.NoError(t, err, "failed to build schema validator")
+
+	if errs := validation.ValidateCustomResource(nil, obj, schemaValidator); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+
+	celValidator := cel.NewValidator(v.structural, false, celconfig.PerCallLimit)
+	celErrs, _ := celValidator.Validate(context.Background(), nil, v.structural, obj, nil, celconfig.RuntimeCELCostBudget)
+	if len(celErrs) > 0 {
+		return celErrs.ToAggregate()
+	}
+	return nil
 }
 
-// TestCEL_SubjectRule_Logic verifies the CEL expression used in the XValidation marker.
-func TestCEL_SubjectRule_Logic(t *testing.T) {
-	// Non-Path scopes with a non-empty name must pass.
-	for _, scope := range []string{ScopeHeader, ScopeQuery, ScopeCookie, ScopeVariable, ScopeBody} {
-		assert.True(t, evalCELSubjectRule(t, scope, "field"), "scope=%s with name should pass", scope)
-	}
-	// Path scope with empty name must pass (name is ignored for Path).
-	assert.True(t, evalCELSubjectRule(t, ScopePath, ""), "Path with empty name should pass")
-	// Non-Path scopes with empty name must fail.
-	for _, scope := range []string{ScopeHeader, ScopeQuery, ScopeCookie, ScopeVariable, ScopeBody} {
-		assert.False(t, evalCELSubjectRule(t, scope, ""), "scope=%s with empty name should fail", scope)
-	}
-}
+// loadApisixRouteSchema reads the ApisixRoute CRD YAML and returns a
+// validator backed by the real generated schema.
+func loadApisixRouteSchema(t *testing.T) *routeSchemaValidator {
+	t.Helper()
 
-// TestCEL_SubjectRule_InCRD verifies the generated CRD YAML contains the XValidation rule
-// with correct (ASCII) quote characters and not typographic quotes.
-func TestCEL_SubjectRule_InCRD(t *testing.T) {
-	const crdPath = "../../config/crd/bases/apisix.apache.org_apisixroutes.yaml"
+	_, thisFile, _, _ := runtime.Caller(0)
+	crdPath := filepath.Join(filepath.Dir(thisFile), "..", "..",
+		"config", "crd", "bases", "apisix.apache.org_apisixroutes.yaml")
+
 	data, err := os.ReadFile(crdPath)
-	require.NoError(t, err, "CRD file should exist; run 'make manifests' if missing")
+	require.NoError(t, err, "failed to read CRD file: %s", crdPath)
 
-	var crd map[string]any
-	require.NoError(t, yaml.Unmarshal(data, &crd))
+	jsonData, err := sigsyaml.YAMLToJSON(data)
+	require.NoError(t, err, "failed to convert CRD YAML to JSON")
 
-	// Ensure no typographic/smart quotes crept in anywhere in the file.
-	raw := string(data)
-	assert.NotContains(t, raw, "\u2018", "CRD must not contain left single quotation mark \u2018")
-	assert.NotContains(t, raw, "\u2019", "CRD must not contain right single quotation mark \u2019")
-	assert.NotContains(t, raw, "\u201c", "CRD must not contain left double quotation mark \u201c")
-	assert.NotContains(t, raw, "\u201d", "CRD must not contain right double quotation mark \u201d")
+	var crd apiextensionsv1.CustomResourceDefinition
+	require.NoError(t, json.Unmarshal(jsonData, &crd), "failed to unmarshal CRD")
 
-	// Walk the parsed CRD to extract the x-kubernetes-validations rule string directly,
-	// which is more robust than substring matching against the raw YAML (line-wrapping safe).
-	rule := extractXValidationRule(t, crd)
-	assert.Equal(t, celSubjectRule, rule,
-		"XValidation rule in CRD must match the expected CEL expression")
-}
-
-// extractXValidationRule walks the parsed CRD map to find the first
-// x-kubernetes-validations rule on the subject property of HTTP match exprs.
-func extractXValidationRule(t *testing.T, crd map[string]any) string {
-	t.Helper()
-	// Path: spec.versions[0].schema.openAPIV3Schema
-	//   .properties.spec.properties.http.items
-	//   .properties.match.properties.exprs.items
-	//   .properties.subject.x-kubernetes-validations[0].rule
-	get := func(m map[string]any, key string) map[string]any {
-		v, ok := m[key]
-		require.True(t, ok, "key %q not found", key)
-		mv, ok := v.(map[string]any)
-		require.True(t, ok, "key %q is not a map", key)
-		return mv
+	var v1Schema *apiextensionsv1.JSONSchemaProps
+	for _, v := range crd.Spec.Versions {
+		if v.Name == "v2" {
+			v1Schema = v.Schema.OpenAPIV3Schema
+			break
+		}
 	}
-	spec := get(crd, "spec")
-	versions := spec["versions"].([]any)
-	require.NotEmpty(t, versions)
-	schema := get(versions[0].(map[string]any), "schema")
-	root := get(schema, "openAPIV3Schema")
-	props := get(root, "properties")
-	specProps := get(get(props, "spec"), "properties")
-	httpItems := get(get(specProps, "http"), "items")
-	matchProps := get(get(get(httpItems, "properties"), "match"), "properties")
-	exprsItems := get(get(matchProps, "exprs"), "items")
-	subject := get(get(exprsItems, "properties"), "subject")
-	validations, ok := subject["x-kubernetes-validations"].([]any)
-	require.True(t, ok, "x-kubernetes-validations not found or not a list")
-	require.NotEmpty(t, validations)
-	first := validations[0].(map[string]any)
-	rule, ok := first["rule"].(string)
-	require.True(t, ok, "rule field not found or not a string")
-	return rule
+	require.NotNil(t, v1Schema, "v2 schema not found in CRD")
+
+	var internal apiextensions.JSONSchemaProps
+	require.NoError(t,
+		apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(v1Schema, &internal, nil),
+		"failed to convert v1 schema to internal",
+	)
+
+	structural, err := structuralschema.NewStructural(&internal)
+	require.NoError(t, err, "failed to build structural schema")
+	return &routeSchemaValidator{structural: structural, internal: &internal}
 }
 
-func TestToVars_ScopeBody_SimpleField(t *testing.T) {
-	exprs := ApisixRouteHTTPMatchExprs{
-		{
-			Subject: ApisixRouteHTTPMatchExprSubject{
-				Scope: ScopeBody,
-				Name:  "action",
+func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }
+func intPtr(i int) *int       { return &i }
+
+func newRouteWithBodyExpr(namespace, ingressClass, fieldName, value string) *apisixv2.ApisixRoute {
+	return &apisixv2.ApisixRoute{
+		Spec: apisixv2.ApisixRouteSpec{
+			IngressClassName: ingressClass,
+			HTTP: []apisixv2.ApisixRouteHTTP{
+				{
+					Name:      "rule0",
+					Websocket: boolPtr(false),
+					Match: apisixv2.ApisixRouteHTTPMatch{
+						Paths: []string{"/*"},
+						NginxVars: apisixv2.ApisixRouteHTTPMatchExprs{
+							{
+								Subject: apisixv2.ApisixRouteHTTPMatchExprSubject{
+									Scope: apisixv2.ScopeBody,
+									Name:  fieldName,
+								},
+								Op:    apisixv2.OpEqual,
+								Set:   []string{},
+								Value: strPtr(value),
+							},
+						},
+					},
+					Backends: []apisixv2.ApisixRouteHTTPBackend{
+						{ServiceName: "my-svc", ServicePort: intstr.FromInt(80), Weight: intPtr(100)},
+					},
+				},
 			},
-			Op:    OpEqual,
-			Value: strPtr("login"),
 		},
 	}
-
-	vars, err := exprs.ToVars()
-	require.NoError(t, err)
-	require.Len(t, vars, 1)
-
-	// vars[0] is []StringOrSlice: [subject, op, value]
-	// Should map to post_arg.action
-	assert.Equal(t, "post_arg.action", vars[0][0].StrVal)
-	assert.Equal(t, "==", vars[0][1].StrVal)
-	assert.Equal(t, "login", vars[0][2].StrVal)
 }
 
-func TestToVars_ScopeBody_NestedJSONPath(t *testing.T) {
-	exprs := ApisixRouteHTTPMatchExprs{
-		{
-			Subject: ApisixRouteHTTPMatchExprSubject{
-				Scope: ScopeBody,
-				Name:  "model.version",
-			},
-			Op:    OpEqual,
-			Value: strPtr("gpt-4"),
-		},
-	}
-
-	vars, err := exprs.ToVars()
-	require.NoError(t, err)
-	require.Len(t, vars, 1)
-
-	// Should map to post_arg.model.version (dot-notation passthrough)
-	assert.Equal(t, "post_arg.model.version", vars[0][0].StrVal)
+// TestApisixRoute_BodyScope_SimpleField verifies that a Body scope expr with a
+// simple field name passes CRD schema validation.
+func TestApisixRoute_BodyScope_SimpleField(t *testing.T) {
+	v := loadApisixRouteSchema(t)
+	ar := newRouteWithBodyExpr("default", "apisix", "action", "login")
+	assert.NoError(t, v.Validate(t, ar))
 }
 
-func TestToVars_ScopeBody_EmptyName_ReturnsError(t *testing.T) {
-	exprs := ApisixRouteHTTPMatchExprs{
-		{
-			Subject: ApisixRouteHTTPMatchExprSubject{
-				Scope: ScopeBody,
-				Name:  "",
+// TestApisixRoute_BodyScope_NestedJSONPath verifies that a Body scope expr with
+// a dot-notation JSON path passes CRD schema validation.
+func TestApisixRoute_BodyScope_NestedJSONPath(t *testing.T) {
+	v := loadApisixRouteSchema(t)
+	ar := newRouteWithBodyExpr("default", "apisix", "model.version", "gpt-4")
+	assert.NoError(t, v.Validate(t, ar))
+}
+
+// TestApisixRoute_BodyScope_EmptyName verifies that a Body scope expr with an
+// empty name is rejected by the CEL XValidation rule.
+func TestApisixRoute_BodyScope_EmptyName(t *testing.T) {
+	v := loadApisixRouteSchema(t)
+	ar := newRouteWithBodyExpr("default", "apisix", "", "login")
+	err := v.Validate(t, ar)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name is required when scope is not Path")
+}
+
+// TestApisixRoute_PathScope_EmptyName verifies that Path scope without a name
+// passes CRD schema validation (name is optional for Path).
+func TestApisixRoute_PathScope_EmptyName(t *testing.T) {
+	v := loadApisixRouteSchema(t)
+	ar := &apisixv2.ApisixRoute{
+		Spec: apisixv2.ApisixRouteSpec{
+			HTTP: []apisixv2.ApisixRouteHTTP{
+				{
+					Name:      "rule0",
+					Websocket: boolPtr(false),
+					Match: apisixv2.ApisixRouteHTTPMatch{
+						Paths: []string{"/*"},
+						NginxVars: apisixv2.ApisixRouteHTTPMatchExprs{
+							{
+								Subject: apisixv2.ApisixRouteHTTPMatchExprSubject{
+									Scope: apisixv2.ScopePath,
+								},
+								Op:    apisixv2.OpEqual,
+								Set:   []string{},
+								Value: strPtr("/api"),
+							},
+						},
+					},
+					Backends: []apisixv2.ApisixRouteHTTPBackend{
+						{ServiceName: "my-svc", ServicePort: intstr.FromInt(80), Weight: intPtr(100)},
+					},
+				},
 			},
-			Op:    OpEqual,
-			Value: strPtr("login"),
 		},
 	}
-
-	_, err := exprs.ToVars()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "empty subject.name")
+	assert.NoError(t, v.Validate(t, ar))
 }

--- a/api/v2/crd_schema_validator_test.go
+++ b/api/v2/crd_schema_validator_test.go
@@ -38,9 +38,9 @@ type crdSchemaValidator struct {
 	internal   *apiextensions.JSONSchemaProps
 }
 
-// validateObject marshals obj to JSON then runs the CRD's OpenAPI schema validator
+// Validate marshals obj to JSON then runs the CRD's OpenAPI schema validator
 // followed by any CEL x-kubernetes-validations rules.
-func (v *crdSchemaValidator) validateObject(t *testing.T, obj any) error {
+func (v *crdSchemaValidator) Validate(t *testing.T, obj any) error {
 	t.Helper()
 
 	data, err := json.Marshal(obj)

--- a/api/v2/crd_schema_validator_test.go
+++ b/api/v2/crd_schema_validator_test.go
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// crdSchemaValidator holds the parsed CRD schema and validates objects against it,
+// including both OpenAPI structural validation and CEL x-kubernetes-validations rules.
+type crdSchemaValidator struct {
+	structural *structuralschema.Structural
+	internal   *apiextensions.JSONSchemaProps
+}
+
+// validateObject marshals obj to JSON then runs the CRD's OpenAPI schema validator
+// followed by any CEL x-kubernetes-validations rules.
+func (v *crdSchemaValidator) validateObject(t *testing.T, obj any) error {
+	t.Helper()
+
+	data, err := json.Marshal(obj)
+	require.NoError(t, err, "failed to marshal object")
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw), "failed to unmarshal to map")
+
+	schemaValidator, _, err := validation.NewSchemaValidator(v.internal)
+	require.NoError(t, err, "failed to build schema validator")
+
+	if errs := validation.ValidateCustomResource(nil, raw, schemaValidator); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+
+	celValidator := cel.NewValidator(v.structural, false, celconfig.PerCallLimit)
+	celErrs, _ := celValidator.Validate(context.Background(), nil, v.structural, raw, nil, celconfig.RuntimeCELCostBudget)
+	if len(celErrs) > 0 {
+		return celErrs.ToAggregate()
+	}
+	return nil
+}
+
+// loadCRDSchema reads a CRD YAML file and returns a validator for the "v2" version schema.
+func loadCRDSchema(t *testing.T, crdPath string) *crdSchemaValidator {
+	t.Helper()
+
+	data, err := os.ReadFile(crdPath)
+	require.NoError(t, err, "failed to read CRD file: %s", crdPath)
+
+	jsonData, err := sigsyaml.YAMLToJSON(data)
+	require.NoError(t, err, "failed to convert CRD YAML to JSON")
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	require.NoError(t, json.Unmarshal(jsonData, &crd), "failed to unmarshal CRD")
+
+	var v1Schema *apiextensionsv1.JSONSchemaProps
+	for _, v := range crd.Spec.Versions {
+		if v.Name == "v2" {
+			v1Schema = v.Schema.OpenAPIV3Schema
+			break
+		}
+	}
+	require.NotNil(t, v1Schema, "v2 schema not found in CRD")
+
+	var internal apiextensions.JSONSchemaProps
+	require.NoError(t,
+		apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(v1Schema, &internal, nil),
+		"failed to convert v1 schema to internal",
+	)
+
+	structural, err := structuralschema.NewStructural(&internal)
+	require.NoError(t, err, "failed to build structural schema")
+	return &crdSchemaValidator{structural: structural, internal: &internal}
+}

--- a/api/v2/shared_types.go
+++ b/api/v2/shared_types.go
@@ -86,6 +86,11 @@ const (
 	ScopeCookie = "Cookie"
 	// ScopeVariable means the route match expression subject is in variable.
 	ScopeVariable = "Variable"
+	// ScopeBody means the route match expression subject is in the request body.
+	// Name supports dot-notation JSON path (e.g., "model.version", "messages[*].role"),
+	// and maps to APISIX's post_arg.<name> variable, which supports application/json,
+	// application/x-www-form-urlencoded, and multipart/form-data content types.
+	ScopeBody = "Body"
 )
 
 const (

--- a/config/crd/bases/apisix.apache.org_apisixroutes.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixroutes.yaml
@@ -249,7 +249,6 @@ spec:
                           description: |-
                             FilterFunc is a user-defined function for advanced request filtering.
                             The function can use Nginx variables through the `vars` parameter.
-                            This field is supported in APISIX but not in API7 Enterprise.
                           type: string
                         hosts:
                           description: |-

--- a/config/crd/bases/apisix.apache.org_apisixroutes.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixroutes.yaml
@@ -217,7 +217,7 @@ spec:
                                       Supported values: `Header`, `Query`, `Path`, `Cookie`, `Variable`, `Body`.
                                       When Scope is `Path`, Name will be ignored.
                                       When Scope is `Body`, Name supports dot-notation JSON path (e.g., "model.version",
-                                      "messages[*].role") and maps to APISIX's `post_arg.{name}` variable, which works with
+                                      "messages[*].role") and maps to APISIX's `post_arg.<name>` variable, which works with
                                       application/json, application/x-www-form-urlencoded, and multipart/form-data.
                                     enum:
                                     - Header

--- a/config/crd/bases/apisix.apache.org_apisixroutes.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixroutes.yaml
@@ -203,7 +203,7 @@ spec:
                               subject:
                                 description: |-
                                   Subject defines the left-hand side of the expression.
-                                  It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal.
+                                  It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal.
                                 properties:
                                   name:
                                     description: |-

--- a/config/crd/bases/apisix.apache.org_apisixroutes.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixroutes.yaml
@@ -203,21 +203,37 @@ spec:
                               subject:
                                 description: |-
                                   Subject defines the left-hand side of the expression.
-                                  It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal.
+                                  It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal.
                                 properties:
                                   name:
-                                    description: Name is the name of the header or
-                                      query parameter.
+                                    description: |-
+                                      Name is the name of the subject within the given scope: the header name, query
+                                      parameter name, cookie name, Nginx variable name, or body field name (dot-notation
+                                      JSON path supported for Body scope). Optional when Scope is Path.
                                     type: string
                                   scope:
                                     description: |-
-                                      Scope specifies the subject scope and can be `Header`, `Query`, or `Path`.
+                                      Scope specifies the subject scope.
+                                      Supported values: `Header`, `Query`, `Path`, `Cookie`, `Variable`, `Body`.
                                       When Scope is `Path`, Name will be ignored.
+                                      When Scope is `Body`, Name supports dot-notation JSON path (e.g., "model.version",
+                                      "messages[*].role") and maps to APISIX's `post_arg.{name}` variable, which works with
+                                      application/json, application/x-www-form-urlencoded, and multipart/form-data.
+                                    enum:
+                                    - Header
+                                    - Query
+                                    - Path
+                                    - Cookie
+                                    - Variable
+                                    - Body
                                     type: string
                                 required:
-                                - name
                                 - scope
                                 type: object
+                                x-kubernetes-validations:
+                                - message: name is required when scope is not Path
+                                  rule: self.scope == 'Path' || size(self.name) >
+                                    0
                               value:
                                 description: |-
                                   Value defines a single value to compare against the subject.
@@ -233,6 +249,7 @@ spec:
                           description: |-
                             FilterFunc is a user-defined function for advanced request filtering.
                             The function can use Nginx variables through the `vars` parameter.
+                            This field is supported in APISIX but not in API7 Enterprise.
                           type: string
                         hosts:
                           description: |-

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -367,7 +367,7 @@ LoadBalancer describes the load balancing parameters.
 | --- | --- |
 | `type` _string_ | Type specifies the load balancing algorithms to route traffic to the backend. Default is `roundrobin`. Can be `roundrobin`, `chash`, `ewma`, or `least_conn`. |
 | `hashOn` _string_ | HashOn specified the type of field used for hashing, required when type is `chash`. Default is `vars`. Can be `vars`, `header`, `cookie`, `consumer`, or `vars_combinations`. |
-| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable/). |
+| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [built-in variables](/enterprise/reference/built-in-variables). |
 
 
 _Appears in:_
@@ -781,9 +781,6 @@ _Appears in:_
 
 
 ApisixConsumerJwtAuthValue defines configuration for JWT authentication.
-For asymmetric algorithms (RS*, ES*, PS*, EdDSA), at least one of public_key
-or private_key must be provided. Symmetric algorithms (HS256, HS384, HS512)
-and unset algorithm do not require any key field.
 
 
 
@@ -793,7 +790,7 @@ and unset algorithm do not require any key field.
 | `secret` _string_ | Secret is the shared secret used to sign the JWT (for symmetric algorithms). |
 | `public_key` _string_ | PublicKey is the public key used to verify JWT signatures (for asymmetric algorithms). |
 | `private_key` _string_ | PrivateKey is the private key used to sign the JWT (for asymmetric algorithms). |
-| `algorithm` _string_ | Algorithm specifies the signing algorithm. Can be `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. |
+| `algorithm` _string_ | Algorithm specifies the signing algorithm. Can be `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. Currently APISIX only supports `HS256`, `HS512`, `RS256`, and `ES256`. API7 Enterprise supports all algorithms. |
 | `exp` _integer_ | Exp is the token expiration period in seconds. |
 | `base64_secret` _boolean_ | Base64Secret indicates whether the secret is base64-encoded. |
 | `lifetime_grace_period` _integer_ | LifetimeGracePeriod is the allowed clock skew in seconds for token expiration. |
@@ -1089,7 +1086,7 @@ ApisixRouteHTTPMatch defines the conditions used to match incoming HTTP requests
 | `hosts` _string array_ | Hosts specifies Host header values to match. Supports exact and wildcard domains. Only one level of wildcard is allowed (e.g., `*.example.com` is valid, but `*.*.example.com` is not). |
 | `remoteAddrs` _string array_ | RemoteAddrs is a list of source IP addresses or CIDR ranges to match. Supports both IPv4 and IPv6 formats. |
 | `exprs` _[ApisixRouteHTTPMatchExprs](#apisixroutehttpmatchexprs)_ | NginxVars defines match conditions based on Nginx variables. |
-| `filter_func` _string_ | FilterFunc is a user-defined function for advanced request filtering. The function can use Nginx variables through the `vars` parameter. |
+| `filter_func` _string_ | FilterFunc is a user-defined function for advanced request filtering. The function can use Nginx variables through the `vars` parameter. This field is supported in APISIX but not in API7 Enterprise. |
 
 
 _Appears in:_
@@ -1104,7 +1101,7 @@ ApisixRouteHTTPMatchExpr represents a binary expression used to match requests b
 
 | Field | Description |
 | --- | --- |
-| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal. |
+| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal. |
 | `op` _string_ | Op specifies the operator used in the expression. Can be `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual`, `RegexMatch`, `RegexNotMatch`, `RegexMatchCaseInsensitive`, `RegexNotMatchCaseInsensitive`, `In`, or `NotIn`. |
 | `set` _string array_ | Set provides a list of acceptable values for the expression. This should be used when Op is `In` or `NotIn`. |
 | `value` _string_ | Value defines a single value to compare against the subject. This should be used when Op is not `In` or `NotIn`. Set and Value are mutually exclusive—only one should be set at a time. |
@@ -1122,8 +1119,8 @@ ApisixRouteHTTPMatchExprSubject describes the subject of a route matching expres
 
 | Field | Description |
 | --- | --- |
-| `scope` _string_ | Scope specifies the subject scope and can be `Header`, `Query`, or `Path`. When Scope is `Path`, Name will be ignored. |
-| `name` _string_ | Name is the name of the header or query parameter. |
+| `scope` _string_ | Scope specifies the subject scope. Supported values: `Header`, `Query`, `Path`, `Cookie`, `Variable`, `Body`. When Scope is `Path`, Name will be ignored. When Scope is `Body`, Name supports dot-notation JSON path (e.g., "model.version", "messages[*].role") and maps to APISIX's `post_arg.<name>` variable, which works with application/json, application/x-www-form-urlencoded, and multipart/form-data. |
+| `name` _string_ | Name is the name of the subject within the given scope: the header name, query parameter name, cookie name, Nginx variable name, or body field name (dot-notation JSON path supported for Body scope). Optional when Scope is Path. |
 
 
 _Appears in:_
@@ -1138,7 +1135,7 @@ _Base type:_ `[ApisixRouteHTTPMatchExpr](#apisixroutehttpmatchexpr)`
 
 | Field | Description |
 | --- | --- |
-| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal. |
+| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal. |
 | `op` _string_ | Op specifies the operator used in the expression. Can be `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual`, `RegexMatch`, `RegexNotMatch`, `RegexMatchCaseInsensitive`, `RegexNotMatchCaseInsensitive`, `In`, or `NotIn`. |
 | `set` _string array_ | Set provides a list of acceptable values for the expression. This should be used when Op is `In` or `NotIn`. |
 | `value` _string_ | Value defines a single value to compare against the subject. This should be used when Op is not `In` or `NotIn`. Set and Value are mutually exclusive—only one should be set at a time. |
@@ -1476,7 +1473,7 @@ LoadBalancer defines the load balancing strategy for distributing traffic across
 | --- | --- |
 | `type` _string_ | Type specifies the load balancing algorithms to route traffic to the backend. Default is `roundrobin`. Can be `roundrobin`, `chash`, `ewma`, or `least_conn`. |
 | `hashOn` _string_ | HashOn specified the type of field used for hashing, required when type is `chash`. Default is `vars`. Can be `vars`, `header`, `cookie`, `consumer`, or `vars_combinations`. |
-| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [APISIX variables](https://apisix.apache.org/docs/apisix/apisix-variable). |
+| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [built-in variables](/enterprise/reference/built-in-variables). |
 
 
 _Appears in:_
@@ -1565,8 +1562,6 @@ them if they are set on the port level.
 
 _Appears in:_
 - [ApisixUpstreamSpec](#apisixupstreamspec)
-
-
 
 
 

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -1089,7 +1089,7 @@ ApisixRouteHTTPMatch defines the conditions used to match incoming HTTP requests
 | `hosts` _string array_ | Hosts specifies Host header values to match. Supports exact and wildcard domains. Only one level of wildcard is allowed (e.g., `*.example.com` is valid, but `*.*.example.com` is not). |
 | `remoteAddrs` _string array_ | RemoteAddrs is a list of source IP addresses or CIDR ranges to match. Supports both IPv4 and IPv6 formats. |
 | `exprs` _[ApisixRouteHTTPMatchExprs](#apisixroutehttpmatchexprs)_ | NginxVars defines match conditions based on Nginx variables. |
-| `filter_func` _string_ | FilterFunc is a user-defined function for advanced request filtering. The function can use Nginx variables through the `vars` parameter. This field is supported in APISIX but not in API7 Enterprise. |
+| `filter_func` _string_ | FilterFunc is a user-defined function for advanced request filtering. The function can use Nginx variables through the `vars` parameter. |
 
 
 _Appears in:_

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -367,7 +367,7 @@ LoadBalancer describes the load balancing parameters.
 | --- | --- |
 | `type` _string_ | Type specifies the load balancing algorithms to route traffic to the backend. Default is `roundrobin`. Can be `roundrobin`, `chash`, `ewma`, or `least_conn`. |
 | `hashOn` _string_ | HashOn specified the type of field used for hashing, required when type is `chash`. Default is `vars`. Can be `vars`, `header`, `cookie`, `consumer`, or `vars_combinations`. |
-| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [built-in variables](/enterprise/reference/built-in-variables). |
+| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable/). |
 
 
 _Appears in:_
@@ -781,6 +781,9 @@ _Appears in:_
 
 
 ApisixConsumerJwtAuthValue defines configuration for JWT authentication.
+For asymmetric algorithms (RS*, ES*, PS*, EdDSA), at least one of public_key
+or private_key must be provided. Symmetric algorithms (HS256, HS384, HS512)
+and unset algorithm do not require any key field.
 
 
 
@@ -790,7 +793,7 @@ ApisixConsumerJwtAuthValue defines configuration for JWT authentication.
 | `secret` _string_ | Secret is the shared secret used to sign the JWT (for symmetric algorithms). |
 | `public_key` _string_ | PublicKey is the public key used to verify JWT signatures (for asymmetric algorithms). |
 | `private_key` _string_ | PrivateKey is the private key used to sign the JWT (for asymmetric algorithms). |
-| `algorithm` _string_ | Algorithm specifies the signing algorithm. Can be `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. Currently APISIX only supports `HS256`, `HS512`, `RS256`, and `ES256`. API7 Enterprise supports all algorithms. |
+| `algorithm` _string_ | Algorithm specifies the signing algorithm. Can be `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. |
 | `exp` _integer_ | Exp is the token expiration period in seconds. |
 | `base64_secret` _boolean_ | Base64Secret indicates whether the secret is base64-encoded. |
 | `lifetime_grace_period` _integer_ | LifetimeGracePeriod is the allowed clock skew in seconds for token expiration. |
@@ -1473,7 +1476,7 @@ LoadBalancer defines the load balancing strategy for distributing traffic across
 | --- | --- |
 | `type` _string_ | Type specifies the load balancing algorithms to route traffic to the backend. Default is `roundrobin`. Can be `roundrobin`, `chash`, `ewma`, or `least_conn`. |
 | `hashOn` _string_ | HashOn specified the type of field used for hashing, required when type is `chash`. Default is `vars`. Can be `vars`, `header`, `cookie`, `consumer`, or `vars_combinations`. |
-| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [built-in variables](/enterprise/reference/built-in-variables). |
+| `key` _string_ | Key is used with HashOn, generally required when type is `chash`. When HashOn is `header` or `cookie`, specifies the name of the header or cookie. When HashOn is `consumer`, key is not required, as the consumer name is used automatically. When HashOn is `vars` or `vars_combinations`, key refers to one or a combination of [APISIX variables](https://apisix.apache.org/docs/apisix/apisix-variable). |
 
 
 _Appears in:_
@@ -1562,6 +1565,8 @@ them if they are set on the port level.
 
 _Appears in:_
 - [ApisixUpstreamSpec](#apisixupstreamspec)
+
+
 
 
 

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -1104,7 +1104,7 @@ ApisixRouteHTTPMatchExpr represents a binary expression used to match requests b
 
 | Field | Description |
 | --- | --- |
-| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal. |
+| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal. |
 | `op` _string_ | Op specifies the operator used in the expression. Can be `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual`, `RegexMatch`, `RegexNotMatch`, `RegexMatchCaseInsensitive`, `RegexNotMatchCaseInsensitive`, `In`, or `NotIn`. |
 | `set` _string array_ | Set provides a list of acceptable values for the expression. This should be used when Op is `In` or `NotIn`. |
 | `value` _string_ | Value defines a single value to compare against the subject. This should be used when Op is not `In` or `NotIn`. Set and Value are mutually exclusive—only one should be set at a time. |
@@ -1138,7 +1138,7 @@ _Base type:_ `[ApisixRouteHTTPMatchExpr](#apisixroutehttpmatchexpr)`
 
 | Field | Description |
 | --- | --- |
-| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal. |
+| `subject` _[ApisixRouteHTTPMatchExprSubject](#apisixroutehttpmatchexprsubject)_ | Subject defines the left-hand side of the expression. It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal. |
 | `op` _string_ | Op specifies the operator used in the expression. Can be `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual`, `RegexMatch`, `RegexNotMatch`, `RegexMatchCaseInsensitive`, `RegexNotMatchCaseInsensitive`, `In`, or `NotIn`. |
 | `set` _string array_ | Set provides a list of acceptable values for the expression. This should be used when Op is `In` or `NotIn`. |
 | `value` _string_ | Value defines a single value to compare against the subject. This should be used when Op is not `In` or `NotIn`. Set and Value are mutually exclusive—only one should be set at a time. |

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/gavv/httpexpect/v2 v2.16.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
-	github.com/google/cel-go v0.22.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -118,6 +117,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gavv/httpexpect/v2 v2.16.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
+	github.com/google/cel-go v0.22.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -33,6 +34,7 @@ require (
 	k8s.io/api v0.32.3
 	k8s.io/apiextensions-apiserver v0.32.3
 	k8s.io/apimachinery v0.32.3
+	k8s.io/apiserver v0.32.3
 	k8s.io/client-go v0.32.3
 	k8s.io/kubectl v0.30.3
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
@@ -116,7 +118,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -209,7 +210,6 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	k8s.io/apiserver v0.32.3 // indirect
 	k8s.io/component-base v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,10 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
 github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
@@ -208,6 +212,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
@@ -434,8 +440,16 @@ github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZ
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.etcd.io/etcd/api/v3 v3.5.16 h1:WvmyJVbjWqK4R1E+B12RRHz3bRGy9XVfh++MgbN+6n0=
+go.etcd.io/etcd/api/v3 v3.5.16/go.mod h1:1P4SlIP/VwkDmGo3OlOD7faPeP8KDIFhqvciH5EfN28=
+go.etcd.io/etcd/client/pkg/v3 v3.5.16 h1:ZgY48uH6UvB+/7R9Yf4x574uCO3jIx0TRDyetSfId3Q=
+go.etcd.io/etcd/client/pkg/v3 v3.5.16/go.mod h1:V8acl8pcEK0Y2g19YlOV9m9ssUe6MgiDSobSoaBAM0E=
+go.etcd.io/etcd/client/v3 v3.5.16 h1:sSmVYOAHeC9doqi0gv7v86oY/BTld0SEFGaxsU9eRhE=
+go.etcd.io/etcd/client/v3 v3.5.16/go.mod h1:X+rExSGkyqxvu276cr2OwPLBaeqFu1cIl4vmRjAD/50=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 h1:r6I7RJCN86bpD/FQwedZ0vSixDpwuWREjW9oRMsmqDc=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0/go.mod h1:B9yO6b04uB80CzjedvewuqDhxJxi11s7/GtiGa8bAjI=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 h1:TT4fX+nBOA/+LUkobKGW1ydGcn+G3vRw9+g5HwCphpk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0/go.mod h1:L7UH0GbB0p47T4Rri3uHjbpCFYrVrwc1I25QhNPiGK8=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -289,7 +289,6 @@ spec:
 			s.NewAPISIXClient().GET("/get").Expect().Status(http.StatusNotFound)
 		})
 
-
 		It("Test ApisixRoute match by body vars (urlencoded)", func() {
 			const apisixRouteSpec = `
 apiVersion: apisix.apache.org/v2

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -289,6 +289,100 @@ spec:
 			s.NewAPISIXClient().GET("/get").Expect().Status(http.StatusNotFound)
 		})
 
+
+		It("Test ApisixRoute match by body vars (urlencoded)", func() {
+			const apisixRouteSpec = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: default
+  namespace: %s
+spec:
+  ingressClassName: %s
+  http:
+  - name: rule0
+    match:
+      paths:
+      - /*
+      methods:
+      - POST
+      exprs:
+      - subject:
+          scope: Body
+          name: action
+        op: Equal
+        value: login
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+			By("apply ApisixRoute with Body scope expr")
+			var apisixRoute apiv2.ApisixRoute
+			applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"},
+				&apisixRoute, fmt.Sprintf(apisixRouteSpec, s.Namespace(), s.Namespace()))
+
+			By("verify matching POST with form field action=login returns 200")
+			request := func() int {
+				return s.NewAPISIXClient().POST("/post").
+					WithFormField("action", "login").
+					Expect().Raw().StatusCode
+			}
+			Eventually(request).WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
+
+			By("verify non-matching POST with wrong action value returns 404")
+			s.NewAPISIXClient().POST("/post").
+				WithFormField("action", "logout").
+				Expect().Status(http.StatusNotFound)
+
+			By("verify GET request (no body) returns 404")
+			s.NewAPISIXClient().GET("/get").Expect().Status(http.StatusNotFound)
+		})
+
+		It("Test ApisixRoute match by body vars (JSON nested path)", func() {
+			const apisixRouteSpec = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: default
+  namespace: %s
+spec:
+  ingressClassName: %s
+  http:
+  - name: rule0
+    match:
+      paths:
+      - /*
+      methods:
+      - POST
+      exprs:
+      - subject:
+          scope: Body
+          name: model.version
+        op: Equal
+        value: gpt-4
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+			By("apply ApisixRoute with Body scope dot-notation JSON path expr")
+			var apisixRoute apiv2.ApisixRoute
+			applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"},
+				&apisixRoute, fmt.Sprintf(apisixRouteSpec, s.Namespace(), s.Namespace()))
+
+			By("verify matching POST with JSON body {model: {version: gpt-4}} returns 200")
+			request := func() int {
+				return s.NewAPISIXClient().POST("/post").
+					WithJSON(map[string]any{"model": map[string]string{"version": "gpt-4"}}).
+					Expect().Raw().StatusCode
+			}
+			Eventually(request).WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
+
+			By("verify non-matching JSON body with wrong nested value returns 404")
+			s.NewAPISIXClient().POST("/post").
+				WithJSON(map[string]any{"model": map[string]string{"version": "gpt-3"}}).
+				Expect().Status(http.StatusNotFound)
+		})
+
 		It("Test ApisixRoute filterFunc", func() {
 			const apisixRouteSpec = `
 apiVersion: apisix.apache.org/v2


### PR DESCRIPTION
## Summary


Add `Body` as a new scope value for `ApisixRouteHTTPMatchExprSubject`, enabling request body matching in `ApisixRoute` HTTP match expressions.

## How it works

When `scope: Body` is used, the subject maps to APISIX's `post_arg.<name>` variable. This variable supports:

- `application/json`
- `application/x-www-form-urlencoded`
- `multipart/form-data`

Dot-notation JSON path expressions are also supported (e.g., `model.version`, `messages[*].role`).

**Example:**

```yaml
exprs:
- subject:
    scope: Body
    name: action        # matches form field or JSON key
  op: Equal
  value: login
```

```yaml
exprs:
- subject:
    scope: Body
    name: model.version  # dot-notation JSON path
  op: Equal
  value: gpt-4
```

## Changes

- `api/v2/shared_types.go`: add `ScopeBody = "Body"` constant
- `api/v2/apisixroute_types.go`:
  - Add `case ScopeBody` in `ToVars()` mapping to `post_arg.<name>`
  - Add `Body` to `+kubebuilder:validation:Enum` on `Scope` field
  - Add `+kubebuilder:validation:XValidation` CEL rule: `name` is required when `scope` is not `Path`
  - Make `Name` field optional (`omitempty`) so `Path` scope works without providing a name
- `api/v2/apisixroute_types_test.go`: unit tests for Body scope and CEL validation
- `config/crd/bases/apisix.apache.org_apisixroutes.yaml`: regenerated
- `docs/en/latest/reference/api-reference.md`: regenerated
- `test/e2e/crds/v2/route.go`: e2e tests for urlencoded form field and JSON nested path matching

## Testing

Unit tests:
```
go test ./api/v2/... -run "TestToVars|TestCEL"
```

E2e tests added:
- `Test ApisixRoute match by body vars (urlencoded)`: POST form field `action=login`
- `Test ApisixRoute match by body vars (JSON nested path)`: POST JSON `{"model": {"version": "gpt-4"}}` with `model.version` dot-notation