### PR TITLE
docs: describe how a wildcard Ingress hostname is matched

### DIFF
--- a/docs/en/latest/concepts/resources.md
+++ b/docs/en/latest/concepts/resources.md
@@ -44,6 +44,14 @@ The APISIX Ingress Controller continuously tracks matching EndpointSlice objects
 
 Ingress is a Kubernetes resource that manages external access to services within a cluster, typically HTTP and HTTPS traffic. It provides a way to define rules for routing external traffic to internal services.
 
+#### Wildcard hostnames
+
+A wildcard `spec.rules[].host` such as `*.example.com` is passed to APISIX unchanged and matched as a suffix, so it matches any number of leading labels: both `foo.example.com` and `bar.foo.example.com`.
+
+This is the same behavior as nginx, whose `server_name` documentation states that `*.example.org` matches `www.sub.example.org` as well, and therefore the same behavior as ingress-nginx. It is broader than the [Kubernetes Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards) describes, which covers a single DNS label.
+
+If a route must match exactly one label, match the hostname explicitly rather than relying on the wildcard. Note that Gateway API defines wildcard hostnames as a multi-label suffix match, so an `HTTPRoute` with `*.example.com` behaves the same way by specification.
+
 ## Gateway API
 
 Gateway API is an official Kubernetes project focused on L4 and L7 routing in Kubernetes. This project represents the next generation of Kubernetes Ingress, Load Balancing, and Service Mesh APIs.


### PR DESCRIPTION
### Type of change:

- [x] Documentation

### What this PR does / why we need it:

A wildcard `spec.rules[].host` such as `*.tenant.example.com` also matches `one.two.tenant.example.com`. Users expect it to cover a single label, because that is what the [Kubernetes Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards) describes, and report the multi-label match as a bug.

The controller passes `rule.Host` to the APISIX `hosts` field unchanged (`internal/adc/translator/ingress.go`, where `NormalizeHosts` only lowercases and de-duplicates), and APISIX matches it as a reversed-domain suffix.

This is not specific to APISIX and is not a regression. v1.8.4 does the same (`pkg/providers/ingress/translation/translator.go`, `route.Host = rule.Host`), and nginx documents the same semantics:

> An asterisk can match several name parts. The name `*.example.org` matches not only `www.example.org` but `www.sub.example.org` as well.

ingress-nginx emits `server_name *.example.org` directly, so it behaves identically. Narrowing the match would be a silent runtime break for anyone relying on it, with no apply-time signal, and would diverge from the most widely deployed Ingress implementation. Documenting it is the better trade.

Gateway API is unaffected either way: `sigs.k8s.io/gateway-api` specifies wildcard hostnames as a multi-label suffix match, so `HTTPRoute` is already correct.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible?