### PR TITLE
docs: explain how to enable WebSocket with an HTTPRoute

### DIFF
--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -90,3 +90,28 @@ The fields below are specified in the Gateway API specification but are either p
 | `spec.listeners[].tls.mode`                          | Partially supported  | `Terminate` is implemented; `Passthrough` is effectively unsupported for Gateway listeners.    |
 | `spec.listeners[].tls.frontendValidation`            | Partially supported  | Enables downstream (client) mTLS. `caCertificateRefs` may reference a `ConfigMap` (Gateway API Core support) or a `Secret` (implementation-specific) holding the CA certificate under the `ca.crt` key; clients are then required to present a certificate signed by one of the referenced CAs. |
 | `spec.addresses`                                     | Not supported        | Controller does not read or act on `spec.addresses`.                                           |
+
+## Proxying WebSocket
+
+An `HTTPRoute` has no field that enables WebSocket. The controller decides from the `appProtocol` of the Service port the route sends traffic to, so the Service is where the protocol is declared:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: websocket-service
+spec:
+  ports:
+  - name: ws
+    port: 80
+    targetPort: 8080
+    appProtocol: kubernetes.io/ws    # use kubernetes.io/wss for a TLS backend
+```
+
+Without it the route is proxied as ordinary HTTP: the upgrade request is answered with a normal `200` response instead of `101 Switching Protocols`, and the connection is never upgraded. Nothing in the `HTTPRoute` status reports this, because the route itself is valid.
+
+`appProtocol` also selects the upstream scheme: `kubernetes.io/ws` and `http` proxy over HTTP, `kubernetes.io/wss` and `https` proxy over HTTPS.
+
+The other resources declare it on the route instead. An `ApisixRoute` uses `spec.http[].websocket: true`, and an Ingress uses the [`k8s.apisix.apache.org/enable-websocket`](../reference/annotations.md#enable-websocket) annotation. An Ingress accepts either the annotation or the Service `appProtocol`.
+
+Two behaviors are worth knowing when verifying a change. Switching the backend Service or its endpoints only affects connections opened afterwards, and deleting the `HTTPRoute` stops new requests but does not terminate WebSocket connections that are already open.

--- a/docs/en/latest/reference/annotations.md
+++ b/docs/en/latest/reference/annotations.md
@@ -462,6 +462,8 @@ spec:
 
 The `k8s.apisix.apache.org/enable-websocket` annotation enables WebSocket support for an Ingress when set to `true`.
 
+Setting `appProtocol: kubernetes.io/ws` (or `kubernetes.io/wss`) on the backend Service port has the same effect and is the only way to enable WebSocket for an `HTTPRoute`. See [Proxying WebSocket](../concepts/gateway-api.md#proxying-websocket).
+
 For example:
 
 ```yaml


### PR DESCRIPTION
### Type of change:

- [x] Documentation

### What this PR does / why we need it:

There is no documented way to enable WebSocket with Gateway API, and the natural assumption, that an `HTTPRoute` proxying a WebSocket backend just works, produces a silent failure: the upgrade request is answered with a normal `200` instead of `101 Switching Protocols`, and nothing in the route status explains it because the route itself is valid.

The switch is `appProtocol` on the backend Service port. `translateBackendRef` reads it and sets `EnableWebsocket` when it is `kubernetes.io/ws` or `kubernetes.io/wss`, and `appProtocolToUpstreamScheme` uses the same value to pick the upstream scheme. Adding it to an existing Service is enough; the `HTTPRoute` does not change.

The three resources each declare it differently, which is the other half of the confusion:

| Resource | How WebSocket is enabled |
|---|---|
| `HTTPRoute` | Service port `appProtocol: kubernetes.io/ws` or `kubernetes.io/wss` |
| `ApisixRoute` | `spec.http[].websocket: true` |
| `Ingress` | `k8s.apisix.apache.org/enable-websocket` annotation, or the Service `appProtocol` |

This PR adds a "Proxying WebSocket" section to the Gateway API concept page covering all three, and cross-links it from the `enable-websocket` annotation reference. It also records two behaviors that come up when verifying a change: switching the backend only affects connections opened afterwards, and deleting the `HTTPRoute` does not terminate connections that are already open.

No behavior change.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible?