### PR TITLE
fix: allow webhook NetworkPolicy traffic on pod port 9443

### DIFF
--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -23,5 +23,7 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        # Match the webhook-server containerPort; NetworkPolicy evaluates the
+        # pod's destination port (post-Service DNAT), not the Service port.
+        - port: 9443
           protocol: TCP


### PR DESCRIPTION
### What this does

The `allow-webhook-traffic` NetworkPolicy opens ingress on port `443`, but the webhook server pod listens on `containerPort: 9443` (`config/default/manager_webhook_patch.yaml`).

NetworkPolicy ingress rules match the pod's destination port **after** Service DNAT, not the Service port. So on a NetworkPolicy-enforcing CNI, `AdmissionReview` traffic destined for `9443` is dropped by a policy that only allows `443`. Because the validating webhook uses `failurePolicy: Ignore`, the dropped calls time out and every admission request is silently admitted without validation, so the isolation control appears healthy while doing nothing.

### Fix

Point the NetworkPolicy at `9443` to match the webhook-server `containerPort`.

### Notes

- The network-policy overlay is opt-in (not in the default kustomization), so this affects clusters that apply it on an enforcing CNI with the webhook enabled.
- Reconciler/translator re-validation still backstops admission, so this restores a defense-in-depth layer rather than the only check.