### PR TITLE
docs: improve Kubernetes Gateway API page SEO

### DIFF
--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -1,10 +1,12 @@
 ---
-title: Gateway API
+title: Kubernetes Gateway API Support
 keywords:
   - APISIX Ingress
   - Apache APISIX
   - Kubernetes Ingress
-  - Gateway API
+  - Kubernetes Gateway API
+  - K8s Gateway API
+description: Learn which Kubernetes Gateway API resources, API versions, and fields are supported by the APISIX Ingress Controller.
 ---
 <!--
 #
@@ -25,9 +27,9 @@ keywords:
 #
 -->
 
-Gateway API is dedicated to achieving expressive and scalable Kubernetes service networking through various custom resources.
+Kubernetes Gateway API provides portable, role-oriented resources for managing L4 and L7 traffic in Kubernetes. APISIX Ingress Controller watches supported Gateway API resources and translates them into Apache APISIX configuration.
 
-By supporting Gateway API, the APISIX Ingress controller can realize richer functions, including Gateway management, multi-cluster support, and other features. It is also possible to manage running instances of the APISIX gateway through Gateway API resource management.
+This page summarizes the resources, API versions, and fields that APISIX Ingress Controller supports. To create a route with Gateway API, follow [Configure Routes](../getting-started/configure-routes.md).
 
 ## Concepts
 
@@ -41,7 +43,7 @@ By supporting Gateway API, the APISIX Ingress controller can realize richer func
 - **UDPRoute**: Configures routing for UDP traffic.
 - **BackendTLSPolicy**: Specifies how a Gateway should validate TLS connections to its backends, including trusted certificate authorities and verification modes.
 
-## Gateway API Support Level
+## Supported Kubernetes Gateway API Resources
 
 | Resource         | Core Support Level  | Extended Support Level | Implementation-Specific Support Level | API Version |
 | ---------------- | ------------------- | ---------------------- | ------------------------------------- | ----------- |
@@ -57,7 +59,7 @@ By supporting Gateway API, the APISIX Ingress controller can realize richer func
 
 ## Examples
 
-For configuration examples, see the Gateway API tabs in [Configuration Examples](../reference/example.md).
+For configuration examples, see the Gateway API tabs in [Configuration Examples](../reference/example.md). For APISIX-specific extensions to Gateway API, see [APISIX Ingress Controller Resources](./resources.md#gateway-api-extensions).
 
 For a complete list of configuration options, refer to the [Gateway API Reference](https://gateway-api.sigs.k8s.io/reference/1.3/spec/). Be aware that some fields are not supported, or partially supported.
 


### PR DESCRIPTION
## Summary

- clarify the page title and metadata around Kubernetes Gateway API support
- replace the generic introduction with an APISIX Ingress Controller-specific overview
- improve discovery of supported resources, route configuration examples, and Gateway API extensions

## Validation

- `git diff --check`
- verified all added internal link targets and the `gateway-api-extensions` anchor
- verified frontmatter parsing and description length
- independent final-diff review: no blockers or actionable findings

Local markdownlint 0.48 only reports table-alignment findings that are already present on the base version; the repository CI uses markdownlint-cli 0.36.0.
