### PR TITLE
fix: trim whitespace in comma-separated annotation values

### DIFF
--- a/internal/adc/translator/annotations/types.go
+++ b/internal/adc/translator/annotations/types.go
@@ -131,7 +131,13 @@ func (e *extractor) GetStringsAnnotation(name string) []string {
 	if value == "" {
 		return nil
 	}
-	return strings.Split(value, ",")
+	var result []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 func (e *extractor) GetBoolAnnotation(name string) bool {

--- a/internal/adc/translator/annotations/types_test.go
+++ b/internal/adc/translator/annotations/types_test.go
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetStringsAnnotation(t *testing.T) {
+	const key = "test-key"
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		expected    []string
+	}{
+		{
+			name:        "no spaces",
+			annotations: map[string]string{key: "127.0.0.1,0.0.0.0"},
+			expected:    []string{"127.0.0.1", "0.0.0.0"},
+		},
+		{
+			name:        "spaces after comma",
+			annotations: map[string]string{key: "127.0.0.1, 0.0.0.0"},
+			expected:    []string{"127.0.0.1", "0.0.0.0"},
+		},
+		{
+			name:        "tabs and surrounding spaces",
+			annotations: map[string]string{key: " 127.0.0.1 ,\t0.0.0.0\t"},
+			expected:    []string{"127.0.0.1", "0.0.0.0"},
+		},
+		{
+			name:        "empty and blank elements",
+			annotations: map[string]string{key: "127.0.0.1,, ,0.0.0.0,"},
+			expected:    []string{"127.0.0.1", "0.0.0.0"},
+		},
+		{
+			name:        "single value",
+			annotations: map[string]string{key: "127.0.0.1"},
+			expected:    []string{"127.0.0.1"},
+		},
+		{
+			name:        "all blank elements",
+			annotations: map[string]string{key: " , ,\t"},
+			expected:    nil,
+		},
+		{
+			name:        "absent annotation",
+			annotations: map[string]string{},
+			expected:    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewExtractor(tc.annotations)
+			assert.Equal(t, tc.expected, e.GetStringsAnnotation(key))
+		})
+	}
+}


### PR DESCRIPTION
### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Fixes #2723

`GetStringsAnnotation` split comma-separated annotation values with `strings.Split(value, ",")` and did not trim whitespace. A value like `127.0.0.1, 0.0.0.0` produced `["127.0.0.1", " 0.0.0.0"]`; the leading space made the IP invalid, which failed validation and stalled sync for every resource under that ingressClass.

This trims each split element and drops blanks (so trailing/extra commas don't yield empty entries).

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve?
- [x] Have you added corresponding test cases? (`TestGetStringsAnnotation`)
- [ ] Have you modified the corresponding document? (n/a)
- [x] Is this PR backward compatible?