### PR TITLE
fix: never treat an unreachable API server as a missing API resource

### DIFF
--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -95,7 +95,9 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:/home/nonroot/main.cjs adc.js
+          # main.cjs lives in the image's WORKDIR, not at the container root,
+          # and docker cp resolves a relative SRC_PATH against the root.
+          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV
@@ -165,7 +167,9 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:/home/nonroot/main.cjs adc.js
+          # main.cjs lives in the image's WORKDIR, not at the container root,
+          # and docker cp resolves a relative SRC_PATH against the root.
+          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.cjs adc.js
+          docker cp adc-temp:/home/nonroot/main.cjs adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV
@@ -165,7 +165,7 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.cjs adc.js
+          docker cp adc-temp:/home/nonroot/main.cjs adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -98,7 +98,9 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:/home/nonroot/main.cjs adc.js
+          # main.cjs lives in the image's WORKDIR, not at the container root,
+          # and docker cp resolves a relative SRC_PATH against the root.
+          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -98,7 +98,7 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.cjs adc.js
+          docker cp adc-temp:/home/nonroot/main.cjs adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -62,7 +62,14 @@ type ConsumerReconciler struct { //nolint:revive
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if config.ControllerConfig.DisableGatewayAPI || !pkgutils.HasAPIResource(mgr, &gatewayv1.Gateway{}) {
+	hasGatewayAPI := false
+	if !config.ControllerConfig.DisableGatewayAPI {
+		var err error
+		if hasGatewayAPI, err = pkgutils.HasAPIResource(mgr, &gatewayv1.Gateway{}); err != nil {
+			return err
+		}
+	}
+	if !hasGatewayAPI {
 		r.Log.Info("skipping Consumer controller setup as Gateway API is not available")
 		return nil
 	}

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -105,19 +105,31 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(referenceGrantPredicates(KindGateway)),
 		)
 	}
-	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{}) {
+	hasTCPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{})
+	if err != nil {
+		return err
+	}
+	if hasTCPRoute {
 		bdr.Watches(
 			&gatewayv1alpha2.TCPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
-	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{}) {
+	hasTLSRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{})
+	if err != nil {
+		return err
+	}
+	if hasTLSRoute {
 		bdr.Watches(
 			&gatewayv1alpha2.TLSRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
-	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{}) {
+	hasUDPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{})
+	if err != nil {
+		return err
+	}
+	if hasUDPRoute {
 		bdr.Watches(
 			&gatewayv1alpha2.UDPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),

--- a/internal/controller/gatewayproxy_controller.go
+++ b/internal/controller/gatewayproxy_controller.go
@@ -54,9 +54,14 @@ type GatewayProxyController struct {
 }
 
 func (r *GatewayProxyController) SetupWithManager(mrg ctrl.Manager) error {
-	if config.ControllerConfig.DisableGatewayAPI || !pkgutils.HasAPIResource(mrg, &gatewayv1.Gateway{}) {
-		r.disableGatewayAPI = true
+	hasGatewayAPI := false
+	if !config.ControllerConfig.DisableGatewayAPI {
+		var err error
+		if hasGatewayAPI, err = pkgutils.HasAPIResource(mrg, &gatewayv1.Gateway{}); err != nil {
+			return err
+		}
 	}
+	r.disableGatewayAPI = !hasGatewayAPI
 	builder := ctrl.NewControllerManagedBy(mrg).
 		For(&v1alpha1.GatewayProxy{}).
 		WithEventFilter(

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -65,12 +65,16 @@ func SetupAPIv1alpha1Indexer(mgr ctrl.Manager) error {
 		&v1alpha1.GatewayProxy{}:         setupGatewayProxyIndexer,
 		&v1alpha1.L4RoutePolicy{}:        setupL4RoutePolicyIndexer,
 	} {
-		if utils.HasAPIResource(mgr, resource) {
-			if err := setup(mgr); err != nil {
-				return err
-			}
-		} else {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
+		}
+		if !installed {
 			setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+			continue
+		}
+		if err := setup(mgr); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -87,12 +91,16 @@ func SetupAPIv2Indexer(mgr ctrl.Manager) error {
 		&apiv2.ApisixTls{}:           setupApisixTlsIndexer,
 		&apiv2.ApisixGlobalRule{}:    setupApisixGlobalRuleIndexer,
 	} {
-		if utils.HasAPIResource(mgr, resource) {
-			if err := setup(mgr); err != nil {
-				return err
-			}
-		} else {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
+		}
+		if !installed {
 			setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+			continue
+		}
+		if err := setup(mgr); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -110,12 +118,16 @@ func SetupGatewayAPIIndexer(mgr ctrl.Manager) error {
 		&gatewayv1alpha2.TLSRoute{}: setupTLSRouteIndexer,
 		&gatewayv1.GatewayClass{}:   setupGatewayClassIndexer,
 	} {
-		if utils.HasAPIResource(mgr, resource) {
-			if err := setup(mgr); err != nil {
-				return err
-			}
-		} else {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
+		}
+		if !installed {
 			setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+			continue
+		}
+		if err := setup(mgr); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -101,7 +101,11 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// L4RoutePolicy is an optional CRD. Only watch it when installed so the
 	// controller still starts if the CRD has not been applied yet (e.g. upgrades).
-	r.supportsL4RoutePolicy = pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	supportsL4RoutePolicy, err := pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	if err != nil {
+		return err
+	}
+	r.supportsL4RoutePolicy = supportsL4RoutePolicy
 	if r.supportsL4RoutePolicy {
 		bdr.Watches(&v1alpha1.L4RoutePolicy{},
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForL4RoutePolicy),

--- a/internal/controller/tlsroute_controller.go
+++ b/internal/controller/tlsroute_controller.go
@@ -101,7 +101,11 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// L4RoutePolicy is an optional CRD. Only watch it when installed so the
 	// controller still starts if the CRD has not been applied yet (e.g. upgrades).
-	r.supportsL4RoutePolicy = pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	supportsL4RoutePolicy, err := pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	if err != nil {
+		return err
+	}
+	r.supportsL4RoutePolicy = supportsL4RoutePolicy
 	if r.supportsL4RoutePolicy {
 		bdr.Watches(&v1alpha1.L4RoutePolicy{},
 			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForL4RoutePolicy),

--- a/internal/controller/udproute_controller.go
+++ b/internal/controller/udproute_controller.go
@@ -101,7 +101,11 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// L4RoutePolicy is an optional CRD. Only watch it when installed so the
 	// controller still starts if the CRD has not been applied yet (e.g. upgrades).
-	r.supportsL4RoutePolicy = pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	supportsL4RoutePolicy, err := pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	if err != nil {
+		return err
+	}
+	r.supportsL4RoutePolicy = supportsL4RoutePolicy
 	if r.supportsL4RoutePolicy {
 		bdr.Watches(&v1alpha1.L4RoutePolicy{},
 			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForL4RoutePolicy),

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -211,11 +211,15 @@ func setupGatewayAPIControllers(ctx context.Context, mgr manager.Manager, pro pr
 			Readier:  readier,
 		},
 	} {
-		if utils.HasAPIResource(mgr, resource) {
-			runnables = append(runnables, controller)
-		} else {
-			setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return nil, err
 		}
+		if !installed {
+			setupLog.Info("Skipping controller setup, API not found in cluster", "api", utils.FormatGVK(resource))
+			continue
+		}
+		runnables = append(runnables, controller)
 	}
 	return runnables, nil
 }
@@ -288,69 +292,88 @@ func setupAPIv2Controllers(ctx context.Context, mgr manager.Manager, pro provide
 			Updater: updater,
 		},
 	} {
-		if utils.HasAPIResource(mgr, resource) {
-			runnables = append(runnables, controller)
-		} else {
-			setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return nil, err
 		}
+		if !installed {
+			setupLog.Info("Skipping controller setup, API not found in cluster", "api", utils.FormatGVK(resource))
+			continue
+		}
+		runnables = append(runnables, controller)
 	}
 	return runnables, nil
 }
 
-func registerReadiness(mgr manager.Manager, readier readiness.ReadinessManager) {
+func registerReadiness(mgr manager.Manager, readier readiness.ReadinessManager) error {
 	log := ctrl.LoggerFrom(context.Background()).WithName("readiness")
 
-	registerAPIv2ForReadiness(mgr, log, readier)
-	if !config.ControllerConfig.DisableGatewayAPI {
-		registerGatewayAPIForReadiness(mgr, log, readier)
+	if err := registerAPIv2ForReadiness(mgr, log, readier); err != nil {
+		return err
 	}
-	registerAPIv1alpha1ForReadiness(mgr, log, readier)
+	if !config.ControllerConfig.DisableGatewayAPI {
+		if err := registerGatewayAPIForReadiness(mgr, log, readier); err != nil {
+			return err
+		}
+	}
+	return registerAPIv1alpha1ForReadiness(mgr, log, readier)
 }
 
 func registerGatewayAPIForReadiness(
 	mgr manager.Manager,
 	log logr.Logger,
 	readier readiness.ReadinessManager,
-) {
-	var installed []schema.GroupVersionKind
-	for _, resource := range []client.Object{
+) error {
+	resources := []client.Object{
 		&gatewayv1.HTTPRoute{},
 		&gatewayv1.GRPCRoute{},
 		&gatewayv1alpha2.TCPRoute{},
 		&gatewayv1alpha2.UDPRoute{},
 		&gatewayv1alpha2.TLSRoute{},
-	} {
+	}
+	installed := make([]schema.GroupVersionKind, 0, len(resources))
+	for _, resource := range resources {
 		gvk := types.GvkOf(resource)
-		if utils.HasAPIResource(mgr, resource) {
-			installed = append(installed, gvk)
-		} else {
-			log.Info("Skipping readiness registration, API not found", "gvk", gvk)
+		has, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
 		}
+		if !has {
+			log.Info("Skipping readiness registration, API not found", "gvk", gvk)
+			continue
+		}
+		installed = append(installed, gvk)
 	}
 	if len(installed) == 0 {
-		return
+		return nil
 	}
 
 	readier.RegisterGVK(readiness.GVKConfig{GVKs: installed})
+	return nil
 }
 
 func registerAPIv2ForReadiness(
 	mgr manager.Manager,
 	log logr.Logger,
 	readier readiness.ReadinessManager,
-) {
-	var installed []schema.GroupVersionKind
-	for _, resource := range apiV2ReadinessResources() {
+) error {
+	resources := apiV2ReadinessResources()
+	installed := make([]schema.GroupVersionKind, 0, len(resources))
+	for _, resource := range resources {
 		gvk := types.GvkOf(resource)
-		if utils.HasAPIResource(mgr, resource) {
-			installed = append(installed, gvk)
-		} else {
-			log.Info("Skipping readiness registration, API not found", "gvk", gvk)
+		has, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
 		}
+		if !has {
+			log.Info("Skipping readiness registration, API not found", "gvk", gvk)
+			continue
+		}
+		installed = append(installed, gvk)
 	}
 
 	if len(installed) == 0 {
-		return
+		return nil
 	}
 
 	readier.RegisterGVK(readiness.GVKConfig{
@@ -361,6 +384,7 @@ func registerAPIv2ForReadiness(
 			return ingressClass != nil
 		}),
 	})
+	return nil
 }
 
 func apiV2ReadinessResources() []client.Object {
@@ -377,20 +401,25 @@ func registerAPIv1alpha1ForReadiness(
 	mgr manager.Manager,
 	log logr.Logger,
 	readier readiness.ReadinessManager,
-) {
-	var installed []schema.GroupVersionKind
-	for _, resource := range []client.Object{
+) error {
+	resources := []client.Object{
 		&v1alpha1.Consumer{},
-	} {
+	}
+	installed := make([]schema.GroupVersionKind, 0, len(resources))
+	for _, resource := range resources {
 		gvk := types.GvkOf(resource)
-		if utils.HasAPIResource(mgr, resource) {
-			installed = append(installed, gvk)
-		} else {
-			log.Info("Skipping readiness registration, API not found", "gvk", gvk)
+		has, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
 		}
+		if !has {
+			log.Info("Skipping readiness registration, API not found", "gvk", gvk)
+			continue
+		}
+		installed = append(installed, gvk)
 	}
 	if len(installed) == 0 {
-		return
+		return nil
 	}
 
 	readier.RegisterGVK(readiness.GVKConfig{
@@ -403,4 +432,5 @@ func registerAPIv1alpha1ForReadiness(
 			return controller.MatchConsumerGatewayRef(context.Background(), mgr.GetClient(), log, consumer)
 		}),
 	})
+	return nil
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -240,7 +240,8 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 	if !hasReferenceGrant {
-		setupLog.Info("CRD ReferenceGrants is not installed")
+		setupLog.Info("CRD ReferenceGrants is not installed, cross-namespace references will be rejected",
+			"gvk", utils.FormatGVK(&v1beta1.ReferenceGrant{}))
 	}
 	controller.SetEnableReferenceGrant(hasReferenceGrant)
 

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/discovery"
@@ -49,6 +48,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	_ "github.com/apache/apisix-ingress-controller/internal/provider/init"
 	_ "github.com/apache/apisix-ingress-controller/pkg/metrics"
+	"github.com/apache/apisix-ingress-controller/pkg/utils"
 )
 
 var (
@@ -85,6 +85,11 @@ func Run(ctx context.Context, logger logr.Logger) error {
 	cfg := config.ControllerConfig
 
 	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
+
+	// SetupSignalHandler must be called exactly once. Install it before setup
+	// starts so that a shutdown signal is honored while waiting for the API
+	// server, not only once the manager is running.
+	signalCtx := ctrl.SetupSignalHandler()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -171,11 +176,25 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 
+	// Which API resources are installed is detected once, below, and gates the
+	// registration of field indexes, controllers and readiness checks for the
+	// whole lifetime of the process. Detecting them against an unreachable API
+	// server would silently classify everything as "not installed" and leave the
+	// controller permanently degraded until it is restarted, so wait for the API
+	// server to answer first.
+	if err := utils.WaitForAPIServer(signalCtx, mgr.GetConfig(), setupLog); err != nil {
+		setupLog.Error(err, "unable to reach the Kubernetes API server")
+		return err
+	}
+
 	// Check Kubernetes cluster version
 	checkK8sVersion(mgr, setupLog)
 
 	readier := readiness.NewReadinessManager(mgr.GetClient(), logger)
-	registerReadiness(mgr, readier)
+	if err := registerReadiness(mgr, readier); err != nil {
+		setupLog.Error(err, "unable to register readiness checks")
+		return err
+	}
 
 	if err := mgr.Add(readier); err != nil {
 		setupLog.Error(err, "unable to add readiness manager")
@@ -215,15 +234,15 @@ func Run(ctx context.Context, logger logr.Logger) error {
 	}
 
 	setupLog.Info("check ReferenceGrants is enabled")
-	_, err = mgr.GetRESTMapper().KindsFor(schema.GroupVersionResource{
-		Group:    v1beta1.GroupVersion.Group,
-		Version:  v1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
+	hasReferenceGrant, err := utils.HasAPIResource(mgr, &v1beta1.ReferenceGrant{})
 	if err != nil {
-		setupLog.Info("CRD ReferenceGrants is not installed", "err", err)
+		setupLog.Error(err, "unable to detect whether ReferenceGrants is installed")
+		return err
 	}
-	controller.SetEnableReferenceGrant(err == nil)
+	if !hasReferenceGrant {
+		setupLog.Info("CRD ReferenceGrants is not installed")
+	}
+	controller.SetEnableReferenceGrant(hasReferenceGrant)
 
 	setupLog.Info("setting up controllers")
 	controllers, err := setupControllers(ctx, mgr, provider, updater.Writer(), readier)
@@ -263,7 +282,7 @@ func Run(ctx context.Context, logger logr.Logger) error {
 	}
 
 	setupLog.Info("starting controller manager")
-	return mgr.Start(ctrl.SetupSignalHandler())
+	return mgr.Start(signalCtx)
 }
 
 func checkK8sVersion(mgr ctrl.Manager, logger logr.Logger) {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -187,12 +187,27 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 
+	// API resource detection runs outside the manager and does not observe
+	// signalCtx, so check between setup phases: now that the signal handler is
+	// installed this early, a shutdown signal would otherwise be swallowed until
+	// mgr.Start.
+	checkShutdown := func() error {
+		if err := signalCtx.Err(); err != nil {
+			setupLog.Info("shutdown requested during setup, stopping", "reason", err)
+			return err
+		}
+		return nil
+	}
+
 	// Check Kubernetes cluster version
 	checkK8sVersion(mgr, setupLog)
 
 	readier := readiness.NewReadinessManager(mgr.GetClient(), logger)
 	if err := registerReadiness(mgr, readier); err != nil {
 		setupLog.Error(err, "unable to register readiness checks")
+		return err
+	}
+	if err := checkShutdown(); err != nil {
 		return err
 	}
 
@@ -233,17 +248,26 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 
-	setupLog.Info("check ReferenceGrants is enabled")
-	hasReferenceGrant, err := utils.HasAPIResource(mgr, &v1beta1.ReferenceGrant{})
-	if err != nil {
-		setupLog.Error(err, "unable to detect whether ReferenceGrants is installed")
-		return err
-	}
-	if !hasReferenceGrant {
-		setupLog.Info("CRD ReferenceGrants is not installed, cross-namespace references will be rejected",
-			"gvk", utils.FormatGVK(&v1beta1.ReferenceGrant{}))
+	// ReferenceGrant is a Gateway API kind and only consulted by Gateway API
+	// paths, so skip the detection entirely when Gateway API is disabled.
+	hasReferenceGrant := false
+	if config.ControllerConfig.DisableGatewayAPI {
+		setupLog.Info("Gateway API is disabled, skipping the ReferenceGrants check")
+	} else {
+		setupLog.Info("check ReferenceGrants is enabled")
+		if hasReferenceGrant, err = utils.HasAPIResource(mgr, &v1beta1.ReferenceGrant{}); err != nil {
+			setupLog.Error(err, "unable to detect whether ReferenceGrants is installed")
+			return err
+		}
+		if !hasReferenceGrant {
+			setupLog.Info("CRD ReferenceGrants is not installed, cross-namespace references will be rejected",
+				"gvk", utils.FormatGVK(&v1beta1.ReferenceGrant{}))
+		}
 	}
 	controller.SetEnableReferenceGrant(hasReferenceGrant)
+	if err := checkShutdown(); err != nil {
+		return err
+	}
 
 	setupLog.Info("setting up controllers")
 	controllers, err := setupControllers(ctx, mgr, provider, updater.Writer(), readier)
@@ -254,6 +278,9 @@ func Run(ctx context.Context, logger logr.Logger) error {
 
 	for _, c := range controllers {
 		if err := c.SetupWithManager(mgr); err != nil {
+			return err
+		}
+		if err := checkShutdown(); err != nil {
 			return err
 		}
 	}

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -41,7 +42,7 @@ const (
 	// to absorb short blips. A longer outage is reported to the caller instead:
 	// it is not this function's job to decide how long to wait for the API server.
 	discoveryRetryInitialInterval = 500 * time.Millisecond
-	discoveryRetrySteps           = 5 // ~7.5s in total
+	discoveryRetrySteps           = 5 // ~7.5s, up to ~8.3s with jitter
 
 	// The startup wait for the API server is deliberately finite. The health
 	// probe endpoint is only served once mgr.Start runs, so a pod still waiting
@@ -49,7 +50,7 @@ const (
 	// explicit error and letting the pod restart says more in the logs than
 	// being killed mid-wait. Longer outages are absorbed by the restart backoff.
 	apiServerWaitInitialInterval = 1 * time.Second
-	apiServerWaitSteps           = 6 // ~31s in total
+	apiServerWaitSteps           = 6 // ~31s, up to ~34s with jitter
 
 	backoffFactor = 2
 	backoffJitter = 0.1
@@ -173,15 +174,19 @@ func WaitForAPIServer(ctx context.Context, cfg *rest.Config, logger logr.Logger)
 func waitForAPIServer(ctx context.Context, probe func() error, backoff wait.Backoff, logger logr.Logger) error {
 	var lastErr error
 	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
-		if lastErr = probe(); lastErr != nil {
+		if lastErr = probe(); !apiServerAnswered(lastErr) {
 			logger.Info("waiting for the Kubernetes API server to become reachable", "error", lastErr)
 			return false, nil
 		}
+		if lastErr != nil {
+			logger.Info("the Kubernetes API server rejected the probe but is reachable, continuing", "error", lastErr)
+		}
 		return true, nil
 	}); err != nil {
-		// Report why the API server did not answer; a cancelled ctx is the
-		// caller shutting us down and must stay recognizable as such.
-		if ctx.Err() == nil && lastErr != nil {
+		// ExponentialBackoffWithContext only ever returns ctx.Err() or its own
+		// interrupted error, so this tells cancellation and an exhausted budget
+		// apart without racing against ctx.
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && lastErr != nil {
 			err = lastErr
 		}
 		return fmt.Errorf("give up waiting for the Kubernetes API server: %w", err)
@@ -189,18 +194,32 @@ func waitForAPIServer(ctx context.Context, probe func() error, backoff wait.Back
 	return nil
 }
 
+// apiServerAnswered reports whether err still proves the API server responded.
+// An authn/authz rejection is an answer: a hardened cluster may not grant the
+// controller's service account access to the probed endpoint, and that is no
+// reason to hold up startup.
+func apiServerAnswered(err error) bool {
+	return err == nil || apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)
+}
+
 // retryUntilDefinitive runs probe until it returns nil or a definitive answer,
 // and reports the last failure once the retry budget is exhausted.
 func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func() error) error {
+	var probed bool
 	var lastErr error
-	//nolint:errcheck // the loop only ever exhausts its steps; lastErr carries the outcome.
-	_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		probed = true
 		if lastErr = probe(); lastErr == nil || isResourceAbsent(lastErr) {
 			return true, nil
 		}
 		logger.Info("discovery request failed, retrying", "error", lastErr)
 		return false, nil
 	})
+	if !probed {
+		// A backoff with no steps left never runs the condition. Reporting nil
+		// here would be read as "the resource is present" by every caller.
+		return fmt.Errorf("discovery was never attempted: %w", err)
+	}
 	return lastErr
 }
 

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -18,8 +18,18 @@
 package utils
 
 import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -27,20 +37,38 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/types"
 )
 
-// HasAPIResource checks if a specific API resource is available in the current cluster.
-// It uses the Discovery API to query the cluster's available resources and returns true
-// if the resource is found, false otherwise.
-func HasAPIResource(mgr ctrl.Manager, obj client.Object) bool {
+const (
+	// A discovery request that neither succeeds nor gives a definitive answer is
+	// retried a few times to absorb short blips. A longer outage is reported to
+	// the caller instead: it is not this function's job to decide how long the
+	// process should wait for the API server.
+	discoveryRetryInterval = 500 * time.Millisecond
+	discoveryRetryFactor   = 2
+	discoveryRetrySteps    = 4
+
+	// Interval bounds used while waiting for the API server to become reachable.
+	apiServerWaitInitialInterval = 1 * time.Second
+	apiServerWaitMaxInterval     = 30 * time.Second
+)
+
+// HasAPIResource reports whether the API resource of obj is served by the cluster.
+//
+// An error is returned when discovery cannot produce a definitive answer, for
+// instance because the API server is unreachable. Callers must not fall back to
+// "resource absent" in that case: detection runs once at startup and gates field
+// index, controller and readiness registration, so a temporary API server outage
+// would otherwise leave the controller permanently degraded until it is
+// restarted.
+func HasAPIResource(mgr ctrl.Manager, obj client.Object) (bool, error) {
 	return HasAPIResourceWithLogger(mgr, obj, ctrl.Log.WithName("api-detection"))
 }
 
 // HasAPIResourceWithLogger is the same as HasAPIResource but accepts a custom logger
 // for more detailed debugging information.
-func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.Logger) bool {
+func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.Logger) (bool, error) {
 	gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
 	if err != nil {
-		logger.Info("cannot derive GVK from scheme", "error", err)
-		return false
+		return false, fmt.Errorf("cannot derive GVK from scheme: %w", err)
 	}
 
 	groupVersion := gvk.GroupVersion().String()
@@ -55,26 +83,107 @@ func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.L
 	// Create discovery client
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
-		logger.Info("failed to create discovery client", "error", err)
-		return false
+		return false, fmt.Errorf("failed to create discovery client: %w", err)
 	}
 
 	// Query server resources for the specific group/version
-	apiResources, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
-	if err != nil {
+	var apiResources *metav1.APIResourceList
+	err = discoverWithRetry(func() error {
+		var err error
+		apiResources, err = discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+		return err
+	}, logger, time.Sleep)
+	switch {
+	case err == nil:
+	case isResourceAbsent(err):
 		logger.Info("group/version not available in cluster", "error", err)
-		return false
+		return false, nil
+	default:
+		return false, fmt.Errorf("failed to detect API resource %s: %w", gvk, err)
 	}
 
 	// Check if the specific kind exists in the resource list
 	for _, res := range apiResources.APIResources {
 		if res.Kind == gvk.Kind {
-			return true
+			return true, nil
 		}
 	}
 
 	logger.Info("API resource kind not found in group/version")
-	return false
+	return false, nil
+}
+
+// WaitForAPIServer blocks until the API server answers a discovery request, or
+// ctx is done.
+//
+// Capability detection (field indexes, optional CRDs, ReferenceGrant support) is
+// decided once at startup and cannot be revised afterwards, so it must not run
+// against an unreachable API server.
+func WaitForAPIServer(ctx context.Context, cfg *rest.Config, logger logr.Logger) error {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	backoff := wait.Backoff{
+		Duration: apiServerWaitInitialInterval,
+		Factor:   discoveryRetryFactor,
+		Jitter:   0.1,
+		Cap:      apiServerWaitMaxInterval,
+		// Retry until ctx is done rather than for a fixed number of attempts:
+		// the controller cannot do anything useful without the API server.
+		Steps: math.MaxInt32,
+	}
+	return waitForAPIServer(ctx, discoveryClient.ServerVersion, backoff, logger)
+}
+
+func waitForAPIServer(ctx context.Context, probe func() (*version.Info, error), backoff wait.Backoff, logger logr.Logger) error {
+	var lastErr error
+	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
+		if _, lastErr = probe(); lastErr != nil {
+			logger.Info("waiting for the Kubernetes API server to become reachable", "error", lastErr)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		if lastErr != nil {
+			err = lastErr
+		}
+		return fmt.Errorf("give up waiting for the Kubernetes API server: %w", err)
+	}
+	return nil
+}
+
+// discoverWithRetry runs probe until it returns nil or a definitive answer,
+// retrying at most discoveryRetrySteps times. sleep is injected for testability.
+func discoverWithRetry(probe func() error, logger logr.Logger, sleep func(time.Duration)) error {
+	interval := discoveryRetryInterval
+	for i := 0; ; i++ {
+		err := probe()
+		if err == nil || isResourceAbsent(err) || i == discoveryRetrySteps {
+			return err
+		}
+		logger.Info("discovery request failed, retrying", "error", err, "retryIn", interval.String())
+		sleep(interval)
+		interval *= discoveryRetryFactor
+	}
+}
+
+// isResourceAbsent reports whether err definitively means the group/version is
+// not usable, as opposed to discovery having failed to reach a conclusion.
+func isResourceAbsent(err error) bool {
+	switch {
+	// Discovery of a group/version that is not installed answers 404.
+	case apierrors.IsNotFound(err):
+		return true
+	// RBAC forbids discovery: the resource is not usable by this controller and
+	// waiting will not change that.
+	case apierrors.IsForbidden(err):
+		return true
+	// Connection refused, timeouts, EOF, 5xx, throttling: the API server may
+	// answer differently once it is reachable again, so no conclusion yet.
+	default:
+		return false
+	}
 }
 
 func FormatGVK(obj client.Object) string {

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -79,12 +79,12 @@ func apiServerWaitBackoff() wait.Backoff {
 
 // HasAPIResource reports whether the API resource of obj is served by the cluster.
 //
-// An error is returned when discovery cannot produce a definitive answer, for
-// instance because the API server is unreachable. Callers must not fall back to
-// "resource absent" in that case: detection runs once at startup and gates field
-// index, controller and readiness registration, so a temporary API server outage
-// would otherwise leave the controller permanently degraded until it is
-// restarted.
+// Only a 404 from discovery reports the resource as absent. Every other failure
+// returns an error, including a Forbidden discovery request: callers must not
+// fall back to "resource absent" there. Detection runs once at startup and gates
+// field index, controller and readiness registration, so an API server outage or
+// an RBAC mistake would otherwise leave the controller permanently degraded
+// until it is restarted.
 func HasAPIResource(mgr ctrl.Manager, obj client.Object) (bool, error) {
 	return HasAPIResourceWithLogger(mgr, obj, ctrl.Log.WithName("api-detection"))
 }
@@ -134,11 +134,12 @@ func hasAPIResource(
 		logger.Info("group/version not available in cluster", "error", err)
 		return false, nil
 	case apierrors.IsForbidden(err):
-		// Definitive, but a misconfiguration rather than an absent CRD: log loudly
-		// so it is not mistaken for "the CRD was never installed".
-		logger.Error(err, "discovery is forbidden, treating the API resource as not installed; "+
-			"check the discovery permissions of the controller service account")
-		return false, nil
+		// Definitive, but no evidence of absence: the resource may well be served
+		// and only discovery is denied. Resolving it to "absent" would be cached
+		// for the lifetime of the manager and permanently skip the controller, so
+		// an RBAC misconfiguration must abort startup instead.
+		return false, fmt.Errorf("discovery of %s is forbidden, check the discovery "+
+			"permissions of the controller service account: %w", gvk, err)
 	default:
 		return false, fmt.Errorf("failed to detect API resource %s: %w", gvk, err)
 	}
@@ -209,7 +210,7 @@ func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func()
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		probed = true
-		if lastErr = probe(); lastErr == nil || isResourceAbsent(lastErr) {
+		if lastErr = probe(); lastErr == nil || isDefinitive(lastErr) {
 			return true, nil
 		}
 		logger.Info("discovery request failed, retrying", "error", lastErr)
@@ -223,15 +224,16 @@ func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func()
 	return lastErr
 }
 
-// isResourceAbsent reports whether err definitively means the group/version is
-// not usable, as opposed to discovery having failed to reach a conclusion.
-func isResourceAbsent(err error) bool {
+// isDefinitive reports whether err settles the discovery request, so that
+// retrying it cannot change the outcome. Only the caller decides what a
+// definitive failure means: NotFound is absence, Forbidden is a misconfiguration.
+func isDefinitive(err error) bool {
 	switch {
 	// Discovery of a group/version that is not installed answers 404.
 	case apierrors.IsNotFound(err):
 		return true
-	// RBAC forbids discovery: the resource is not usable by this controller and
-	// waiting will not change that.
+	// RBAC forbids discovery: waiting will not change that, but it says nothing
+	// about whether the resource is served.
 	case apierrors.IsForbidden(err):
 		return true
 	// Connection refused, timeouts, EOF, 5xx, throttling: the API server may

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -20,14 +20,13 @@ package utils
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,18 +37,44 @@ import (
 )
 
 const (
-	// A discovery request that neither succeeds nor gives a definitive answer is
-	// retried a few times to absorb short blips. A longer outage is reported to
-	// the caller instead: it is not this function's job to decide how long the
-	// process should wait for the API server.
-	discoveryRetryInterval = 500 * time.Millisecond
-	discoveryRetryFactor   = 2
-	discoveryRetrySteps    = 4
+	// A discovery request that gives no definitive answer is retried a few times
+	// to absorb short blips. A longer outage is reported to the caller instead:
+	// it is not this function's job to decide how long to wait for the API server.
+	discoveryRetryInitialInterval = 500 * time.Millisecond
+	discoveryRetrySteps           = 5 // ~7.5s in total
 
-	// Interval bounds used while waiting for the API server to become reachable.
+	// The startup wait for the API server is deliberately finite. The health
+	// probe endpoint is only served once mgr.Start runs, so a pod still waiting
+	// here fails its liveness probe and is killed anyway; giving up with an
+	// explicit error and letting the pod restart says more in the logs than
+	// being killed mid-wait. Longer outages are absorbed by the restart backoff.
 	apiServerWaitInitialInterval = 1 * time.Second
-	apiServerWaitMaxInterval     = 30 * time.Second
+	apiServerWaitSteps           = 6 // ~31s in total
+
+	backoffFactor = 2
+	backoffJitter = 0.1
 )
+
+// Neither backoff sets Cap: wait.Backoff zeroes the remaining steps as soon as
+// the capped interval is reached, which would silently cut the retries short.
+
+func discoveryBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: discoveryRetryInitialInterval,
+		Factor:   backoffFactor,
+		Jitter:   backoffJitter,
+		Steps:    discoveryRetrySteps,
+	}
+}
+
+func apiServerWaitBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: apiServerWaitInitialInterval,
+		Factor:   backoffFactor,
+		Jitter:   backoffJitter,
+		Steps:    apiServerWaitSteps,
+	}
+}
 
 // HasAPIResource reports whether the API resource of obj is served by the cluster.
 //
@@ -71,6 +96,21 @@ func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.L
 		return false, fmt.Errorf("cannot derive GVK from scheme: %w", err)
 	}
 
+	// Create discovery client
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		return false, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	return hasAPIResource(discoveryClient, gvk, discoveryBackoff(), logger)
+}
+
+func hasAPIResource(
+	discoveryClient discovery.DiscoveryInterface,
+	gvk schema.GroupVersionKind,
+	backoff wait.Backoff,
+	logger logr.Logger,
+) (bool, error) {
 	groupVersion := gvk.GroupVersion().String()
 
 	logger = logger.WithValues(
@@ -80,23 +120,23 @@ func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.L
 		"groupVersion", groupVersion,
 	)
 
-	// Create discovery client
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
-	if err != nil {
-		return false, fmt.Errorf("failed to create discovery client: %w", err)
-	}
-
 	// Query server resources for the specific group/version
 	var apiResources *metav1.APIResourceList
-	err = discoverWithRetry(func() error {
+	err := retryUntilDefinitive(backoff, logger, func() error {
 		var err error
 		apiResources, err = discoveryClient.ServerResourcesForGroupVersion(groupVersion)
 		return err
-	}, logger, time.Sleep)
+	})
 	switch {
 	case err == nil:
-	case isResourceAbsent(err):
+	case apierrors.IsNotFound(err):
 		logger.Info("group/version not available in cluster", "error", err)
+		return false, nil
+	case apierrors.IsForbidden(err):
+		// Definitive, but a misconfiguration rather than an absent CRD: log loudly
+		// so it is not mistaken for "the CRD was never installed".
+		logger.Error(err, "discovery is forbidden, treating the API resource as not installed; "+
+			"check the discovery permissions of the controller service account")
 		return false, nil
 	default:
 		return false, fmt.Errorf("failed to detect API resource %s: %w", gvk, err)
@@ -113,8 +153,8 @@ func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.L
 	return false, nil
 }
 
-// WaitForAPIServer blocks until the API server answers a discovery request, or
-// ctx is done.
+// WaitForAPIServer blocks until the API server answers a discovery request, ctx
+// is done, or the wait budget is exhausted.
 //
 // Capability detection (field indexes, optional CRDs, ReferenceGrant support) is
 // decided once at startup and cannot be revised afterwards, so it must not run
@@ -124,28 +164,24 @@ func WaitForAPIServer(ctx context.Context, cfg *rest.Config, logger logr.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to create discovery client: %w", err)
 	}
-	backoff := wait.Backoff{
-		Duration: apiServerWaitInitialInterval,
-		Factor:   discoveryRetryFactor,
-		Jitter:   0.1,
-		Cap:      apiServerWaitMaxInterval,
-		// Retry until ctx is done rather than for a fixed number of attempts:
-		// the controller cannot do anything useful without the API server.
-		Steps: math.MaxInt32,
-	}
-	return waitForAPIServer(ctx, discoveryClient.ServerVersion, backoff, logger)
+	return waitForAPIServer(ctx, func() error {
+		_, err := discoveryClient.ServerVersion()
+		return err
+	}, apiServerWaitBackoff(), logger)
 }
 
-func waitForAPIServer(ctx context.Context, probe func() (*version.Info, error), backoff wait.Backoff, logger logr.Logger) error {
+func waitForAPIServer(ctx context.Context, probe func() error, backoff wait.Backoff, logger logr.Logger) error {
 	var lastErr error
 	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
-		if _, lastErr = probe(); lastErr != nil {
+		if lastErr = probe(); lastErr != nil {
 			logger.Info("waiting for the Kubernetes API server to become reachable", "error", lastErr)
 			return false, nil
 		}
 		return true, nil
 	}); err != nil {
-		if lastErr != nil {
+		// Report why the API server did not answer; a cancelled ctx is the
+		// caller shutting us down and must stay recognizable as such.
+		if ctx.Err() == nil && lastErr != nil {
 			err = lastErr
 		}
 		return fmt.Errorf("give up waiting for the Kubernetes API server: %w", err)
@@ -153,19 +189,19 @@ func waitForAPIServer(ctx context.Context, probe func() (*version.Info, error), 
 	return nil
 }
 
-// discoverWithRetry runs probe until it returns nil or a definitive answer,
-// retrying at most discoveryRetrySteps times. sleep is injected for testability.
-func discoverWithRetry(probe func() error, logger logr.Logger, sleep func(time.Duration)) error {
-	interval := discoveryRetryInterval
-	for i := 0; ; i++ {
-		err := probe()
-		if err == nil || isResourceAbsent(err) || i == discoveryRetrySteps {
-			return err
+// retryUntilDefinitive runs probe until it returns nil or a definitive answer,
+// and reports the last failure once the retry budget is exhausted.
+func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func() error) error {
+	var lastErr error
+	//nolint:errcheck // the loop only ever exhausts its steps; lastErr carries the outcome.
+	_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		if lastErr = probe(); lastErr == nil || isResourceAbsent(lastErr) {
+			return true, nil
 		}
-		logger.Info("discovery request failed, retrying", "error", err, "retryIn", interval.String())
-		sleep(interval)
-		interval *= discoveryRetryFactor
-	}
+		logger.Info("discovery request failed, retrying", "error", lastErr)
+		return false, nil
+	})
+	return lastErr
 }
 
 // isResourceAbsent reports whether err definitively means the group/version is

--- a/pkg/utils/k8s_test.go
+++ b/pkg/utils/k8s_test.go
@@ -42,10 +42,20 @@ func fastBackoff(steps int) wait.Backoff {
 	return wait.Backoff{Duration: time.Millisecond, Factor: backoffFactor, Jitter: backoffJitter, Steps: steps}
 }
 
+// declaredBudget is how long a backoff sleeps in total before jitter, i.e. the
+// sum of the intervals between its attempts.
+func declaredBudget(backoff wait.Backoff) time.Duration {
+	var total, interval time.Duration = 0, backoff.Duration
+	for i := 0; i < backoff.Steps-1; i++ {
+		total += interval
+		interval = time.Duration(float64(interval) * backoff.Factor)
+	}
+	return total
+}
+
 // countingBackoff reports how many times a backoff actually runs its condition.
 func countAttempts(backoff wait.Backoff) int {
 	var attempts int
-	//nolint:errcheck // the condition never succeeds, the error is always ErrWaitTimeout.
 	_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
 		attempts++
 		return false, nil
@@ -62,14 +72,17 @@ func TestBackoffsUseAllTheirSteps(t *testing.T) {
 		name    string
 		backoff wait.Backoff
 		steps   int
+		budget  time.Duration // as documented next to the constants
 	}{
-		{"discovery", discoveryBackoff(), discoveryRetrySteps},
-		{"apiServerWait", apiServerWaitBackoff(), apiServerWaitSteps},
+		{"discovery", discoveryBackoff(), discoveryRetrySteps, 7500 * time.Millisecond},
+		{"apiServerWait", apiServerWaitBackoff(), apiServerWaitSteps, 31 * time.Second},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			assert.Zero(t, tt.backoff.Cap, "Cap truncates the retries, see wait.delay()")
+			assert.Equal(t, tt.budget, declaredBudget(tt.backoff), "the documented budget must match the backoff")
+
 			b := tt.backoff
 			b.Duration = time.Microsecond // keep the test fast, preserve the shape
-			assert.Zero(t, b.Cap, "Cap truncates the retries, see wait.delay()")
 			assert.Equal(t, tt.steps, countAttempts(b))
 		})
 	}
@@ -147,6 +160,22 @@ func TestRetryUntilDefinitive_DefinitiveAbsent(t *testing.T) {
 	assert.Equal(t, 1, calls, "a definitive NotFound must not be retried")
 }
 
+// TestRetryUntilDefinitive_NeverProbed guards the caller's assumption that a
+// nil error means "the probe succeeded": a backoff with no steps left never runs
+// the condition, and reporting nil there would be read as "resource present".
+func TestRetryUntilDefinitive_NeverProbed(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		return nil
+	}
+
+	err := retryUntilDefinitive(wait.Backoff{Steps: 0}, logr.Discard(), probe)
+	require.Error(t, err)
+	assert.Zero(t, calls)
+	assert.False(t, isResourceAbsent(err), "an unattempted probe must not resolve to absent either")
+}
+
 func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
 	var calls int
 	probe := func() error {
@@ -159,6 +188,27 @@ func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
 
 	require.NoError(t, waitForAPIServer(context.Background(), probe, fastBackoff(6), logr.Discard()))
 	assert.Equal(t, 3, calls)
+}
+
+// TestWaitForAPIServer_AuthRejectionIsReachable covers a hardened cluster that
+// does not grant the controller access to the probed endpoint: the API server
+// answered, so startup must proceed instead of stalling until the budget runs
+// out and then failing on a perfectly healthy cluster.
+func TestWaitForAPIServer_AuthRejectionIsReachable(t *testing.T) {
+	for name, probeErr := range map[string]error{
+		"unauthorized": apierrors.NewUnauthorized("no token"),
+		"forbidden":    apierrors.NewForbidden(schema.GroupResource{}, "", errors.New("nope")),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var calls int
+			probe := func() error {
+				calls++
+				return probeErr
+			}
+			require.NoError(t, waitForAPIServer(context.Background(), probe, fastBackoff(5), logr.Discard()))
+			assert.Equal(t, 1, calls, "an answer, even a rejection, must not be retried")
+		})
+	}
 }
 
 func TestWaitForAPIServer_GivesUpWithTheLastError(t *testing.T) {

--- a/pkg/utils/k8s_test.go
+++ b/pkg/utils/k8s_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -30,11 +32,48 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 )
 
-// testBackoff keeps the API server wait tests fast.
-var testBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 1, Steps: 10}
+// fastBackoff keeps the tests quick while preserving the shape of the
+// production backoffs (a growing interval over a fixed number of steps).
+func fastBackoff(steps int) wait.Backoff {
+	return wait.Backoff{Duration: time.Millisecond, Factor: backoffFactor, Jitter: backoffJitter, Steps: steps}
+}
+
+// countingBackoff reports how many times a backoff actually runs its condition.
+func countAttempts(backoff wait.Backoff) int {
+	var attempts int
+	//nolint:errcheck // the condition never succeeds, the error is always ErrWaitTimeout.
+	_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		attempts++
+		return false, nil
+	})
+	return attempts
+}
+
+// TestBackoffsUseAllTheirSteps guards against a subtle wait.Backoff behavior:
+// setting Cap zeroes the remaining steps as soon as the capped interval is
+// reached, silently cutting the retries short. Both backoffs must run every
+// step they declare.
+func TestBackoffsUseAllTheirSteps(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		backoff wait.Backoff
+		steps   int
+	}{
+		{"discovery", discoveryBackoff(), discoveryRetrySteps},
+		{"apiServerWait", apiServerWaitBackoff(), apiServerWaitSteps},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			b := tt.backoff
+			b.Duration = time.Microsecond // keep the test fast, preserve the shape
+			assert.Zero(t, b.Cap, "Cap truncates the retries, see wait.delay()")
+			assert.Equal(t, tt.steps, countAttempts(b))
+		})
+	}
+}
 
 func TestIsResourceAbsent(t *testing.T) {
 	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
@@ -62,25 +101,24 @@ func TestIsResourceAbsent(t *testing.T) {
 	}
 }
 
-// TestDiscoverWithRetry_ReportsIndeterminateFailure is the core regression test
-// for #2734: a discovery failure that gives no definitive answer must surface as
-// an error so the caller aborts startup, instead of collapsing into "resource
-// absent" and permanently skipping the field index and its controller.
-func TestDiscoverWithRetry_ReportsIndeterminateFailure(t *testing.T) {
+// TestRetryUntilDefinitive_ReportsIndeterminateFailure is the core regression
+// test for #2734: a discovery failure that gives no definitive answer must
+// surface as an error so the caller aborts startup, instead of collapsing into
+// "resource absent" and permanently skipping the field index and its controller.
+func TestRetryUntilDefinitive_ReportsIndeterminateFailure(t *testing.T) {
 	var calls int
 	probe := func() error {
 		calls++
 		return apierrors.NewServiceUnavailable("apiserver not ready")
 	}
 
-	var slept int
-	err := discoverWithRetry(probe, logr.Discard(), func(time.Duration) { slept++ })
+	err := retryUntilDefinitive(fastBackoff(3), logr.Discard(), probe)
 	require.Error(t, err, "an unreachable API server must not be reported as a definitive answer")
-	assert.Equal(t, discoveryRetrySteps+1, calls)
-	assert.Equal(t, discoveryRetrySteps, slept)
+	assert.False(t, isResourceAbsent(err))
+	assert.Equal(t, 3, calls, "the whole retry budget must be used")
 }
 
-func TestDiscoverWithRetry_TransientThenSuccess(t *testing.T) {
+func TestRetryUntilDefinitive_TransientThenSuccess(t *testing.T) {
 	var calls int
 	probe := func() error {
 		calls++
@@ -90,15 +128,13 @@ func TestDiscoverWithRetry_TransientThenSuccess(t *testing.T) {
 		return nil
 	}
 
-	var slept int
-	require.NoError(t, discoverWithRetry(probe, logr.Discard(), func(time.Duration) { slept++ }))
+	require.NoError(t, retryUntilDefinitive(fastBackoff(5), logr.Discard(), probe))
 	assert.Equal(t, 3, calls, "an indeterminate failure must be retried, not given up on")
-	assert.Equal(t, 2, slept, "backoff must be applied between retries")
 }
 
-// TestDiscoverWithRetry_DefinitiveAbsent ensures a genuinely absent CRD is
+// TestRetryUntilDefinitive_DefinitiveAbsent ensures a genuinely absent CRD is
 // answered immediately without retrying, preserving optional-CRD support.
-func TestDiscoverWithRetry_DefinitiveAbsent(t *testing.T) {
+func TestRetryUntilDefinitive_DefinitiveAbsent(t *testing.T) {
 	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
 	var calls int
 	probe := func() error {
@@ -106,38 +142,128 @@ func TestDiscoverWithRetry_DefinitiveAbsent(t *testing.T) {
 		return apierrors.NewNotFound(gr, "tcproutes")
 	}
 
-	var slept int
-	err := discoverWithRetry(probe, logr.Discard(), func(time.Duration) { slept++ })
+	err := retryUntilDefinitive(fastBackoff(5), logr.Discard(), probe)
 	assert.True(t, isResourceAbsent(err))
 	assert.Equal(t, 1, calls, "a definitive NotFound must not be retried")
-	assert.Equal(t, 0, slept)
 }
 
 func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
 	var calls int
-	probe := func() (*version.Info, error) {
+	probe := func() error {
 		calls++
 		if calls < 3 {
-			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+			return &net.OpError{Op: "dial", Err: errors.New("connection refused")}
 		}
-		return &version.Info{GitVersion: "v1.31.0"}, nil
+		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	require.NoError(t, waitForAPIServer(ctx, probe, testBackoff, logr.Discard()))
+	require.NoError(t, waitForAPIServer(context.Background(), probe, fastBackoff(6), logr.Discard()))
 	assert.Equal(t, 3, calls)
 }
 
-// TestWaitForAPIServer_HonorsContext ensures the wait is interruptible, so a
-// shutdown signal is not ignored while the API server is unreachable.
+func TestWaitForAPIServer_GivesUpWithTheLastError(t *testing.T) {
+	probe := func() error { return apierrors.NewServiceUnavailable("apiserver not ready") }
+
+	err := waitForAPIServer(context.Background(), probe, fastBackoff(3), logr.Discard())
+	require.Error(t, err)
+	assert.True(t, apierrors.IsServiceUnavailable(errors.Unwrap(err)), "the last probe error must be reported, got %v", err)
+}
+
+// TestWaitForAPIServer_HonorsContext ensures the wait is interrupted mid-flight,
+// so a shutdown signal is not ignored while the API server is unreachable.
 func TestWaitForAPIServer_HonorsContext(t *testing.T) {
-	probe := func() (*version.Info, error) {
-		return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int
+	probe := func() error {
+		if calls++; calls == 2 {
+			cancel()
+		}
+		return &net.OpError{Op: "dial", Err: errors.New("connection refused")}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	err := waitForAPIServer(ctx, probe, testBackoff, logr.Discard())
-	require.Error(t, err)
+	// A budget far larger than the number of attempts the test expects: the wait
+	// must end because ctx was cancelled, not because it ran out of steps.
+	err := waitForAPIServer(ctx, probe, fastBackoff(100), logr.Discard())
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 2, calls, "the probe must stop being called once ctx is cancelled")
+}
+
+// newDiscoveryClient serves discovery responses from handler.
+func newDiscoveryClient(t *testing.T, handler http.HandlerFunc) discovery.DiscoveryInterface {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := discovery.NewDiscoveryClientForConfig(&rest.Config{Host: srv.URL})
+	require.NoError(t, err)
+	return c
+}
+
+// TestHasAPIResource covers the contract every caller depends on, against a real
+// discovery client rather than a fake: only a definitive answer may resolve to
+// "absent", everything else must be an error.
+func TestHasAPIResource(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
+
+	tests := []struct {
+		name      string
+		handler   http.HandlerFunc
+		wantFound bool
+		wantErr   bool
+	}{
+		{
+			name: "kind served",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1alpha2",` +
+					`"resources":[{"name":"tcproutes","kind":"TCPRoute"}]}`))
+			},
+			wantFound: true,
+		},
+		{
+			name: "group/version served but kind missing",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1alpha2",` +
+					`"resources":[{"name":"udproutes","kind":"UDPRoute"}]}`))
+			},
+		},
+		{
+			// What a real API server returns for a group/version that is not
+			// installed: a plain-text 404, not a Status object.
+			name: "group/version not installed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.NotFound(w, nil)
+			},
+		},
+		{
+			// The #2734 scenario: the API server cannot answer. This must not be
+			// reported as "the CRD is not installed".
+			name: "api server unavailable",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			wantErr: true,
+		},
+		{
+			name: "discovery forbidden",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found, err := hasAPIResource(newDiscoveryClient(t, tt.handler), gvk, fastBackoff(2), logr.Discard())
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.False(t, found)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFound, found)
+		})
+	}
 }

--- a/pkg/utils/k8s_test.go
+++ b/pkg/utils/k8s_test.go
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+// testBackoff keeps the API server wait tests fast.
+var testBackoff = wait.Backoff{Duration: time.Millisecond, Factor: 1, Steps: 10}
+
+func TestIsResourceAbsent(t *testing.T) {
+	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
+	tests := []struct {
+		name   string
+		err    error
+		absent bool
+	}{
+		// Definitive: the group/version is genuinely not served.
+		{"not found", apierrors.NewNotFound(gr, "tcproutes"), true},
+		// Definitive: RBAC will not self-heal by waiting.
+		{"forbidden", apierrors.NewForbidden(gr, "tcproutes", errors.New("nope")), true},
+		// Indeterminate: the API server is temporarily unreachable or overloaded.
+		{"connection refused", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, false},
+		{"service unavailable", apierrors.NewServiceUnavailable("apiserver is starting up"), false},
+		{"server timeout", apierrors.NewServerTimeout(gr, "get", 1), false},
+		{"too many requests", apierrors.NewTooManyRequestsError("slow down"), false},
+		{"internal error", apierrors.NewInternalError(errors.New("boom")), false},
+		{"generic transport error", errors.New("EOF"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.absent, isResourceAbsent(tt.err))
+		})
+	}
+}
+
+// TestDiscoverWithRetry_ReportsIndeterminateFailure is the core regression test
+// for #2734: a discovery failure that gives no definitive answer must surface as
+// an error so the caller aborts startup, instead of collapsing into "resource
+// absent" and permanently skipping the field index and its controller.
+func TestDiscoverWithRetry_ReportsIndeterminateFailure(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		return apierrors.NewServiceUnavailable("apiserver not ready")
+	}
+
+	var slept int
+	err := discoverWithRetry(probe, logr.Discard(), func(time.Duration) { slept++ })
+	require.Error(t, err, "an unreachable API server must not be reported as a definitive answer")
+	assert.Equal(t, discoveryRetrySteps+1, calls)
+	assert.Equal(t, discoveryRetrySteps, slept)
+}
+
+func TestDiscoverWithRetry_TransientThenSuccess(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		if calls < 3 {
+			return apierrors.NewServiceUnavailable("apiserver not ready")
+		}
+		return nil
+	}
+
+	var slept int
+	require.NoError(t, discoverWithRetry(probe, logr.Discard(), func(time.Duration) { slept++ }))
+	assert.Equal(t, 3, calls, "an indeterminate failure must be retried, not given up on")
+	assert.Equal(t, 2, slept, "backoff must be applied between retries")
+}
+
+// TestDiscoverWithRetry_DefinitiveAbsent ensures a genuinely absent CRD is
+// answered immediately without retrying, preserving optional-CRD support.
+func TestDiscoverWithRetry_DefinitiveAbsent(t *testing.T) {
+	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
+	var calls int
+	probe := func() error {
+		calls++
+		return apierrors.NewNotFound(gr, "tcproutes")
+	}
+
+	var slept int
+	err := discoverWithRetry(probe, logr.Discard(), func(time.Duration) { slept++ })
+	assert.True(t, isResourceAbsent(err))
+	assert.Equal(t, 1, calls, "a definitive NotFound must not be retried")
+	assert.Equal(t, 0, slept)
+}
+
+func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
+	var calls int
+	probe := func() (*version.Info, error) {
+		calls++
+		if calls < 3 {
+			return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		}
+		return &version.Info{GitVersion: "v1.31.0"}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, waitForAPIServer(ctx, probe, testBackoff, logr.Discard()))
+	assert.Equal(t, 3, calls)
+}
+
+// TestWaitForAPIServer_HonorsContext ensures the wait is interruptible, so a
+// shutdown signal is not ignored while the API server is unreachable.
+func TestWaitForAPIServer_HonorsContext(t *testing.T) {
+	probe := func() (*version.Info, error) {
+		return nil, &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := waitForAPIServer(ctx, probe, testBackoff, logr.Discard())
+	require.Error(t, err)
+}

--- a/pkg/utils/k8s_test.go
+++ b/pkg/utils/k8s_test.go
@@ -88,12 +88,12 @@ func TestBackoffsUseAllTheirSteps(t *testing.T) {
 	}
 }
 
-func TestIsResourceAbsent(t *testing.T) {
+func TestIsDefinitive(t *testing.T) {
 	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
 	tests := []struct {
-		name   string
-		err    error
-		absent bool
+		name       string
+		err        error
+		definitive bool
 	}{
 		// Definitive: the group/version is genuinely not served.
 		{"not found", apierrors.NewNotFound(gr, "tcproutes"), true},
@@ -109,7 +109,7 @@ func TestIsResourceAbsent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.absent, isResourceAbsent(tt.err))
+			assert.Equal(t, tt.definitive, isDefinitive(tt.err))
 		})
 	}
 }
@@ -127,7 +127,7 @@ func TestRetryUntilDefinitive_ReportsIndeterminateFailure(t *testing.T) {
 
 	err := retryUntilDefinitive(fastBackoff(3), logr.Discard(), probe)
 	require.Error(t, err, "an unreachable API server must not be reported as a definitive answer")
-	assert.False(t, isResourceAbsent(err))
+	assert.False(t, isDefinitive(err))
 	assert.Equal(t, 3, calls, "the whole retry budget must be used")
 }
 
@@ -156,7 +156,7 @@ func TestRetryUntilDefinitive_DefinitiveAbsent(t *testing.T) {
 	}
 
 	err := retryUntilDefinitive(fastBackoff(5), logr.Discard(), probe)
-	assert.True(t, isResourceAbsent(err))
+	assert.True(t, isDefinitive(err))
 	assert.Equal(t, 1, calls, "a definitive NotFound must not be retried")
 }
 
@@ -173,7 +173,7 @@ func TestRetryUntilDefinitive_NeverProbed(t *testing.T) {
 	err := retryUntilDefinitive(wait.Backoff{Steps: 0}, logr.Discard(), probe)
 	require.Error(t, err)
 	assert.Zero(t, calls)
-	assert.False(t, isResourceAbsent(err), "an unattempted probe must not resolve to absent either")
+	assert.False(t, isDefinitive(err), "an unattempted probe must not look like a definitive answer either")
 }
 
 func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
@@ -297,10 +297,15 @@ func TestHasAPIResource(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// Forbidden is definitive but proves nothing about the resource: the
+			// CRD may well be served and only discovery denied. Resolving it to
+			// "absent" would permanently skip the controller, so it must abort
+			// startup and point at the RBAC instead.
 			name: "discovery forbidden",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusForbidden)
 			},
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Fixes #2734

After a control-plane failover (kube-apiserver unreachable while the controller was starting up), every reconcile failed forever with `Index with name field:serviceRefs/secretRefs/ingressClassParametersRef does not exist` until the pod was restarted manually.

**Root cause.** `HasAPIResource` returned `false` on *any* discovery error — indistinguishable from "the CRD is genuinely not installed". API resource detection runs once at startup and gates field index, controller and readiness registration, so an API server that was unreachable at that instant classified everything as absent. Informers reconnected on their own once the API server came back, so reconciles ran, but every `List` with a field selector failed permanently.

The ReferenceGrant detection in `run.go` had the same defect through a different call: a transient `RESTMapper.KindsFor` error set the process-wide `enableReferenceGrant` to `false`, which makes `checkReferenceGrant` reject every cross-namespace reference and skips the ReferenceGrant watches. That failure is visible in the issue's own log (`CRD ReferenceGrants is not installed {"err": "... connect: no route to host"}`).

**Fix.**

1. Wait for the API server to answer a discovery request before any capability detection runs (`utils.WaitForAPIServer`). These are one-shot decisions that cannot be revised later, so they must not be made against a dead API server. The wait is bounded (~31s) on purpose: the health probe endpoint is only served once `mgr.Start` runs, so a pod still waiting here fails its liveness probe anyway, and an explicit error says more in the logs than being killed mid-wait.
2. `ctrl.SetupSignalHandler` moves to the start of `Run` so the wait is interruptible, and setup checks the signal context between phases so a shutdown signal is not swallowed until `mgr.Start`.
3. `HasAPIResource` returns `(bool, error)`. Only a 404 on the group/version (not installed) or a Forbidden (RBAC, will not resolve by waiting) resolves to "absent"; anything else — connection refused, timeout, EOF, 5xx, throttling — is retried briefly and then surfaced as an error that aborts setup. All ~20 call sites propagate it, so a controller, a field index or a readiness check can no longer be silently disabled. A Forbidden is logged at error level with a distinct message so it is not misread as a missing CRD.
4. An authn/authz rejection of the reachability probe counts as the API server having answered: a hardened cluster may not grant the controller access to the probed endpoint, and that is no reason to hold up startup.
5. ReferenceGrant support is detected through the same path instead of a bare `RESTMapper` lookup, and skipped entirely when Gateway API is disabled.

**What an operator sees.** The failure mode changes from "the pod is Running but half of it is permanently dead" to "the pod exits with an explicit error and is restarted". If the API server is still unreachable after the wait budget, `Run` returns e.g. `give up waiting for the Kubernetes API server: dial tcp ...: connect: connection refused`, the process exits non-zero and the kubelet restarts it with the usual CrashLoopBackOff. Retrying does not stop — it moves from an in-process loop to the pod restart loop, which is where Kubernetes wants it.

Behavior for a genuinely absent optional CRD is unchanged: detection returns `false` immediately, without retrying, and the corresponding indexer/controller/watch is skipped as before.

Registering the indexes unconditionally is not an option: `IndexField` eagerly resolves the GVK through the RESTMapper, which errors when the CRD really is absent.

### Tests

`pkg/utils/k8s_test.go` covers the error classification, the detection contract against a real discovery client driven by `httptest` (kind served / kind missing / group-version absent / API server unavailable / forbidden), the retry budgets, and that the wait is interruptible mid-flight.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document? (n/a)
- [x] Is this PR backward compatible?