### PR TITLE
Add AGENTS.md + SECURITY.md pointing at project security threat model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Apache APISIX Ingress Controller — Agent Instructions
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository. It
+points them at the human-authored references they should
+consult before producing output.
+
+## Security Model
+
+This repository inherits the Apache APISIX project threat
+model. The authoritative document lives at:
+
+  https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md
+
+The §4.2 component-family table in that document covers this
+repository under the `apisix-ingress-controller` family.
+
+Of particular relevance to this controller specifically: §4.8
+includes a CRD-to-Admin-API fidelity invariant — silent drop,
+injection, or rename between the Kubernetes `apisix.apache.org`
+CRD spec and the Admin API target is a controller bug, not
+operator misconfiguration. The §4.8 entry recommends an e2e
+contract test enforcing this invariant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ consult before producing output.
 This repository inherits the Apache APISIX project threat
 model. The authoritative document lives at:
 
-  https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md
+<https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md>
 
 The §4.2 component-family table in that document covers this
 repository under the `apisix-ingress-controller` family.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Security Policy
+
+Apache APISIX (including this ingress controller) follows the
+Apache Software Foundation's vulnerability-disclosure policy.
+Please report security vulnerabilities to the ASF Security
+team at <security@apache.org> per
+<https://www.apache.org/security/>.
+
+## Threat Model
+
+This repository inherits the Apache APISIX project threat
+model at:
+
+  https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md
+
+Of particular relevance to `apisix-ingress-controller`:
+§4.8 covers a CRD-to-Admin-API fidelity invariant specific
+to this controller (silent drop / injection / rename
+between the `apisix.apache.org` CRD spec and the Admin API
+target is a controller bug).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ team at <security@apache.org> per
 This repository inherits the Apache APISIX project threat
 model at:
 
-  https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md
+<https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md>
 
 Of particular relevance to `apisix-ingress-controller`:
 §4.8 covers a CRD-to-Admin-API fidelity invariant specific


### PR DESCRIPTION
## Summary

This PR adds the discoverability scaffold (`AGENTS.md` +
`SECURITY.md`) so automated security scanners and AI assistants
can mechanically locate the Apache APISIX project's security
threat model from this repository.

The threat model itself lives at
[`apache/apisix:docs/en/latest/security-threat-model.md`](https://github.com/apache/apisix/blob/master/docs/en/latest/security-threat-model.md)
(pending merge of [apache/apisix#TBD]). The §4.2 component-
family table in that document covers this repository under
the `apisix-ingress-controller` family.

## What apisix-ingress-controller-specific content is in the model

Of particular relevance to this controller:

- **§4.8 CRD-to-Admin-API fidelity invariant** — silent drop,
  injection, or rename between the Kubernetes `apisix.apache.org`
  CRD spec and the Admin API target is treated as a controller
  bug, not operator misconfiguration. The model recommends an
  e2e contract test enforcing this invariant.
- **§4.3 cluster-RBAC boundary** — the controller's own RBAC
  requirements are documented in
  `apisix-ingress-controller/config/rbac/role.yaml`. Reports
  depending on the cluster operator granting over-broad RBAC
  beyond the documented set are out-of-model
  (operator-misconfig).

## What this PR does not change

This PR is purely the discoverability scaffold — no code
changes, no behavioural changes to the controller. Once it
lands, automated scanners running against this repository can
follow `AGENTS.md → SECURITY.md → threat model` to reach the
authoritative document.

The threat model itself was generated by an automated agentic
security scan being piloted by the ASF Security team; the
discoverability work is independent of any specific scan run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
