### PR TITLE
docs: fix incorrect unit test command in developer guide

### DIFF
--- a/docs/en/latest/developer-guide.md
+++ b/docs/en/latest/developer-guide.md
@@ -103,7 +103,7 @@ make undeploy
 To run unit tests:
 
 ```shell
-make unit-test
+make test
 ```
 
 ### e2e Tests


### PR DESCRIPTION
### Type of change

- [x] Documentation

### What this PR does / why we need it

The developer guide instructs contributors to run `make unit-test` to run unit tests, but no such target exists in the `Makefile`. The actual unit test target is `make test` (`manifests generate fmt vet envtest` + `go test`). This updates the documented command so the step works as written.

### Pre-submission checklist

- [x] I have followed the project's [developer guide](https://github.com/apache/apisix-ingress-controller/blob/master/docs/en/latest/developer-guide.md).
- [x] This change is documentation only and is backward compatible.