### PR TITLE
fix: accept whitespace-separated hmac-auth signed_headers and document the format

### DIFF
--- a/api/v2/apisixconsumer_types.go
+++ b/api/v2/apisixconsumer_types.go
@@ -164,6 +164,8 @@ type ApisixConsumerJwtAuthValue struct {
 // ApisixConsumerHMACAuth defines configuration for the HMAC authentication.
 type ApisixConsumerHMACAuth struct {
 	// SecretRef references a Kubernetes Secret containing the HMAC credentials.
+	// Unlike Value, the Secret stores signed_headers as a single string listing the
+	// header names separated by commas or whitespace, for example "X-Date, Host".
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
 	// Value specifies HMAC authentication credentials.
 	Value *ApisixConsumerHMACAuthValue `json:"value,omitempty" yaml:"value,omitempty"`

--- a/config/crd/bases/apisix.apache.org_apisixconsumers.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixconsumers.yaml
@@ -82,8 +82,10 @@ spec:
                     description: HMACAuth configures the HMAC authentication details.
                     properties:
                       secretRef:
-                        description: SecretRef references a Kubernetes Secret containing
-                          the HMAC credentials.
+                        description: |-
+                          SecretRef references a Kubernetes Secret containing the HMAC credentials.
+                          Unlike Value, the Secret stores signed_headers as a single string listing the
+                          header names separated by commas or whitespace, for example "X-Date, Host".
                         properties:
                           name:
                             default: ""

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -896,7 +896,7 @@ ApisixConsumerHMACAuth defines configuration for the HMAC authentication.
 
 | Field | Description |
 | --- | --- |
-| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials. |
+| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials.<br />Unlike Value, the Secret stores signed_headers as a single string listing the<br />header names separated by commas or whitespace, for example "X-Date, Host". |
 | `value` _[ApisixConsumerHMACAuthValue](#apisixconsumerhmacauthvalue)_ | Value specifies HMAC authentication credentials. |
 
 

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -896,7 +896,7 @@ ApisixConsumerHMACAuth defines configuration for the HMAC authentication.
 
 | Field | Description |
 | --- | --- |
-| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials.<br />Unlike Value, the Secret stores signed_headers as a single string listing the<br />header names separated by commas or whitespace, for example "X-Date, Host". |
+| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials. Unlike Value, the Secret stores signed_headers as a single string listing the header names separated by commas or whitespace, for example "X-Date, Host". |
 | `value` _[ApisixConsumerHMACAuthValue](#apisixconsumerhmacauthvalue)_ | Value specifies HMAC authentication credentials. |
 
 

--- a/internal/adc/translator/apisixconsumer.go
+++ b/internal/adc/translator/apisixconsumer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -320,14 +321,11 @@ func (t *Translator) translateConsumerHMACAuthPlugin(tctx *provider.TranslateCon
 		clockSkew = _hmacAuthClockSkewDefaultValue
 	}
 
-	// comma-separated header names, not raw bytes
+	// header names are RFC 7230 tokens, so a comma or any space is always a separator
 	signedHeadersRaw := sec.Data["signed_headers"]
-	var signedHeaders []string
-	for _, h := range strings.Split(string(signedHeadersRaw), ",") {
-		if h = strings.TrimSpace(h); h != "" {
-			signedHeaders = append(signedHeaders, h)
-		}
-	}
+	signedHeaders := strings.FieldsFunc(string(signedHeadersRaw), func(r rune) bool {
+		return r == ',' || unicode.IsSpace(r)
+	})
 
 	var keepHeader bool
 	keepHeaderRaw, ok := sec.Data["keep_headers"]

--- a/internal/adc/translator/apisixconsumer_test.go
+++ b/internal/adc/translator/apisixconsumer_test.go
@@ -33,52 +33,76 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 )
 
-func hmacConsumerWithSecret(name string) *apiv2.ApisixConsumer {
+func hmacConsumerWithSecret(secretName string) *apiv2.ApisixConsumer {
 	return &apiv2.ApisixConsumer{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
 		Spec: apiv2.ApisixConsumerSpec{
 			AuthParameter: &apiv2.ApisixConsumerAuthParameter{
 				HMACAuth: &apiv2.ApisixConsumerHMACAuth{
-					SecretRef: &corev1.LocalObjectReference{Name: name},
+					SecretRef: &corev1.LocalObjectReference{Name: secretName},
 				},
 			},
 		},
 	}
 }
 
-func TestTranslateApisixConsumer_HMACAuthSignedHeadersFromSecret(t *testing.T) {
-	translator := NewTranslator(logr.Discard(), "")
-	tctx := provider.NewDefaultTranslateContext(context.Background())
-	tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = &corev1.Secret{
-		Data: map[string][]byte{
-			"key_id":         []byte("my-key"),
-			"secret_key":     []byte("my-secret"),
-			"signed_headers": []byte("X-Date, Host"),
-		},
-	}
-
-	result, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
-	require.NoError(t, err)
-	require.Len(t, result.Consumers, 1)
-
-	cfg := result.Consumers[0].Plugins["hmac-auth"].(*adctypes.HMACAuthConsumerConfig)
-	require.Equal(t, []string{"X-Date", "Host"}, cfg.SignedHeaders)
+func hmacSecret(data map[string][]byte) *corev1.Secret {
+	data["key_id"] = []byte("my-key")
+	data["secret_key"] = []byte("my-secret")
+	return &corev1.Secret{Data: data}
 }
 
-func TestTranslateApisixConsumer_HMACAuthRejectsInvalidClockSkew(t *testing.T) {
-	translator := NewTranslator(logr.Discard(), "")
-	tctx := provider.NewDefaultTranslateContext(context.Background())
-	tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = &corev1.Secret{
-		Data: map[string][]byte{
-			"key_id":     []byte("my-key"),
-			"secret_key": []byte("my-secret"),
-			"clock_skew": []byte("3O0"), // typo: letter O
-		},
-	}
+func TestTranslateApisixConsumer_HMACAuthSignedHeadersFromSecret(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		raw      string
+		expected []string
+	}{
+		{name: "comma separated", raw: "X-Date,Host", expected: []string{"X-Date", "Host"}},
+		{name: "padding and empty entries", raw: " X-Date, , Host, ", expected: []string{"X-Date", "Host"}},
+		{name: "newline separated", raw: "X-Date\nHost", expected: []string{"X-Date", "Host"}},
+		{name: "space separated", raw: "X-Date Host", expected: []string{"X-Date", "Host"}},
+		{name: "single header", raw: "X-Date", expected: []string{"X-Date"}},
+		{name: "empty", raw: "", expected: []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			translator := NewTranslator(logr.Discard(), "")
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+			tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = hmacSecret(map[string][]byte{
+				"signed_headers": []byte(tc.raw),
+			})
 
-	_, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "clock_skew")
+			result, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
+			require.NoError(t, err)
+			require.Len(t, result.Consumers, 1)
+
+			cfg := result.Consumers[0].Plugins["hmac-auth"].(*adctypes.HMACAuthConsumerConfig)
+			require.Equal(t, tc.expected, cfg.SignedHeaders)
+		})
+	}
+}
+
+func TestTranslateApisixConsumer_HMACAuthRejectsUnparseableNumbers(t *testing.T) {
+	for _, tc := range []struct {
+		key string
+		raw string
+	}{
+		{key: "clock_skew", raw: "3O0"}, // typo: letter O
+		{key: "max_req_body", raw: "invalid"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			translator := NewTranslator(logr.Discard(), "")
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+			tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = hmacSecret(map[string][]byte{
+				tc.key: []byte(tc.raw),
+			})
+
+			_, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.key)
+			require.Contains(t, err.Error(), "default/hmac")
+		})
+	}
 }
 
 func TestTranslateApisixConsumer_UsesMetadataLabelsWithoutOverwritingControllerLabels(t *testing.T) {


### PR DESCRIPTION
Follow-up to #2809, which was merged with three review points still open.

### 1. `signed_headers` delimiter was an undocumented convention

#2809 made the Secret path split `signed_headers` on commas. As raised in review, that left a silent footgun: a newline- or space-separated value collapses into a single bogus header name, failing exactly as quietly as the byte-split bug that PR fixed.

Rather than only documenting the comma convention, this accepts commas **and** whitespace as separators. Header field-names are RFC 7230 tokens, so they can never legitimately contain a comma, space, tab or newline. Splitting on all of them is lossless, cannot mis-split a valid header name, and removes the failure class instead of signposting it. Comma remains the canonical form in the docs.

### 2. Documented the Secret-vs-Value format difference

The two paths necessarily differ (a Secret value is an opaque string, `Value` takes a native `[]string`). That is now stated on the `ApisixConsumerHMACAuth.SecretRef` field, with the CRD and API reference regenerated.

### 3. Applied a review suggestion that was marked resolved but never landed

The `hmacConsumerWithSecret` helper parameter was still named `name` despite being the SecretRef name; renamed to `secretName`.

### Tests

- `signed_headers` table now covers comma, newline, space, padding/empty entries, single-header and empty input.
- Adds the previously missing `max_req_body` parse-failure case, and asserts the error names the offending Secret (`default/hmac`) — behavior added in #2809 but never covered by a test.

### Behavior-change note for the changelog

Also flagged in the #2809 review and worth restating here: since #2809, a consumer whose Secret carries an unparseable `clock_skew` or `max_req_body` now **fails translation and stops syncing**, where it previously defaulted silently and synced. The failure is self-scoped to that consumer. Empty/absent values still take the default path.

Paired enterprise change: api7/api7-ingress-controller#436.