### PR TITLE
fix: don't require certificateRefs for Passthrough-mode Gateway listeners

### DIFF
--- a/internal/adc/translator/gateway.go
+++ b/internal/adc/translator/gateway.go
@@ -72,12 +72,12 @@ func (t *Translator) translateSecret(tctx *provider.TranslateContext, listener g
 	if tctx.Secrets == nil {
 		return nil, nil
 	}
-	if listener.TLS.CertificateRefs == nil {
-		return nil, fmt.Errorf("no certificateRefs found in listener %s", listener.Name)
-	}
 	sslObjs := make([]*adctypes.SSL, 0)
 	switch *listener.TLS.Mode {
 	case gatewayv1.TLSModeTerminate:
+		if listener.TLS.CertificateRefs == nil {
+			return nil, fmt.Errorf("no certificateRefs found in listener %s", listener.Name)
+		}
 		// frontendValidation configures downstream mTLS: clients must present a
 		// certificate signed by one of the referenced CAs during the TLS handshake.
 		client, err := t.translateFrontendValidation(tctx, listener, obj)

--- a/internal/adc/translator/gateway_test.go
+++ b/internal/adc/translator/gateway_test.go
@@ -208,3 +208,34 @@ func TestTranslateSecret_FrontendValidation(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestTranslateSecret_Passthrough(t *testing.T) {
+	t.Run("passthrough listener with nil certificateRefs is valid, not an error", func(t *testing.T) {
+		tr := &Translator{Log: logr.Discard()}
+		gateway := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "gw",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name: "tls-passthrough",
+						TLS: &gatewayv1.GatewayTLSConfig{
+							Mode: ptr.To(gatewayv1.TLSModePassthrough),
+							// Per the Gateway API spec, Passthrough listeners MUST NOT
+							// set certificateRefs: the Gateway never terminates TLS, so
+							// there is no certificate for it to present.
+							CertificateRefs: nil,
+						},
+					},
+				},
+			},
+		}
+		tctx := newTranslateContextWithTLS()
+
+		ssl, err := tr.translateSecret(tctx, gateway.Spec.Listeners[0], gateway)
+		require.NoError(t, err)
+		assert.Empty(t, ssl)
+	})
+}


### PR DESCRIPTION
### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

`translateSecret()` rejects any TLS listener with `nil` `CertificateRefs` before it even checks `listener.TLS.Mode`, so any Gateway with a `Passthrough`-mode listener fails translation with:

```
no certificateRefs found in listener <name>
```

and the Gateway's `Accepted` condition is permanently `False` — even though `CertificateRefs` must be empty in `Passthrough` mode per the Gateway API spec (TLS is never terminated at the Gateway, so there's no certificate for it to present). The `switch` statement already has a case correctly documenting this:

```go
// Only supported on TLSRoute. The certificateRefs field is ignored in this mode.
case gatewayv1.TLSModePassthrough:
	return sslObjs, nil
```

but the guard above the switch makes that case unreachable.

This also isn't purely cosmetic: `TranslateGateway` returns early on this error, so it never reaches the `GatewayProxy` global-rules/plugin-metadata aggregation at the bottom of the function — meaning any cluster-wide plugins/plugin-metadata configured via a `GatewayProxy` attached to a Gateway with a Passthrough listener silently never get applied.

This PR moves the nil check into the `Terminate` case, the only mode that actually needs a certificate.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible? Yes — it only relaxes a previously-unconditional error for a spec-valid input (`Passthrough` listener with no `certificateRefs`). `Terminate`-mode behavior is unchanged.