### PR TITLE
feat: log why a resource is ignored when no IngressClass selects it

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1923,11 +1923,16 @@ func matchesIngressClassOrLog(c client.Client, log logr.Logger, obj client.Objec
 	case k8serrors.IsNotFound(err):
 		log.Info("ignoring the object: the referenced IngressClass does not exist",
 			"kind", kind, "object", key, "ingressClassName", ExtractIngressClass(obj))
-	default:
-		// the IngressClass belongs to another controller (or the lookup hit a
-		// transient error); this object is not ours to report on loudly
+	case errors.Is(err, errForeignIngressClass):
+		// the object belongs to another controller and is not ours to report
+		// on loudly
 		log.V(1).Info("ignoring the object: its IngressClass is not managed by this controller",
-			"kind", kind, "object", key, "ingressClassName", ExtractIngressClass(obj), "reason", err.Error())
+			"kind", kind, "object", key, "ingressClassName", ExtractIngressClass(obj))
+	default:
+		// an unexpected lookup failure is not an ownership verdict; the event
+		// is still dropped to keep the pre-existing admission semantics
+		log.Error(err, "failed to determine the IngressClass for the object; ignoring the event",
+			"kind", kind, "object", key, "ingressClassName", ExtractIngressClass(obj))
 	}
 	return false
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -79,6 +79,9 @@ const defaultIngressClassAnnotation = "ingressclass.kubernetes.io/is-default-cla
 
 var (
 	ErrNoMatchingListenerHostname = errors.New("no matching hostnames in listener")
+
+	errNoDefaultIngressClass = errors.New("no default ingress class found")
+	errForeignIngressClass   = errors.New("ingress class is not controlled by us")
 )
 
 var (
@@ -1737,7 +1740,7 @@ func FindMatchingIngressClassByName(ctx context.Context, c client.Client, log lo
 				return &ic, nil
 			}
 		}
-		return nil, errors.New("no default ingress class found")
+		return nil, errNoDefaultIngressClass
 	}
 
 	// Check if the specified ingress class is controlled by us
@@ -1750,7 +1753,7 @@ func FindMatchingIngressClassByName(ctx context.Context, c client.Client, log lo
 		return &ingressClass, nil
 	}
 
-	return nil, errors.New("ingress class is not controlled by us")
+	return nil, errForeignIngressClass
 }
 
 // distinctRequests distinct the requests
@@ -1886,10 +1889,12 @@ func GetGatewayProxyByGateway(ctx context.Context, r client.Client, gateway *gat
 
 func MatchesIngressClassPredicate(c client.Client, log logr.Logger) predicate.Funcs {
 	predicateFuncs := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return MatchesIngressClass(c, log, obj)
+		return matchesIngressClassOrLog(c, log, obj)
 	})
 	predicateFuncs.UpdateFunc = func(e event.UpdateEvent) bool {
-		return MatchesIngressClass(c, log, e.ObjectOld) || MatchesIngressClass(c, log, e.ObjectNew)
+		// the old object is checked silently so a fully filtered update is
+		// explained by a single log line for the new object
+		return MatchesIngressClass(c, log, e.ObjectOld) || matchesIngressClassOrLog(c, log, e.ObjectNew)
 	}
 	return predicateFuncs
 }
@@ -1897,6 +1902,34 @@ func MatchesIngressClassPredicate(c client.Client, log logr.Logger) predicate.Fu
 func MatchesIngressClass(c client.Client, log logr.Logger, obj client.Object) bool {
 	_, err := FindMatchingIngressClass(context.Background(), c, log, obj)
 	return err == nil
+}
+
+// matchesIngressClassOrLog reports whether obj is selected by an IngressClass
+// of this controller, and explains a negative answer in the log. It is meant
+// for watch predicates only: the list-mapping helpers iterate unrelated
+// objects on every event and must keep using the silent MatchesIngressClass.
+func matchesIngressClassOrLog(c client.Client, log logr.Logger, obj client.Object) bool {
+	_, err := FindMatchingIngressClass(context.Background(), c, log, obj)
+	if err == nil {
+		return true
+	}
+
+	kind := types.KindOf(obj)
+	key := client.ObjectKeyFromObject(obj).String()
+	switch {
+	case errors.Is(err, errNoDefaultIngressClass):
+		log.Info("ignoring the object: it has no spec.ingressClassName and no IngressClass of this controller is marked as default; it will not be reconciled until one of the two is set",
+			"kind", kind, "object", key)
+	case k8serrors.IsNotFound(err):
+		log.Info("ignoring the object: the referenced IngressClass does not exist",
+			"kind", kind, "object", key, "ingressClassName", ExtractIngressClass(obj))
+	default:
+		// the IngressClass belongs to another controller (or the lookup hit a
+		// transient error); this object is not ours to report on loudly
+		log.V(1).Info("ignoring the object: its IngressClass is not managed by this controller",
+			"kind", kind, "object", key, "ingressClassName", ExtractIngressClass(obj), "reason", err.Error())
+	}
+	return false
 }
 
 func ExtractIngressClass(obj client.Object) string {

--- a/internal/controller/utils_ingressclass_test.go
+++ b/internal/controller/utils_ingressclass_test.go
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	"github.com/apache/apisix-ingress-controller/internal/controller/config"
+	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
+)
+
+func buildIngressClassTestClient(t *testing.T, objs ...runtime.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, apiv2.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&networkingv1.IngressClass{}, indexer.IngressClass, indexer.IngressClassIndexFunc).
+		WithRuntimeObjects(objs...).
+		Build()
+}
+
+// capturingLogger records every log line emitted at the default verbosity;
+// V(1) and above are suppressed, mirroring the controller's default log level.
+func capturingLogger() (logr.Logger, *[]string) {
+	lines := &[]string{}
+	log := funcr.New(func(prefix, args string) {
+		*lines = append(*lines, args)
+	}, funcr.Options{})
+	return log, lines
+}
+
+func ourIngressClass(isDefault bool) *networkingv1.IngressClass {
+	ic := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "apisix"},
+		Spec:       networkingv1.IngressClassSpec{Controller: config.GetControllerName()},
+	}
+	if isDefault {
+		ic.Annotations = map[string]string{defaultIngressClassAnnotation: "true"}
+	}
+	return ic
+}
+
+func foreignIngressClass(name string) *networkingv1.IngressClass {
+	return &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       networkingv1.IngressClassSpec{Controller: "example.com/other-controller"},
+	}
+}
+
+func apisixRouteWithClass(ingressClassName string) *apiv2.ApisixRoute {
+	return &apiv2.ApisixRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-route", Namespace: "demo-ns"},
+		Spec:       apiv2.ApisixRouteSpec{IngressClassName: ingressClassName},
+	}
+}
+
+func joinedLines(lines *[]string) string {
+	return strings.Join(*lines, "\n")
+}
+
+// A CR without ingressClassName is silently dropped today when no IngressClass
+// of ours is marked default; the predicate must explain the drop in the log.
+func TestMatchesIngressClassPredicate_LogsWhenNoDefaultIngressClass(t *testing.T) {
+	c := buildIngressClassTestClient(t, ourIngressClass(false))
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	admitted := p.Create(event.CreateEvent{Object: apisixRouteWithClass("")})
+
+	require.False(t, admitted)
+	require.Len(t, *lines, 1, "exactly one log line must explain the skip")
+	require.Contains(t, joinedLines(lines), "demo-ns/demo-route")
+	require.Contains(t, joinedLines(lines), "ApisixRoute")
+	require.Contains(t, joinedLines(lines), "no spec.ingressClassName")
+	require.Contains(t, joinedLines(lines), "marked as default")
+}
+
+// Referencing an IngressClass that does not exist is a user typo the log must
+// surface.
+func TestMatchesIngressClassPredicate_LogsWhenIngressClassNotFound(t *testing.T) {
+	c := buildIngressClassTestClient(t, ourIngressClass(false))
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	admitted := p.Create(event.CreateEvent{Object: apisixRouteWithClass("no-such-class")})
+
+	require.False(t, admitted)
+	require.Len(t, *lines, 1, "exactly one log line must explain the skip")
+	require.Contains(t, joinedLines(lines), "demo-ns/demo-route")
+	require.Contains(t, joinedLines(lines), "no-such-class")
+}
+
+// A CR explicitly bound to another controller's IngressClass belongs to that
+// controller; it must stay quiet at the default log level.
+func TestMatchesIngressClassPredicate_SilentForForeignIngressClass(t *testing.T) {
+	c := buildIngressClassTestClient(t, ourIngressClass(false), foreignIngressClass("other"))
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	admitted := p.Create(event.CreateEvent{Object: apisixRouteWithClass("other")})
+
+	require.False(t, admitted)
+	require.Empty(t, *lines, "resources of other controllers must not be logged at the default level")
+}
+
+// Regression guard: matching resources are admitted without any log noise.
+func TestMatchesIngressClassPredicate_AdmitsMatchingClass(t *testing.T) {
+	c := buildIngressClassTestClient(t, ourIngressClass(false))
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	require.True(t, p.Create(event.CreateEvent{Object: apisixRouteWithClass("apisix")}))
+	require.Empty(t, *lines)
+}
+
+// Regression guard: the default-IngressClass fallback still admits CRs without
+// an explicit ingressClassName, without log noise.
+func TestMatchesIngressClassPredicate_AdmitsViaDefaultClass(t *testing.T) {
+	c := buildIngressClassTestClient(t, ourIngressClass(true))
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	require.True(t, p.Create(event.CreateEvent{Object: apisixRouteWithClass("")}))
+	require.Empty(t, *lines)
+}
+
+// An update whose old and new objects both miss must produce one line, not two.
+func TestMatchesIngressClassPredicate_UpdateLogsOnce(t *testing.T) {
+	c := buildIngressClassTestClient(t, ourIngressClass(false))
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	admitted := p.Update(event.UpdateEvent{
+		ObjectOld: apisixRouteWithClass(""),
+		ObjectNew: apisixRouteWithClass(""),
+	})
+
+	require.False(t, admitted)
+	require.Len(t, *lines, 1, "an update event must log the skip exactly once")
+}

--- a/internal/controller/utils_ingressclass_test.go
+++ b/internal/controller/utils_ingressclass_test.go
@@ -18,6 +18,8 @@
 package controller
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -30,6 +32,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -169,4 +172,32 @@ func TestMatchesIngressClassPredicate_UpdateLogsOnce(t *testing.T) {
 
 	require.False(t, admitted)
 	require.Len(t, *lines, 1, "an update event must log the skip exactly once")
+}
+
+// An unexpected lookup failure (not NotFound, not a foreign class) is not an
+// ownership verdict; it must be reported at Error level, not mislabeled.
+func TestMatchesIngressClassPredicate_UnexpectedLookupErrorIsLoud(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, apiv2.AddToScheme(scheme))
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&networkingv1.IngressClass{}, indexer.IngressClass, indexer.IngressClassIndexFunc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return errors.New("apiserver timeout")
+			},
+		}).
+		Build()
+	log, lines := capturingLogger()
+	p := MatchesIngressClassPredicate(c, log)
+
+	admitted := p.Create(event.CreateEvent{Object: apisixRouteWithClass("apisix")})
+
+	require.False(t, admitted, "admission semantics must not change on lookup errors")
+	require.Len(t, *lines, 1, "the lookup failure must be logged")
+	require.Contains(t, joinedLines(lines), "apiserver timeout")
+	require.Contains(t, joinedLines(lines), "demo-ns/demo-route")
+	require.NotContains(t, joinedLines(lines), "not managed by this controller",
+		"a lookup failure is not an ownership verdict and must not be mislabeled")
 }


### PR DESCRIPTION
### Type of change:

- [x] New feature provided

### What this PR does / why we need it:

A resource whose IngressClass does not select this controller is filtered out at the watch predicate, so it is dropped with no log, no event, and no status. Users cannot tell why their resource is never reconciled (see the `ingressClassName` part of #2756).

The shared predicate now logs why an object is ignored: at Info level when the resource is effectively orphaned (no `spec.ingressClassName` and no default IngressClass of this controller, or a referenced IngressClass that does not exist), and at `V(1)` when the IngressClass belongs to another controller, so multi-controller clusters are not spammed. Admission behavior is unchanged.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
