### PR TITLE
fix(test): keep one recordingProvider stub so internal/controller builds

### DIFF
--- a/internal/controller/apisixconsumer_controller_test.go
+++ b/internal/controller/apisixconsumer_controller_test.go
@@ -41,8 +41,10 @@ import (
 
 const testConsumerNamespace = "default"
 
-// recordingProvider records the objects passed to Delete and can be told to fail.
+// recordingProvider records the objects passed to Update and Delete, and can be
+// told to fail a delete. Shared by the reconciler tests in this package.
 type recordingProvider struct {
+	updated   int
 	deleted   []types.NamespacedName
 	deleteErr error
 }
@@ -50,6 +52,7 @@ type recordingProvider struct {
 func (p *recordingProvider) Register(string, *http.ServeMux) {}
 
 func (p *recordingProvider) Update(context.Context, *provider.TranslateContext, client.Object) error {
+	p.updated++
 	return nil
 }
 

--- a/internal/controller/gateway_controller_publishservice_test.go
+++ b/internal/controller/gateway_controller_publishservice_test.go
@@ -19,7 +19,6 @@ package controller
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -41,23 +40,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 	"github.com/apache/apisix-ingress-controller/internal/controller/status"
-	"github.com/apache/apisix-ingress-controller/internal/provider"
 )
-
-// recordingProvider counts data plane pushes so tests can assert whether a
-// reconcile reached Provider.Update.
-type recordingProvider struct {
-	updated int
-}
-
-func (p *recordingProvider) Update(context.Context, *provider.TranslateContext, client.Object) error {
-	p.updated++
-	return nil
-}
-func (p *recordingProvider) Delete(context.Context, client.Object) error { return nil }
-func (p *recordingProvider) Start(context.Context) error                 { return nil }
-func (p *recordingProvider) NeedLeaderElection() bool                    { return false }
-func (p *recordingProvider) Register(string, *http.ServeMux)             {}
 
 type recordingUpdater struct {
 	updates []status.Update


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] CI/CD or Tests

### What this PR does / why we need it:

`internal/controller` does not build on master. #2846 and #2850 each added a provider stub
named `recordingProvider` to the package, and they landed independently:

- `internal/controller/apisixconsumer_controller_test.go:45`
- `internal/controller/gateway_controller_publishservice_test.go:49`

```console
$ go vet ./internal/controller/
vet: internal/controller/gateway_controller_publishservice_test.go:49:6: recordingProvider redeclared in this block
```

`go vet` runs in the unit test job, in `make lint`, and in the e2e jobs' image build, so this
turns every open pull request red — the e2e jobs never reach the test suite at all.

This keeps the ApisixConsumer stub, which records the objects passed to `Delete` and can be told
to fail, and gives it the `Update` counter the Gateway publishService tests use. No test
assertions change.

```console
$ go vet ./internal/controller/ && go test ./internal/controller/
ok  	github.com/apache/apisix-ingress-controller/internal/controller	0.649s
```

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases? — n/a, this only removes a duplicate test helper
- [ ] Have you modified the corresponding document? — n/a
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**

https://claude.ai/code/session_018uKEPFSzVot9nveU442tD8
