### PR TITLE
fix: update observedGeneration on Gateway-API route status conditions

### DIFF
--- a/internal/provider/apisix/status.go
+++ b/internal/provider/apisix/status.go
@@ -123,6 +123,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1.HTTPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1.HTTPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -158,6 +159,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1alpha2.UDPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1alpha2.UDPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -193,6 +195,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1alpha2.TCPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1alpha2.TCPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -228,6 +231,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1.GRPCRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1.GRPCRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs

--- a/test/e2e/gatewayapi/status.go
+++ b/test/e2e/gatewayapi/status.go
@@ -170,6 +170,7 @@ spec:
 					And(
 						ContainSubstring(`status: "True"`),
 						ContainSubstring(`reason: Accepted`),
+						ContainSubstring(`observedGeneration: 1`),
 					),
 				)
 


### PR DESCRIPTION
### Type of change:

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

Fixes #2767.

Stamps `condition.ObservedGeneration = cp.GetGeneration()` inside the four Gateway-API mutator closures (`HTTPRoute`, `UDPRoute`, `TCPRoute`, `GRPCRoute`) before `MergeCondition`, mirroring what `SetApisixCRDConditionWithGeneration` already does for the legacy CRDs.

**Before** (HTTPRoute after a sync failure→recovery cycle):

```yaml
metadata:
  generation: 1
status:
  parents:
  - conditions:
    - type: Accepted
      status: "True"
      observedGeneration: 0   # mismatched
```

**After:**

```yaml
metadata:
  generation: 1
status:
  parents:
  - conditions:
    - type: Accepted
      status: "True"
      observedGeneration: 1   # matches metadata.generation
```

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (N/A)
- [x] Is this PR backward compatible?
