### PR TITLE
ci: fix workflow failures by upgrading actions to comply with Apache allowlist

### DIFF
--- a/.github/workflows/apisix-conformance-test.yml
+++ b/.github/workflows/apisix-conformance-test.yml
@@ -50,7 +50,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
 

--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
 
@@ -126,7 +126,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
 

--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -60,7 +60,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
 

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
       - name: run gofmt

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -33,18 +33,18 @@ jobs:
           ref: ${{ github.ref }}
           submodules: recursive
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go Env
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24"
       - name: Run unit test


### PR DESCRIPTION
## Problem

All CI workflows have been failing with `startup_failure` since April 2026. Two root causes:

1. **`actions/setup-go@v4` uses deprecated Node.js 16** — GitHub Actions no longer supports Node 16 runners, causing immediate startup failure.

2. **Docker actions referenced by tag (`@v3`) are blocked by Apache's organization-level allowlist policy** — The Apache organization enforces a strict GitHub Actions allowlist (maintained in [apache/infrastructure-actions](https://github.com/apache/infrastructure-actions)). Third-party actions outside the `actions/*`/`github/*` namespace must be pinned to specific commit SHAs approved in the allowlist. Using tag references like `@v3` results in `startup_failure`.

## Fix

- Upgrade `actions/setup-go@v4` → `@v5` (Node.js 20) across **all** workflows
- Pin Docker actions to SHA commits from Apache's approved allowlist:
  - `docker/setup-qemu-action@v3` → `@06116385d9baf250c9f4dcb4858b16962ea869c3` (v4.1.0)
  - `docker/setup-buildx-action@v3` → `@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` (v4.1.0)
  - `docker/login-action@v3` → `@650006c6eb7dba73a995cc03b0b2d7f5ca915bee` (v4.2.0)

## Affected Workflows

- push-docker.yaml
- apisix-conformance-test.yml
- apisix-e2e-test.yml
- benchmark-test.yml
- unit-test.yml
- golangci-lint.yml
- lint-checker.yml

Fixes: https://github.com/apache/apisix-ingress-controller/actions/runs/26492256243