### PR TITLE
docs: refresh 2.1.0 docs on v2.1.0 branch

### DIFF
--- a/docs/en/latest/concepts/resources.md
+++ b/docs/en/latest/concepts/resources.md
@@ -78,7 +78,7 @@ APISIX Ingress Controller CRDs extend Kubernetes functionality to provide declar
 
 * ApisixUpstream: Extends Kubernetes Services with advanced configurations such as load balancing, health checks, retries, timeouts, and service subset selection.
 
-* ApisixConsumer: Defines API consumers and their authentication credentials, supporting methods like basicAuth, keyAuth, jwtAuth, hmacAuth, wolfRBAC, and ldapAuth.
+* ApisixConsumer: Defines API consumers, their authentication credentials, and consumer-scoped plugins, supporting methods like basicAuth, keyAuth, jwtAuth, hmacAuth, wolfRBAC, and ldapAuth. Labels from `metadata.labels` are propagated to the APISIX consumer.
 
 * ApisixPluginConfig: Defines reusable plugin configurations referenced by ApisixRoute through the plugin_config_name field, promoting separation of routing logic and plugin settings.
 

--- a/docs/en/latest/overview.md
+++ b/docs/en/latest/overview.md
@@ -61,6 +61,7 @@ APISIX Ingress Controller 2.0.0+ support the [APISIX Standalone API-driven Mode]
 | APISIX ingress controller | Supported APISIX versions | Recommended APISIX version |
 | ------------------------- | ------------------------- | -------------------------- |
 | `master`                  | `>=3.0`                   | `3.13`                     |
+| `2.1.0`                   | `>=3.0`                   | `3.13`                     |
 | `2.0.0`                   | `>=3.0`                   | `3.13`                     |
 | `1.6.0`                   | `>= 2.15`, `>=3.0`        | `2.15`, `3.0`              |
 | `1.5.0`                   | `>= 2.7`                  | `2.15`                     |

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -604,8 +604,6 @@ kind: ApisixConsumer
 metadata:
   namespace: ingress-apisix
   name: alice
-  labels:
-    team: example
 spec:
   ingressClassName: apisix
   authParameter:
@@ -630,8 +628,6 @@ kind: ApisixConsumer
 metadata:
   namespace: ingress-apisix
   name: alice
-  labels:
-    team: example
 spec:
   ingressClassName: apisix
   authParameter:

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -614,8 +614,6 @@ spec:
         key: alice-primary-key
 ```
 
-Labels in `metadata.labels` are propagated to the APISIX consumer.
-
 You can also use the secret CRD, where the credential should be base64 encoded:
 
 ```yaml

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -784,17 +784,10 @@ spec:
           name: test
         op: Equal
         value: test_name
-      - subject:
-          scope: Body
-          name: action
-        op: Equal
-        value: login
     backends:
     - serviceName: httpbin
       servicePort: 80
 ```
-
-When `scope` is `Body`, the `name` field accepts the request body field to match. For JSON payloads, nested fields can use dot notation such as `model.version`.
 
 </TabItem>
 

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -439,7 +439,7 @@ This configuration is not supported by the Ingress resource.
 
 ## Configure Upstream
 
-To configure upstream related configurations, including load balancing algorithm, how the host header is passed to upstream, service timeout, and more:
+To configure upstream related configurations, including load balancing algorithm, how the host header is passed to upstream, service timeout, health checks, and more:
 
 <Tabs
 groupId="k8s-api"
@@ -472,6 +472,23 @@ spec:
     type: roundrobin
   passHost: rewrite
   upstreamHost: httpbin.example.com
+  healthCheck:
+    active:
+      type: http
+      httpPath: /status/200
+      host: httpbin.org
+      healthy:
+        successes: 2
+        interval: 2s
+      unhealthy:
+        httpFailures: 3
+        interval: 2s
+    passive:
+      type: http
+      healthy:
+        successes: 3
+      unhealthy:
+        httpFailures: 3
 ```
 
 </TabItem>
@@ -496,6 +513,23 @@ spec:
     type: roundrobin
   passHost: rewrite
   upstreamHost: httpbin.example.com
+  healthCheck:
+    active:
+      type: http
+      httpPath: /status/200
+      host: httpbin.org
+      healthy:
+        successes: 2
+        interval: 2s
+      unhealthy:
+        httpFailures: 3
+        interval: 2s
+    passive:
+      type: http
+      healthy:
+        successes: 3
+      unhealthy:
+        httpFailures: 3
 ```
 
 </TabItem>
@@ -570,6 +604,8 @@ kind: ApisixConsumer
 metadata:
   namespace: ingress-apisix
   name: alice
+  labels:
+    team: example
 spec:
   ingressClassName: apisix
   authParameter:
@@ -577,6 +613,8 @@ spec:
       value:
         key: alice-primary-key
 ```
+
+Labels in `metadata.labels` are propagated to the APISIX consumer.
 
 You can also use the secret CRD, where the credential should be base64 encoded:
 
@@ -594,6 +632,8 @@ kind: ApisixConsumer
 metadata:
   namespace: ingress-apisix
   name: alice
+  labels:
+    team: example
 spec:
   ingressClassName: apisix
   authParameter:
@@ -652,7 +692,32 @@ spec:
 
 <TabItem value="apisix-crd">
 
-ApisixConsumer currently does not support configuring plugins on consumers.
+```yaml
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: ingress-apisix
+  name: alice
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: alice-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 60
+        key: consumer_name
+        key_type: var
+        policy: local
+        rejected_code: 429
+        rejected_msg: Too many requests
+        show_limit_quota_header: true
+        allow_degradation: false
+```
 
 </TabItem>
 
@@ -721,10 +786,17 @@ spec:
           name: test
         op: Equal
         value: test_name
+      - subject:
+          scope: Body
+          name: action
+        op: Equal
+        value: login
     backends:
     - serviceName: httpbin
       servicePort: 80
 ```
+
+When `scope` is `Body`, the `name` field accepts the request body field to match. For JSON payloads, nested fields can use dot notation such as `model.version`.
 
 </TabItem>
 


### PR DESCRIPTION
## Summary
Update the docs on the `v2.1.0` branch for the APISIX Ingress Controller `2.1.0` release.

- refresh the `2.1.0` compatibility row in `overview.md`
- document `ApisixConsumer` consumer-scoped plugin support
- add a `BackendTrafficPolicy.healthCheck` example in `example.md`
