### PR TITLE
docs: update 2.1.0 listener port guidance

### DIFF
--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -42,7 +42,7 @@ This tutorial guides you through creating a Route using the APISIX Ingress Contr
 Install the httpbin example application on the cluster to test the configuration:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/apache/apisix-ingress-controller/refs/heads/v2.0.0/examples/httpbin/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/apache/apisix-ingress-controller/refs/heads/v2.1.0/examples/httpbin/deployment.yaml
 ```
 
 ## Configure a Route
@@ -86,7 +86,7 @@ spec:
       name: apisix-config
 ```
 
-Note that the `port` in the Gateway listener is required but ignored. This is due to limitations in the data plane: it cannot dynamically open new ports. Since the Ingress Controller does not manage the data plane deployment, it cannot automatically update the configuration or restart the data plane to apply port changes.
+The `port` in the Gateway listener can be used for route matching based on [`listener_port_match_mode`](../reference/configuration-file.md) (`auto`, `explicit`, or `off`). The controller cannot dynamically open new ports on the data plane, so ensure APISIX is configured to listen on the port.
 
 </details>
 

--- a/docs/en/latest/getting-started/key-authentication.md
+++ b/docs/en/latest/getting-started/key-authentication.md
@@ -76,7 +76,7 @@ spec:
       name: apisix-config
 ```
 
-Note that the `port` in the Gateway listener is required but ignored. This is due to limitations in the data plane: it cannot dynamically open new ports. Since the Ingress Controller does not manage the data plane deployment, it cannot automatically update the configuration or restart the data plane to apply port changes.
+The `port` in the Gateway listener can be used for route matching based on [`listener_port_match_mode`](../reference/configuration-file.md) (`auto`, `explicit`, or `off`). The controller cannot dynamically open new ports on the data plane, so ensure APISIX is configured to listen on the port.
 
 </details>
 

--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -76,7 +76,7 @@ spec:
       name: apisix-config
 ```
 
-Note that the `port` in the Gateway listener is required but ignored. This is due to limitations in the data plane: it cannot dynamically open new ports. Since the Ingress Controller does not manage the data plane deployment, it cannot automatically update the configuration or restart the data plane to apply port changes.
+The `port` in the Gateway listener can be used for route matching based on [`listener_port_match_mode`](../reference/configuration-file.md) (`auto`, `explicit`, or `off`). The controller cannot dynamically open new ports on the data plane, so ensure APISIX is configured to listen on the port.
 
 </details>
 

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -76,7 +76,7 @@ spec:
       name: apisix-config
 ```
 
-Note that the `port` in the Gateway listener is required but ignored. This is due to limitations in the data plane: it cannot dynamically open new ports. Since the Ingress Controller does not manage the data plane deployment, it cannot automatically update the configuration or restart the data plane to apply port changes.
+The `port` in the Gateway listener can be used for route matching based on [`listener_port_match_mode`](../reference/configuration-file.md) (`auto`, `explicit`, or `off`). The controller cannot dynamically open new ports on the data plane, so ensure APISIX is configured to listen on the port.
 
 </details>
 

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -96,7 +96,7 @@ spec:
 
 ❶ The controller name should be customized if you are running multiple distinct instances of the APISIX Ingress Controller in the same cluster (not a single instance with multiple replicas). Each ingress controller instance must use a unique controllerName in its [configuration file](configuration-file.md), and the corresponding GatewayClass should reference that value.
 
-❷ The `port` in the Gateway listener is used for routing matching based on `listener_port_match_mode` in the controller configuration (`auto`, `explicit`, or `off`). The controller cannot dynamically open new ports on the data plane, so ensure APISIX is configured to listen on the port.
+❷ The `port` in the Gateway listener is used for routing matching based on [`listener_port_match_mode`](configuration-file.md) (`auto`, `explicit`, or `off`). The controller cannot dynamically open new ports on the data plane, so ensure APISIX is configured to listen on the port.
 
 ❸ API group of the referenced resource.
 

--- a/docs/en/latest/reference/troubleshoot.md
+++ b/docs/en/latest/reference/troubleshoot.md
@@ -54,3 +54,14 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -H "X-API-KEY: ${ADMIN_API_KEY}
 ```
 
 For reference, see [Admin API](https://apisix.apache.org/docs/apisix/admin-api/).
+
+## Gateway API Routes Return 404 After Upgrade
+
+After upgrading to APISIX Ingress Controller 2.1.0, Gateway API HTTPRoute or GRPCRoute resources may return `404`. This can happen when Gateway listener ports do not match the ports that APISIX actually listens on.
+
+In the default `listener_port_match_mode: auto` mode, the Ingress Controller may inject a `server_port` route variable from the matched Gateway listener ports. The `server_port` variable is evaluated by APISIX against its actual listening port, such as `9080` or `9443`. If the Gateway listener uses `80` or `443` but the gateway Service maps those ports to `9080` or `9443`, the route may not match.
+
+To resolve the issue, use one of the following approaches:
+
+- Set [`listener_port_match_mode`](configuration-file.md) to `"off"` in the controller configuration to disable `server_port` route-var injection.
+- Configure APISIX to listen on the same ports declared in the Gateway listeners.


### PR DESCRIPTION
### What this PR does

Updates the latest docs to match APISIX Ingress Controller 2.1.0 listener-port behavior:

- Replaces stale Gateway listener `port` guidance that said the port is required but ignored.
- Links `listener_port_match_mode` from Gateway setup examples and the configuration reference example.
- Adds troubleshooting guidance for Gateway API HTTPRoute/GRPCRoute `404` responses when Gateway listener ports differ from APISIX data-plane ports.
- Updates the getting-started httpbin example URL from the `v2.0.0` branch to the `v2.1.0` branch.

### Why

In 2.1.0, port-based routing for Gateway API routes can inject `server_port` route vars based on Gateway listener ports. The docs already document this in the Gateway API concept page and configuration reference, but several getting-started pages still said the listener port was ignored.

### Validation

- `git diff --check`
- `npx --yes markdownlint-cli@0.36.0 <changed files>`
- `npx --yes markdown-link-check@3.13.6 <changed files>` checked local changed links successfully. Existing external `https://httpbin.org` links currently return `503` in three changed files and are unrelated to this PR.

I also scanned `docs/en/latest` for explicit RC/release-candidate language and stale listener-port wording; no such docs text remains after this update.
