### PR TITLE
fix: fail loud when enable-csrf is set but csrf-key annotation is missing

### DIFF
--- a/internal/adc/translator/annotations/plugins/csrf.go
+++ b/internal/adc/translator/annotations/plugins/csrf.go
@@ -16,6 +16,8 @@
 package plugins
 
 import (
+	"fmt"
+
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	"github.com/apache/apisix-ingress-controller/internal/adc/translator/annotations"
 )
@@ -39,7 +41,11 @@ func (c *csrf) Handle(e annotations.Extractor) (any, error) {
 
 	key := e.GetStringAnnotation(annotations.AnnotationsCsrfKey)
 	if key == "" {
-		return nil, nil
+		// csrf requested without a key: the webhook rejects this, but log a
+		// breadcrumb for the cases it cannot cover (webhook off, pre-upgrade
+		// Ingress). Parse skips only this plugin, the rest of the route stands.
+		return nil, fmt.Errorf("annotation %q is enabled but %q is missing or empty",
+			annotations.AnnotationsEnableCsrf, annotations.AnnotationsCsrfKey)
 	}
 
 	return &adctypes.CSRFConfig{

--- a/internal/adc/translator/annotations/plugins/csrf_test.go
+++ b/internal/adc/translator/annotations/plugins/csrf_test.go
@@ -43,10 +43,16 @@ func TestCSRFHandler(t *testing.T) {
 	assert.Nil(t, err, "checking given error")
 	assert.Nil(t, out, "checking given output")
 
-	// Test with enable-csrf true but no key
+	// Test with enable-csrf true but no key: errors so Parse logs a breadcrumb
 	anno[annotations.AnnotationsEnableCsrf] = "true"
 	delete(anno, annotations.AnnotationsCsrfKey)
 	out, err = p.Handle(annotations.NewExtractor(anno))
-	assert.Nil(t, err, "checking given error")
+	assert.Error(t, err, "expecting an error when csrf-key is missing")
 	assert.Nil(t, out, "checking given output when key is missing")
+
+	// Test with enable-csrf true but empty key: same behavior
+	anno[annotations.AnnotationsCsrfKey] = ""
+	out, err = p.Handle(annotations.NewExtractor(anno))
+	assert.Error(t, err, "expecting an error when csrf-key is empty")
+	assert.Nil(t, out, "checking given output when key is empty")
 }

--- a/internal/webhook/v1/ingress_webhook.go
+++ b/internal/webhook/v1/ingress_webhook.go
@@ -77,14 +77,14 @@ func (v *IngressCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 		return nil, nil
 	}
 
+	if err := validateAnnotations(ingress); err != nil {
+		return nil, err
+	}
+
 	detector := sslvalidator.NewConflictDetector(v.Client)
 	conflicts := detector.DetectConflicts(ctx, ingress)
 	if len(conflicts) > 0 {
 		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
-	if err := validateAnnotations(ingress); err != nil {
-		return nil, err
 	}
 
 	warnings := v.collectReferenceWarnings(ctx, ingress)
@@ -102,14 +102,14 @@ func (v *IngressCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 		return nil, nil
 	}
 
+	if err := validateAnnotations(ingress); err != nil {
+		return nil, err
+	}
+
 	detector := sslvalidator.NewConflictDetector(v.Client)
 	conflicts := detector.DetectConflicts(ctx, ingress)
 	if len(conflicts) > 0 {
 		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
-	if err := validateAnnotations(ingress); err != nil {
-		return nil, err
 	}
 
 	warnings := v.collectReferenceWarnings(ctx, ingress)

--- a/internal/webhook/v1/ingress_webhook.go
+++ b/internal/webhook/v1/ingress_webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/apache/apisix-ingress-controller/internal/adc/translator/annotations"
 	"github.com/apache/apisix-ingress-controller/internal/controller"
 	"github.com/apache/apisix-ingress-controller/internal/webhook/v1/reference"
 	sslvalidator "github.com/apache/apisix-ingress-controller/internal/webhook/v1/ssl"
@@ -82,6 +83,10 @@ func (v *IngressCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
 	}
 
+	if err := validateAnnotations(ingress); err != nil {
+		return nil, err
+	}
+
 	warnings := v.collectReferenceWarnings(ctx, ingress)
 	return warnings, nil
 }
@@ -103,8 +108,26 @@ func (v *IngressCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
 	}
 
+	if err := validateAnnotations(ingress); err != nil {
+		return nil, err
+	}
+
 	warnings := v.collectReferenceWarnings(ctx, ingress)
 	return warnings, nil
+}
+
+// validateAnnotations rejects annotation combinations that would otherwise be
+// silently dropped, leaving the route without a requested security plugin.
+// enable-csrf with no csrf-key is refused here so kubectl apply fails loudly
+// instead of programming a route the operator believes is protected.
+func validateAnnotations(ingress *networkingv1.Ingress) error {
+	e := annotations.NewExtractor(ingress.Annotations)
+	if e.GetBoolAnnotation(annotations.AnnotationsEnableCsrf) &&
+		e.GetStringAnnotation(annotations.AnnotationsCsrfKey) == "" {
+		return fmt.Errorf("annotation %q is enabled but %q is missing or empty",
+			annotations.AnnotationsEnableCsrf, annotations.AnnotationsCsrfKey)
+	}
+	return nil
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Ingress.

--- a/internal/webhook/v1/ingress_webhook_test.go
+++ b/internal/webhook/v1/ingress_webhook_test.go
@@ -113,3 +113,48 @@ func TestIngressCustomValidator_NoWarningsWhenReferencesExist(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
 }
+
+func csrfIngress(anno map[string]string) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ingress", Namespace: "default", Annotations: anno},
+		Spec:       networkingv1.IngressSpec{},
+	}
+}
+
+func TestIngressCustomValidator_RejectsEnableCsrfWithoutKey(t *testing.T) {
+	validator := buildIngressValidator(t)
+
+	// missing csrf-key
+	_, err := validator.ValidateCreate(context.Background(), csrfIngress(map[string]string{
+		"k8s.apisix.apache.org/enable-csrf": "true",
+	}))
+	require.Error(t, err)
+
+	// empty csrf-key
+	_, err = validator.ValidateCreate(context.Background(), csrfIngress(map[string]string{
+		"k8s.apisix.apache.org/enable-csrf": "true",
+		"k8s.apisix.apache.org/csrf-key":    "",
+	}))
+	require.Error(t, err)
+
+	// the same invalid update must also be rejected, not only create
+	old := csrfIngress(nil)
+	_, err = validator.ValidateUpdate(context.Background(), old, csrfIngress(map[string]string{
+		"k8s.apisix.apache.org/enable-csrf": "true",
+	}))
+	require.Error(t, err)
+}
+
+func TestIngressCustomValidator_AllowsEnableCsrfWithKey(t *testing.T) {
+	validator := buildIngressValidator(t)
+
+	_, err := validator.ValidateCreate(context.Background(), csrfIngress(map[string]string{
+		"k8s.apisix.apache.org/enable-csrf": "true",
+		"k8s.apisix.apache.org/csrf-key":    "my-secret-key",
+	}))
+	require.NoError(t, err)
+
+	// csrf not enabled: key absence is fine
+	_, err = validator.ValidateCreate(context.Background(), csrfIngress(nil))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What this PR does

Fixes FINDING-031. When `enable-csrf: "true"` is set on an Ingress but `csrf-key` is missing or empty, the csrf plugin was silently dropped: the route was programmed **without** CSRF protection and the Ingress reconciled cleanly, so an endpoint the operator believed was protected ran unprotected with no error surfaced.

## Approach (changed after review)

Enforce the rule in the **Ingress validating admission webhook** (`ingress_webhook.go`), for both `ValidateCreate` and `ValidateUpdate`. `enable-csrf: true` with an empty/missing `csrf-key` is now a hard error, so `kubectl apply` is rejected loudly and synchronously, before the object is ever stored, for both new and updated Ingresses.

This replaces the earlier translation-failure approach, per review feedback from @AlinsRan and @nic-6443. That approach was reverted because:

1. **It did not cover the update path.** If an Ingress already served a route without CSRF and was then edited to add `enable-csrf` with no key, `Provider.Update` returned on the translation error *before* `UpdateConfig`, so the old unprotected route stayed live in the data plane (raised by @nic-6443).
2. **It over-reached.** An Ingress syncs `{Service, SSL}` together, so failing the whole translation on any annotation error meant a typo in a non-security annotation (e.g. `upstream-scheme`) took down the Ingress including its TLS (raised by @AlinsRan).
3. **Dropping a route does not stop traffic** anyway: requests fall through to any broader wildcard route, which may have no CSRF (raised by @AlinsRan).

The webhook can enforce severity properly (hard error vs warning) and blocks the bad intent at the source, which the translation layer structurally cannot.

## Known limitation

The Ingress webhook is deployed with `failurePolicy: Ignore`, so if the webhook is unavailable the invalid Ingress is admitted. This is a best-effort gate, not an unbreakable boundary; hardening that bypass is a separate concern (same class as the webhook-availability finding).

## Test

Added to `ingress_webhook_test.go`:
- `enable-csrf` without a key, and with an empty key, are rejected on **create**.
- the same invalid combination is rejected on **update** (covers the already-served case).
- `enable-csrf` with a key, and csrf-not-enabled, are allowed.

```
go test ./internal/webhook/... ./internal/adc/...
```