### PR TITLE
fix: stop requeueing ApisixConsumer forever after a successful delete

### DIFF
--- a/internal/controller/apisixconsumer_controller.go
+++ b/internal/controller/apisixconsumer_controller.go
@@ -73,6 +73,8 @@ func (r *ApisixConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				r.Log.Error(err, "failed to delete provider", "ApisixConsumer", utils.NamespacedName(ac))
 				return ctrl.Result{}, err
 			}
+			r.Log.Info("deleted apisix consumer", "ApisixConsumer", utils.NamespacedName(ac))
+			return ctrl.Result{}, nil
 		}
 		r.Log.Error(err, "failed to get ApisixConsumer", "request", req.NamespacedName)
 		return ctrl.Result{}, err

--- a/internal/controller/apisixconsumer_controller_test.go
+++ b/internal/controller/apisixconsumer_controller_test.go
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+const testConsumerNamespace = "default"
+
+// recordingProvider records the objects passed to Delete and can be told to fail.
+type recordingProvider struct {
+	deleted   []types.NamespacedName
+	deleteErr error
+}
+
+func (p *recordingProvider) Register(string, *http.ServeMux) {}
+
+func (p *recordingProvider) Update(context.Context, *provider.TranslateContext, client.Object) error {
+	return nil
+}
+
+func (p *recordingProvider) Delete(_ context.Context, obj client.Object) error {
+	p.deleted = append(p.deleted, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()})
+	return p.deleteErr
+}
+
+func (p *recordingProvider) Start(context.Context) error { return nil }
+
+func (p *recordingProvider) NeedLeaderElection() bool { return true }
+
+func newApisixConsumerReconciler(t *testing.T, cli client.Client, p provider.Provider) *ApisixConsumerReconciler {
+	t.Helper()
+
+	// A readiness manager with no registered GVKs becomes ready as soon as it is
+	// started. Readier.Done blocks on the started channel, so it must be started.
+	readier := readiness.NewReadinessManager(cli, logr.Discard())
+	require.NoError(t, readier.Start(context.Background()))
+
+	return &ApisixConsumerReconciler{
+		Client:   cli,
+		Scheme:   cli.Scheme(),
+		Log:      logr.Discard(),
+		Provider: p,
+		Readier:  readier,
+	}
+}
+
+func apisixConsumerScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv2.AddToScheme(scheme))
+	return scheme
+}
+
+// A deleted ApisixConsumer must be removed from the provider and then reported
+// as reconciled. Returning the NotFound error instead makes controller-runtime
+// treat the reconcile as failed and requeue it indefinitely with exponential
+// backoff, even though the delete succeeded.
+func TestApisixConsumerReconcile_DeletedObjectDoesNotRequeue(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(apisixConsumerScheme(t)).Build()
+	p := &recordingProvider{}
+	r := newApisixConsumerReconciler(t, cli, p)
+
+	key := types.NamespacedName{Namespace: testConsumerNamespace, Name: "gone"}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.Equal(t, []types.NamespacedName{key}, p.deleted)
+}
+
+// A provider failure must still surface, so the fix does not swallow real errors.
+func TestApisixConsumerReconcile_DeleteErrorIsReturned(t *testing.T) {
+	cli := fake.NewClientBuilder().WithScheme(apisixConsumerScheme(t)).Build()
+	p := &recordingProvider{deleteErr: errors.New("provider unavailable")}
+	r := newApisixConsumerReconciler(t, cli, p)
+
+	key := types.NamespacedName{Namespace: testConsumerNamespace, Name: "gone"}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider unavailable")
+}
+
+// A Get failure that is not NotFound must be returned, and must not be mistaken
+// for a deletion.
+func TestApisixConsumerReconcile_NonNotFoundGetErrorIsReturned(t *testing.T) {
+	cli := fake.NewClientBuilder().
+		WithScheme(apisixConsumerScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return k8serrors.NewInternalError(errors.New("boom"))
+			},
+		}).
+		Build()
+	p := &recordingProvider{}
+	r := newApisixConsumerReconciler(t, cli, p)
+
+	key := types.NamespacedName{Namespace: testConsumerNamespace, Name: "present"}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsInternalError(err), "want an internal error, got %v", err)
+	assert.Empty(t, p.deleted, "a non-NotFound Get error must not trigger a provider delete")
+}


### PR DESCRIPTION
### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Fixes #2849

When an `ApisixConsumer` is deleted, `Reconcile` gets a NotFound from the cache, synthesizes a minimal object and calls `Provider.Delete`. On the success path there is no return, so execution falls out of the `IsNotFound` block to the trailing `return ctrl.Result{}, err`, which hands back the captured NotFound error. controller-runtime sees a non-nil error, so it requeues the key indefinitely with exponential backoff even though the delete already succeeded. That matches the increasing intervals in the report.

The fix is to return after a successful delete, which is what every other reconciler already does.

The issue asks whether other controllers have the same problem. I checked all of them: there are 15 `Provider.Delete` call sites across 13 files in `internal/controller`, and every one is followed by `return ctrl.Result{}, nil` except `apisixconsumer_controller.go`. So this is the only affected reconciler and no wider change is needed.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document? (no user-facing behaviour or API change, so no doc update)
- [x] Is this PR backward compatible?

### Tests

`internal/controller/apisixconsumer_controller_test.go` adds three cases:

- `TestApisixConsumerReconcile_DeletedObjectDoesNotRequeue` is the regression guard. It asserts the reconcile succeeds, returns an empty `ctrl.Result`, and that the provider received the right key. With only the two production lines reverted it fails with `apisixconsumers.apisix.apache.org "gone" not found`, so it is not vacuous.
- `TestApisixConsumerReconcile_DeleteErrorIsReturned` proves a provider failure still propagates rather than being swallowed.
- `TestApisixConsumerReconcile_NonNotFoundGetErrorIsReturned` uses `interceptor.Funcs` to return an internal error from `Get` and asserts it is returned and does not trigger a spurious provider delete.

Verified locally:

- `go build ./...` clean
- `go test $(go list ./... | grep -v '/test/') -count=1` all pass
- `go vet ./internal/controller/` and `gofmt -l` clean
- `golangci-lint run ./internal/controller/...` reports no issues in the changed files

I did not run the envtest-backed `make test` or the e2e and conformance suites. This change touches no CRD, manifest, or API surface.
