### PR TITLE
fix: Ingress with ImplementationSpecific path panics when annotations…

### DIFF
--- a/internal/adc/translator/ingress.go
+++ b/internal/adc/translator/ingress.go
@@ -282,7 +282,7 @@ func (t *Translator) buildRouteFromIngressPath(
 			prefix := strings.TrimSuffix(path.Path, "/") + "/*"
 			uris = append(uris, prefix)
 		case networkingv1.PathTypeImplementationSpecific:
-			if config.UseRegex {
+			if config != nil && config.UseRegex {
 				uris = []string{"/*"}
 				vars := apiv2.ApisixRouteHTTPMatchExprs{
 					apiv2.ApisixRouteHTTPMatchExpr{

--- a/internal/adc/translator/ingress_test.go
+++ b/internal/adc/translator/ingress_test.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+func TestTranslateIngress_ImplementationSpecificPathWithoutAnnotations(t *testing.T) {
+	translator := NewTranslator(logr.Discard(), "")
+	pathType := networkingv1.PathTypeImplementationSpecific
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-ingress",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{
+				Host: "example.com",
+				IngressRuleValue: networkingv1.IngressRuleValue{HTTP: &networkingv1.HTTPIngressRuleValue{
+					Paths: []networkingv1.HTTPIngressPath{{
+						Path:     "/api/(.*)",
+						PathType: &pathType,
+						Backend: networkingv1.IngressBackend{
+							Service: &networkingv1.IngressServiceBackend{
+								Name: "test-svc",
+								Port: networkingv1.ServiceBackendPort{Number: 80},
+							},
+						},
+					}},
+				}},
+			}},
+		},
+	}
+
+	tctx := &provider.TranslateContext{
+		Services: map[types.NamespacedName]*corev1.Service{
+			{Namespace: "default", Name: "test-svc"}: {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-svc"},
+				Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
+			},
+		},
+	}
+
+	result, err := translator.TranslateIngress(tctx, ingress)
+	require.NoError(t, err)
+	require.Len(t, result.Services, 1)
+
+	route := result.Services[0].Routes[0]
+	assert.Equal(t, []string{"/api/(.*)"}, route.Uris)
+	assert.Empty(t, route.Vars)
+}


### PR DESCRIPTION
fix #2779 

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes a panic when translating an Ingress that has no annotations and uses `pathType: ImplementationSpecific`.

  `TranslateIngressAnnotations()` returns `nil` when the Ingress has no annotations. Before this change, the Ingress translator directly accessed `config.UseRegex` while handling
  `PathTypeImplementationSpecific`, which caused a nil pointer dereference.

  This change adds a nil check before reading `UseRegex`, so an Ingress without annotations is translated safely. Regex matching is still enabled only when the `k8s.apisix.apache.org/use-regex` annotation is
  present and set to `true`.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

  - [x] Did you explain what problem does this PR solve? Or what new features have been added?
  - [x] Have you added corresponding test cases?
  - [ ] Have you modified the corresponding document?
  - [x] Is this PR backward compatible?(https://github.com/apache/apisix-ingress-controller#community) first**
