### PR TITLE
test: fix the broken TCPRoute e2e listener port and de-flake two stream/ingress specs

### DIFF
--- a/test/e2e/gatewayapi/tcproute.go
+++ b/test/e2e/gatewayapi/tcproute.go
@@ -34,8 +34,9 @@ import (
 
 var _ = Describe("TCPRoute E2E Test", Label("networking.k8s.io", "tcproute"), func() {
 	s := scaffold.NewDefaultScaffold()
-	Context("TCPRoute Base", func() {
-		var tcpGateway = `
+
+	// Shared by every TCPRoute context so the listener port cannot drift between them.
+	var tcpGateway = `
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -59,6 +60,7 @@ spec:
       name: apisix-proxy-config
 `
 
+	Context("TCPRoute Base", func() {
 		var tcpRoute = `
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
@@ -118,27 +120,6 @@ spec:
 	})
 
 	Context("TCPRoute With BackendTrafficPolicy", func() {
-		var tcpGateway = `
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: %s
-spec:
-  gatewayClassName: %s
-  listeners:
-  - name: tcp
-    protocol: TCP
-    port: 80
-    allowedRoutes:
-      kinds:
-      - kind: TCPRoute
-  infrastructure:
-    parametersRef:
-      group: apisix.apache.org
-      kind: GatewayProxy
-      name: apisix-proxy-config
-`
-
 		var tcpRoute = `
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
@@ -203,30 +184,6 @@ spec:
 	})
 
 	Context("TCPRoute With L4RoutePolicy", func() {
-		var tcpGateway = `
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: %s
-spec:
-  gatewayClassName: %s
-  listeners:
-  - name: tcp
-    protocol: TCP
-    # Must equal APISIX's physical stream_proxy TCP port: the e2e controller runs
-    # with listener_port_match_mode=auto, so sectionName targeting injects
-    # server_port from this listener; it must match the port connections arrive on.
-    port: 9100
-    allowedRoutes:
-      kinds:
-      - kind: TCPRoute
-  infrastructure:
-    parametersRef:
-      group: apisix.apache.org
-      kind: GatewayProxy
-      name: apisix-proxy-config
-`
-
 		var tcpRoute = `
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute

--- a/test/e2e/gatewayapi/tlsroute.go
+++ b/test/e2e/gatewayapi/tlsroute.go
@@ -20,6 +20,7 @@ package gatewayapi
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,17 +89,22 @@ spec:
 			s.ResourceApplied("TLSRoute", "tls-route", tlsRoute, 1)
 
 			client := s.NewAPISIXClientWithTLSProxy(host)
+			// TLSRoute is served by the stream subsystem through a port-forward
+			// tunnel, which needs the same headroom as the other stream specs
+			// (tcproute/udproute); the 30s default is too tight on a loaded runner.
 			s.RequestAssert(&scaffold.RequestAssert{
-				Client: client,
-				Method: http.MethodGet,
-				Path:   "/ip",
-				Check:  scaffold.WithExpectedStatus(http.StatusOK),
+				Client:  client,
+				Method:  http.MethodGet,
+				Path:    "/ip",
+				Check:   scaffold.WithExpectedStatus(http.StatusOK),
+				Timeout: time.Minute * 3,
 			})
 			s.RequestAssert(&scaffold.RequestAssert{
-				Client: client,
-				Method: http.MethodGet,
-				Path:   "/notfound",
-				Check:  scaffold.WithExpectedStatus(http.StatusNotFound),
+				Client:  client,
+				Method:  http.MethodGet,
+				Path:    "/notfound",
+				Check:   scaffold.WithExpectedStatus(http.StatusNotFound),
+				Timeout: time.Minute * 3,
 			})
 
 			Expect(s.DeleteResourceFromString(tlsRoute)).NotTo(HaveOccurred(), "deleting TLSRoute")
@@ -111,7 +117,8 @@ spec:
 					errMsg = reporter.Err().Error()
 				}
 				return errMsg
-			}).Should(ContainSubstring("EOF"), "should get EOF after deleting TLSRoute")
+			}).WithTimeout(time.Minute*3).
+				Should(ContainSubstring("EOF"), "should get EOF after deleting TLSRoute")
 		})
 	})
 })

--- a/test/e2e/ingress/ingress.go
+++ b/test/e2e/ingress/ingress.go
@@ -787,9 +787,14 @@ spec:
 			}).
 				WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusNotFound))
 
+			// The preceding Not Found is also satisfied while the route is being
+			// rebuilt, so this must retry instead of asserting once.
 			By("request the route with the correct vars should be OK")
-			s.NewAPISIXClient().GET("/get").WithHost("example.com").
-				WithHeader("X-HRP-Name", "http-route-policy-0").Expect().Status(http.StatusOK)
+			Eventually(func() int {
+				return s.NewAPISIXClient().GET("/get").WithHost("example.com").
+					WithHeader("X-HRP-Name", "http-route-policy-0").Expect().Raw().StatusCode
+			}).
+				WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
 
 			By("update the HTTPRoutePolicy")
 			err = s.CreateResourceFromStringWithNamespace(httpRoutePolicySpec1, s.Namespace())
@@ -803,8 +808,11 @@ spec:
 				WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusNotFound))
 
 			By("request with the new vars should be OK")
-			s.NewAPISIXClient().GET("/get").WithHost("example.com").
-				WithQuery("hrp_name", "http-route-policy-0").Expect().Status(http.StatusOK)
+			Eventually(func() int {
+				return s.NewAPISIXClient().GET("/get").WithHost("example.com").
+					WithQuery("hrp_name", "http-route-policy-0").Expect().Raw().StatusCode
+			}).
+				WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
 
 			By("update the HTTPRoutePolicy's targetRef")
 			err = s.CreateResourceFromStringWithNamespace(httpRoutePolicySpec2, s.Namespace())
@@ -827,8 +835,11 @@ spec:
 				WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusNotFound))
 
 			By("request the route with the correct vars should be OK")
-			s.NewAPISIXClient().GET("/get").WithHost("example.com").
-				WithHeader("X-HRP-Name", "http-route-policy-0").Expect().Status(http.StatusOK)
+			Eventually(func() int {
+				return s.NewAPISIXClient().GET("/get").WithHost("example.com").
+					WithHeader("X-HRP-Name", "http-route-policy-0").Expect().Raw().StatusCode
+			}).
+				WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
 
 			By("apply conflict HTTPRoutePolicy")
 			err = s.CreateResourceFromStringWithNamespace(httpRoutePolicySpec3, s.Namespace())


### PR DESCRIPTION
### Description

Gets the `APISIX E2E Test` job back to green.

**1. `TCPRoute With BackendTrafficPolicy` — deterministic failure on master**

Two PRs landed on the same day and merged cleanly as text but not semantically:

- #2830 added the `TCPRoute With BackendTrafficPolicy` context, whose Gateway listener uses `port: 80`.
- #2818 moved the TCPRoute e2e Gateway listeners to `9100` — APISIX's physical `stream_proxy` TCP port — because the e2e controller runs with `listener_port_match_mode=auto`, where `sectionName` targeting injects `server_port` from the matched listener. It was written before #2830 existed, so it only updated the two contexts present at the time.

The BackendTrafficPolicy context therefore produced a StreamRoute matching `server_port: 80` while connections arrive on `9100`, so the route never matched and the connection was reset (`tcproute.go:190`, `EOF`). The two sibling contexts in the same file already use `9100` and pass.

The manifest was byte-identical in all three contexts, so instead of patching the port in place this hoists it to a single definition shared by the whole `Describe`, which removes the drift entirely.

**2. `Test TLSRoute TLSRoute Base Basic` — intermittent**

TLSRoute is served by the stream subsystem through a port-forward tunnel to APISIX's TLS stream port — the same setup `tcproute.go` / `udproute.go` drive with a 3 minute budget. It was the only stream spec still on the 30s default, and on a loaded runner the first request after the sync can burn the whole window on `EOF`. Given the same headroom as its siblings.

**3. `Test Ingress HTTPRoutePolicy for Ingress HTTPRoutePolicy targetRef an Ingress` — intermittent**

The positive requests were asserted exactly once, immediately after an `Eventually` that waited for the *other* var set to return 404. That 404 is also satisfied while the route is being rebuilt, so the one-shot assertion could fire inside the same window and observe 404 for the vars that should match (`ingress.go:807`, expected `200 OK`, got `404 Not Found`). Those assertions now retry like the surrounding ones.

### Which issue(s) this PR fixes

Fixes the e2e failures on master.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)