### PR TITLE
fix: wire readiness manager into ApisixPluginConfig and ApisixUpstream controllers

### DIFF
--- a/internal/controller/apisixpluginconfig_controller.go
+++ b/internal/controller/apisixpluginconfig_controller.go
@@ -29,6 +29,7 @@ import (
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -39,6 +40,7 @@ type ApisixPluginConfigReconciler struct {
 	Scheme  *runtime.Scheme
 	Log     logr.Logger
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -51,6 +53,8 @@ func (r *ApisixPluginConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 func (r *ApisixPluginConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer r.Readier.Done(&apiv2.ApisixPluginConfig{}, req.NamespacedName)
+
 	var pc apiv2.ApisixPluginConfig
 	if err := r.Get(ctx, req.NamespacedName, &pc); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controller/apisixupstream_controller.go
+++ b/internal/controller/apisixupstream_controller.go
@@ -28,6 +28,7 @@ import (
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 )
@@ -38,6 +39,7 @@ type ApisixUpstreamReconciler struct {
 	Scheme  *runtime.Scheme
 	Log     logr.Logger
 	Updater status.Updater
+	Readier readiness.ReadinessManager
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -50,6 +52,8 @@ func (r *ApisixUpstreamReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ApisixUpstreamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer r.Readier.Done(&apiv2.ApisixUpstream{}, req.NamespacedName)
+
 	var au apiv2.ApisixUpstream
 	if err := r.Get(ctx, req.NamespacedName, &au); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controller/readinessreconcile/doc.go
+++ b/internal/controller/readinessreconcile/doc.go
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package readinessreconcile contains tests for readiness signalling on API v2
+// reconcilers (see reconciler_readiness_test.go).
+package readinessreconcile

--- a/internal/controller/readinessreconcile/reconciler_readiness_test.go
+++ b/internal/controller/readinessreconcile/reconciler_readiness_test.go
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package readinessreconcile holds tests that verify API v2 reconcilers signal
+// the shared readiness manager without requiring envtest (see #2725 / #2729).
+package readinessreconcile_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	ctrlapi "github.com/apache/apisix-ingress-controller/internal/controller"
+	"github.com/apache/apisix-ingress-controller/internal/controller/status"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
+	apisixtypes "github.com/apache/apisix-ingress-controller/internal/types"
+)
+
+type recordingReadinessManager struct {
+	mu        sync.Mutex
+	doneCalls []recordingReadinessDoneCall
+}
+
+type recordingReadinessDoneCall struct {
+	obj client.Object
+	nn  k8stypes.NamespacedName
+}
+
+func (r *recordingReadinessManager) RegisterGVK(_ ...readiness.GVKConfig) {}
+
+func (r *recordingReadinessManager) Start(_ context.Context) error { return nil }
+
+func (r *recordingReadinessManager) IsReady() bool { return true }
+
+func (r *recordingReadinessManager) WaitReady(_ context.Context, _ time.Duration) bool {
+	return true
+}
+
+func (r *recordingReadinessManager) Done(obj client.Object, nn k8stypes.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.doneCalls = append(r.doneCalls, recordingReadinessDoneCall{obj: obj, nn: nn})
+}
+
+func (r *recordingReadinessManager) lastDone() (schema.GroupVersionKind, k8stypes.NamespacedName, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.doneCalls) == 0 {
+		return schema.GroupVersionKind{}, k8stypes.NamespacedName{}, false
+	}
+	c := r.doneCalls[len(r.doneCalls)-1]
+	return apisixtypes.GvkOf(c.obj), c.nn, true
+}
+
+type noopStatusUpdater struct{}
+
+func (noopStatusUpdater) Update(_ status.Update) {}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	if err := apiv2.AddToScheme(s); err != nil {
+		t.Fatalf("apiv2 AddToScheme: %v", err)
+	}
+	return s
+}
+
+func TestApisixPluginConfigReconciler_CallsReadinessDone(t *testing.T) {
+	ctx := context.Background()
+	ns := "ns-apc"
+	icName := "ic-apc-test"
+
+	scheme := testScheme(t)
+	ic := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: icName},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: "apisix.apache.org/apisix-ingress-controller",
+		},
+	}
+	pc := &apiv2.ApisixPluginConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "pc1", Namespace: ns},
+		Spec: apiv2.ApisixPluginConfigSpec{
+			IngressClassName: icName,
+			Plugins: []apiv2.ApisixRoutePlugin{
+				{Name: "echo", Enable: true, Config: apiextensionsv1.JSON{Raw: []byte(`{}`)}},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, ic, pc).
+		Build()
+
+	readier := &recordingReadinessManager{}
+	r := &ctrlapi.ApisixPluginConfigReconciler{
+		Client:  cl,
+		Scheme:  scheme,
+		Log:     logr.Discard(),
+		Updater: noopStatusUpdater{},
+		Readier: readier,
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: k8stypes.NamespacedName{Namespace: ns, Name: pc.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	gvk, nn, ok := readier.lastDone()
+	if !ok {
+		t.Fatal("expected ReadinessManager.Done to be called")
+	}
+	wantGVK := apisixtypes.GvkOf(&apiv2.ApisixPluginConfig{})
+	if gvk != wantGVK {
+		t.Fatalf("Done object GVK = %v, want %v", gvk, wantGVK)
+	}
+	wantNN := k8stypes.NamespacedName{Namespace: ns, Name: pc.Name}
+	if nn != wantNN {
+		t.Fatalf("Done nn = %v, want %v", nn, wantNN)
+	}
+}
+
+func TestApisixUpstreamReconciler_CallsReadinessDone(t *testing.T) {
+	ctx := context.Background()
+	ns := "ns-au"
+	icName := "ic-au-test"
+
+	scheme := testScheme(t)
+	ic := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: icName},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: "apisix.apache.org/apisix-ingress-controller",
+		},
+	}
+	au := &apiv2.ApisixUpstream{
+		ObjectMeta: metav1.ObjectMeta{Name: "au1", Namespace: ns},
+		Spec: apiv2.ApisixUpstreamSpec{
+			IngressClassName: icName,
+			ExternalNodes: []apiv2.ApisixUpstreamExternalNode{
+				{Type: apiv2.ExternalTypeDomain, Name: "example.com"},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, ic, au).
+		Build()
+
+	readier := &recordingReadinessManager{}
+	r := &ctrlapi.ApisixUpstreamReconciler{
+		Client:  cl,
+		Scheme:  scheme,
+		Log:     logr.Discard(),
+		Updater: noopStatusUpdater{},
+		Readier: readier,
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: k8stypes.NamespacedName{Namespace: ns, Name: au.Name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	gvk, nn, ok := readier.lastDone()
+	if !ok {
+		t.Fatal("expected ReadinessManager.Done to be called")
+	}
+	wantGVK := apisixtypes.GvkOf(&apiv2.ApisixUpstream{})
+	if gvk != wantGVK {
+		t.Fatalf("Done object GVK = %v, want %v", gvk, wantGVK)
+	}
+	wantNN := k8stypes.NamespacedName{Namespace: ns, Name: au.Name}
+	if nn != wantNN {
+		t.Fatalf("Done nn = %v, want %v", nn, wantNN)
+	}
+}

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -269,6 +269,7 @@ func setupAPIv2Controllers(ctx context.Context, mgr manager.Manager, pro provide
 			Scheme:  mgr.GetScheme(),
 			Log:     ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindApisixPluginConfig),
 			Updater: updater,
+			Readier: readier,
 		},
 		&apiv2.ApisixTls{}: &controller.ApisixTlsReconciler{
 			Client:   mgr.GetClient(),
@@ -283,6 +284,7 @@ func setupAPIv2Controllers(ctx context.Context, mgr manager.Manager, pro provide
 			Scheme:  mgr.GetScheme(),
 			Log:     ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindApisixUpstream),
 			Updater: updater,
+			Readier: readier,
 		},
 	} {
 		if utils.HasAPIResource(mgr, resource) {
@@ -367,6 +369,8 @@ func apiV2ReadinessResources() []client.Object {
 		&apiv2.ApisixGlobalRule{},
 		&apiv2.ApisixTls{},
 		&apiv2.ApisixConsumer{},
+		&apiv2.ApisixPluginConfig{},
+		&apiv2.ApisixUpstream{},
 	}
 }
 

--- a/internal/manager/controllers_test.go
+++ b/internal/manager/controllers_test.go
@@ -37,20 +37,12 @@ func TestAPIv2ReadinessResources(t *testing.T) {
 		types.GvkOf(&apiv2.ApisixGlobalRule{}).String(),
 		types.GvkOf(&apiv2.ApisixTls{}).String(),
 		types.GvkOf(&apiv2.ApisixConsumer{}).String(),
+		types.GvkOf(&apiv2.ApisixPluginConfig{}).String(),
+		types.GvkOf(&apiv2.ApisixUpstream{}).String(),
 	}
 	for _, gvk := range want {
 		if !seen[gvk] {
 			t.Fatalf("expected readiness resources to include %s", gvk)
-		}
-	}
-
-	notExpected := []string{
-		types.GvkOf(&apiv2.ApisixPluginConfig{}).String(),
-		types.GvkOf(&apiv2.ApisixUpstream{}).String(),
-	}
-	for _, gvk := range notExpected {
-		if seen[gvk] {
-			t.Fatalf("expected readiness resources to exclude %s", gvk)
 		}
 	}
 }


### PR DESCRIPTION
### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Fixes #2725 

This PR adds readiness manager for ApisixPluginConfig and ApisixUpstream controllers. Lack of readiness manager causes startup of Apisix Ingress Controller to wait for 5 minutes if such objects exist on the cluster. With updated flow Apisix Ingress Controller will not wait until timeout.

I have reverted the workaround from PR #2745 and re-applied fix from #2729 and added tests.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
