### PR TITLE
fix: pin a route to the scheme its listeners accept

### DIFF
--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -90,3 +90,13 @@ The fields below are specified in the Gateway API specification but are either p
 | `spec.listeners[].tls.mode`                          | Partially supported  | `Terminate` is implemented; `Passthrough` is effectively unsupported for Gateway listeners.    |
 | `spec.listeners[].tls.frontendValidation`            | Partially supported  | Enables downstream (client) mTLS. `caCertificateRefs` may reference a `ConfigMap` (Gateway API Core support) or a `Secret` (implementation-specific) holding the CA certificate under the `ca.crt` key; clients are then required to present a certificate signed by one of the referenced CAs. |
 | `spec.addresses`                                     | Not supported        | Controller does not read or act on `spec.addresses`.                                           |
+
+## HTTPS listeners and plaintext requests
+
+A route that attaches only to `HTTPS` listeners is pinned to the `https` scheme, so a plaintext request for the same hostname and path does not match it and falls through to whatever else is configured, or to `404`.
+
+The predicate is evaluated against the connection APISIX accepted, so it holds regardless of the port mapping in front of the data plane. This is what distinguishes it from [`listener_port_match_mode`](../reference/configuration-file.md#listener-port-matching), which pins a route to a listener port and can only isolate protocols when the Gateway's declared ports are the ports APISIX listens on.
+
+A route that also attaches to an `HTTP` listener is not pinned, because it is meant to serve both.
+
+The one deployment this does not fit is TLS terminated in front of APISIX, where the connection APISIX accepts is plaintext even though the client used HTTPS. Declare those listeners as `HTTP`, since the Gateway is not terminating TLS in that topology and the listener's `certificateRefs` would go unused.

--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -91,12 +91,14 @@ The fields below are specified in the Gateway API specification but are either p
 | `spec.listeners[].tls.frontendValidation`            | Partially supported  | Enables downstream (client) mTLS. `caCertificateRefs` may reference a `ConfigMap` (Gateway API Core support) or a `Secret` (implementation-specific) holding the CA certificate under the `ca.crt` key; clients are then required to present a certificate signed by one of the referenced CAs. |
 | `spec.addresses`                                     | Not supported        | Controller does not read or act on `spec.addresses`.                                           |
 
-## HTTPS listeners and plaintext requests
+## Listener protocol and the request scheme
 
-A route that attaches only to `HTTPS` listeners is pinned to the `https` scheme, so a plaintext request for the same hostname and path does not match it and falls through to whatever else is configured, or to `404`.
+A route answers only the schemes its listeners accept. When every listener a route attached to is `HTTPS`, the route is pinned to the `https` scheme, so a plaintext request for the same hostname and path does not match it. When they are all `HTTP`, it is pinned to `http`. A route attached to both is pinned to neither, because it is meant to serve both.
 
-The predicate is evaluated against the connection APISIX accepted, so it holds regardless of the port mapping in front of the data plane. This is what distinguishes it from [`listener_port_match_mode`](../reference/configuration-file.md#listener-port-matching), which pins a route to a listener port and can only isolate protocols when the Gateway's declared ports are the ports APISIX listens on.
+The predicate is evaluated against the connection APISIX accepted, so it holds regardless of the port mapping in front of the data plane. That is what distinguishes it from [`listener_port_match_mode`](../reference/configuration-file.md#listener-port-matching), which pins a route to a listener port and can only isolate protocols when the Gateway's declared ports are the ports APISIX listens on.
 
-A route that also attaches to an `HTTP` listener is not pinned, because it is meant to serve both.
+`TLS`, `TCP` and `UDP` listeners carry the L4 route kinds, which have no request scheme. A route is left unpinned if any of its listeners uses one of these.
 
 The one deployment this does not fit is TLS terminated in front of APISIX, where the connection APISIX accepts is plaintext even though the client used HTTPS. Declare those listeners as `HTTP`, since the Gateway is not terminating TLS in that topology and the listener's `certificateRefs` would go unused.
+
+This narrows which requests reach a route but does not amount to full Listener Isolation, an Extended Gateway API feature that also covers hostname overlap between listeners on the same port. `GatewayHTTPListenerIsolation` is not claimed.

--- a/internal/adc/translator/grpcroute.go
+++ b/internal/adc/translator/grpcroute.go
@@ -313,6 +313,15 @@ func (t *Translator) TranslateGRPCRoute(tctx *provider.TranslateContext, grpcRou
 			routes = append(routes, route)
 		}
 
+		// A route that attached only to HTTPS listeners must not answer plaintext
+		// requests for the same host and path. See the HTTPRoute translator for why
+		// neither hostname matching nor server_port covers this.
+		if listenersAllTerminateTLS(tctx.Listeners) {
+			for _, route := range routes {
+				addSchemeVar(route, apiv2.SchemeHTTPS)
+			}
+		}
+
 		// Hostname-less listener ports decide whether a server_port var is needed;
 		// hostname listeners are isolated by host, not port. When it is added, match
 		// on every targeted listener port so a route attached to both a hostname-less

--- a/internal/adc/translator/grpcroute.go
+++ b/internal/adc/translator/grpcroute.go
@@ -315,11 +315,7 @@ func (t *Translator) TranslateGRPCRoute(tctx *provider.TranslateContext, grpcRou
 
 		// A route answers only the schemes its listeners accept. See the HTTPRoute
 		// translator for why neither hostname matching nor server_port covers this.
-		if scheme := listenerScheme(tctx.Listeners); scheme != "" {
-			for _, route := range routes {
-				addSchemeVar(route, scheme)
-			}
-		}
+		t.pinRoutesToListenerScheme(tctx.Listeners, routes)
 
 		// Hostname-less listener ports decide whether a server_port var is needed;
 		// hostname listeners are isolated by host, not port. When it is added, match

--- a/internal/adc/translator/grpcroute.go
+++ b/internal/adc/translator/grpcroute.go
@@ -313,12 +313,11 @@ func (t *Translator) TranslateGRPCRoute(tctx *provider.TranslateContext, grpcRou
 			routes = append(routes, route)
 		}
 
-		// A route that attached only to HTTPS listeners must not answer plaintext
-		// requests for the same host and path. See the HTTPRoute translator for why
-		// neither hostname matching nor server_port covers this.
-		if listenersAllTerminateTLS(tctx.Listeners) {
+		// A route answers only the schemes its listeners accept. See the HTTPRoute
+		// translator for why neither hostname matching nor server_port covers this.
+		if scheme := listenerScheme(tctx.Listeners); scheme != "" {
 			for _, route := range routes {
-				addSchemeVar(route, apiv2.SchemeHTTPS)
+				addSchemeVar(route, scheme)
 			}
 		}
 

--- a/internal/adc/translator/grpcroute_test.go
+++ b/internal/adc/translator/grpcroute_test.go
@@ -192,7 +192,14 @@ func TestTranslateGRPCRouteServerPortVarsByMode(t *testing.T) {
 			got, err := translator.TranslateGRPCRoute(tctx, grpcRoute)
 			assert.NoError(t, err)
 			if assert.Len(t, got.Services, 1) && assert.Len(t, got.Services[0].Routes, 1) {
-				assert.Equal(t, tt.expected, got.Services[0].Routes[0].Vars)
+				// Every listener in this table is HTTP, so the route also carries the
+				// scheme predicate. TestTranslateHTTPRouteSchemeVar covers that on its own.
+				want := append(adctypes.Vars{{
+					{StrVal: "scheme"},
+					{StrVal: "=="},
+					{StrVal: "http"},
+				}}, tt.expected...)
+				assert.Equal(t, want, got.Services[0].Routes[0].Vars)
 			}
 		})
 	}

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -748,11 +748,7 @@ func (t *Translator) TranslateHTTPRoute(tctx *provider.TranslateContext, httpRou
 		// Nothing else enforces that: hostname matching cannot tell the two apart, and
 		// server_port only can when the Gateway's declared ports equal the ports
 		// APISIX listens on.
-		if scheme := listenerScheme(tctx.Listeners); scheme != "" {
-			for _, route := range routes {
-				addSchemeVar(route, scheme)
-			}
-		}
+		t.pinRoutesToListenerScheme(tctx.Listeners, routes)
 
 		// Hostname-less listener ports decide whether a server_port var is needed;
 		// hostname listeners are isolated by host, not port.

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -742,6 +742,16 @@ func (t *Translator) TranslateHTTPRoute(tctx *provider.TranslateContext, httpRou
 			routes = append(routes, route)
 		}
 
+		// A route that attached only to HTTPS listeners must not answer plaintext
+		// requests for the same host and path. Nothing else enforces that: hostname
+		// matching cannot tell the two apart, and server_port only can when the
+		// Gateway's declared ports equal the ports APISIX listens on.
+		if listenersAllTerminateTLS(tctx.Listeners) {
+			for _, route := range routes {
+				addSchemeVar(route, apiv2.SchemeHTTPS)
+			}
+		}
+
 		// Hostname-less listener ports decide whether a server_port var is needed;
 		// hostname listeners are isolated by host, not port.
 		listenerPorts := collectServerPortMatchPorts(tctx.Listeners)

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -742,13 +742,15 @@ func (t *Translator) TranslateHTTPRoute(tctx *provider.TranslateContext, httpRou
 			routes = append(routes, route)
 		}
 
-		// A route that attached only to HTTPS listeners must not answer plaintext
-		// requests for the same host and path. Nothing else enforces that: hostname
-		// matching cannot tell the two apart, and server_port only can when the
-		// Gateway's declared ports equal the ports APISIX listens on.
-		if listenersAllTerminateTLS(tctx.Listeners) {
+		// A route answers only the schemes its listeners accept: one attached only to
+		// HTTPS listeners must not answer plaintext requests for the same host and
+		// path, and one attached only to HTTP listeners must not answer TLS ones.
+		// Nothing else enforces that: hostname matching cannot tell the two apart, and
+		// server_port only can when the Gateway's declared ports equal the ports
+		// APISIX listens on.
+		if scheme := listenerScheme(tctx.Listeners); scheme != "" {
 			for _, route := range routes {
-				addSchemeVar(route, apiv2.SchemeHTTPS)
+				addSchemeVar(route, scheme)
 			}
 		}
 

--- a/internal/adc/translator/httproute_scheme_test.go
+++ b/internal/adc/translator/httproute_scheme_test.go
@@ -1,0 +1,142 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
+	"github.com/apache/apisix-ingress-controller/internal/controller/config"
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+var httpsSchemeVar = []adctypes.StringOrSlice{
+	{StrVal: "scheme"},
+	{StrVal: "=="},
+	{StrVal: "https"},
+}
+
+// A route attached only to HTTPS listeners must not answer plaintext requests for
+// the same host and path. $scheme is evaluated against the connection APISIX
+// accepted, so this holds whatever port mapping sits in front of the data plane,
+// and it is therefore independent of listener_port_match_mode.
+func TestTranslateHTTPRouteSchemeVar(t *testing.T) {
+	pathMatchType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/"
+
+	https := func(port int32, hostname *gatewayv1.Hostname) gatewayv1.Listener {
+		return gatewayv1.Listener{
+			Name:     "https",
+			Protocol: gatewayv1.HTTPSProtocolType,
+			Port:     gatewayv1.PortNumber(port),
+			Hostname: hostname,
+		}
+	}
+	plain := func(port int32) gatewayv1.Listener {
+		return gatewayv1.Listener{
+			Name:     "http",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     gatewayv1.PortNumber(port),
+		}
+	}
+
+	tests := []struct {
+		name       string
+		mode       config.ListenerPortMatchMode
+		listeners  []gatewayv1.Listener
+		wantScheme bool
+	}{
+		{
+			name:       "https listener pins the scheme with the default mode",
+			mode:       config.ListenerPortMatchModeOff,
+			listeners:  []gatewayv1.Listener{https(443, nil)},
+			wantScheme: true,
+		},
+		{
+			// The declared 443 need not be the port APISIX listens on, which is what
+			// makes server_port unusable here and the scheme var necessary.
+			name:       "https listener with a hostname is pinned too",
+			mode:       config.ListenerPortMatchModeOff,
+			listeners:  []gatewayv1.Listener{https(443, ptr.To(gatewayv1.Hostname("secure.example")))},
+			wantScheme: true,
+		},
+		{
+			name:       "a plaintext listener in the set keeps the route on both schemes",
+			mode:       config.ListenerPortMatchModeOff,
+			listeners:  []gatewayv1.Listener{https(443, nil), plain(80)},
+			wantScheme: false,
+		},
+		{
+			name:       "plaintext only is left alone",
+			mode:       config.ListenerPortMatchModeOff,
+			listeners:  []gatewayv1.Listener{plain(80)},
+			wantScheme: false,
+		},
+		{
+			name:       "no listener means nothing to pin",
+			mode:       config.ListenerPortMatchModeOff,
+			listeners:  nil,
+			wantScheme: false,
+		},
+		{
+			name:       "auto mode still pins the scheme",
+			mode:       config.ListenerPortMatchModeAuto,
+			listeners:  []gatewayv1.Listener{https(9443, nil)},
+			wantScheme: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+			tctx.Listeners = tt.listeners
+
+			httpRoute := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{{
+						Matches: []gatewayv1.HTTPRouteMatch{{
+							Path: &gatewayv1.HTTPPathMatch{Type: &pathMatchType, Value: &pathValue},
+						}},
+					}},
+				},
+			}
+
+			got, err := NewTranslator(logr.Discard(), tt.mode).TranslateHTTPRoute(tctx, httpRoute)
+			assert.NoError(t, err)
+			if !assert.Len(t, got.Services, 1) || !assert.Len(t, got.Services[0].Routes, 1) {
+				return
+			}
+			vars := got.Services[0].Routes[0].Vars
+			if tt.wantScheme {
+				assert.Contains(t, vars, httpsSchemeVar,
+					"a route attached only to HTTPS listeners must be pinned to the https scheme")
+				return
+			}
+			assert.NotContains(t, vars, httpsSchemeVar,
+				"a route that can be reached over plaintext must not be pinned to https")
+		})
+	}
+}

--- a/internal/adc/translator/httproute_scheme_test.go
+++ b/internal/adc/translator/httproute_scheme_test.go
@@ -32,16 +32,17 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 )
 
-var httpsSchemeVar = []adctypes.StringOrSlice{
-	{StrVal: "scheme"},
-	{StrVal: "=="},
-	{StrVal: "https"},
+func schemeVar(scheme string) []adctypes.StringOrSlice {
+	return []adctypes.StringOrSlice{
+		{StrVal: "scheme"},
+		{StrVal: "=="},
+		{StrVal: scheme},
+	}
 }
 
-// A route attached only to HTTPS listeners must not answer plaintext requests for
-// the same host and path. $scheme is evaluated against the connection APISIX
-// accepted, so this holds whatever port mapping sits in front of the data plane,
-// and it is therefore independent of listener_port_match_mode.
+// A route answers only the schemes its listeners accept. $scheme is evaluated
+// against the connection APISIX accepted, so this holds whatever port mapping sits
+// in front of the data plane, and it is independent of listener_port_match_mode.
 func TestTranslateHTTPRouteSchemeVar(t *testing.T) {
 	pathMatchType := gatewayv1.PathMatchPathPrefix
 	pathValue := "/"
@@ -63,48 +64,55 @@ func TestTranslateHTTPRouteSchemeVar(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		mode       config.ListenerPortMatchMode
-		listeners  []gatewayv1.Listener
-		wantScheme bool
+		name      string
+		mode      config.ListenerPortMatchMode
+		listeners []gatewayv1.Listener
+		// want is the scheme the route must be pinned to, or "" for no pinning.
+		want string
 	}{
 		{
-			name:       "https listener pins the scheme with the default mode",
-			mode:       config.ListenerPortMatchModeOff,
-			listeners:  []gatewayv1.Listener{https(443, nil)},
-			wantScheme: true,
+			name:      "https listener pins https with the default mode",
+			mode:      config.ListenerPortMatchModeOff,
+			listeners: []gatewayv1.Listener{https(443, nil)},
+			want:      "https",
 		},
 		{
 			// The declared 443 need not be the port APISIX listens on, which is what
 			// makes server_port unusable here and the scheme var necessary.
-			name:       "https listener with a hostname is pinned too",
-			mode:       config.ListenerPortMatchModeOff,
-			listeners:  []gatewayv1.Listener{https(443, ptr.To(gatewayv1.Hostname("secure.example")))},
-			wantScheme: true,
+			name:      "https listener with a hostname is pinned too",
+			mode:      config.ListenerPortMatchModeOff,
+			listeners: []gatewayv1.Listener{https(443, ptr.To(gatewayv1.Hostname("secure.example")))},
+			want:      "https",
 		},
 		{
-			name:       "a plaintext listener in the set keeps the route on both schemes",
-			mode:       config.ListenerPortMatchModeOff,
-			listeners:  []gatewayv1.Listener{https(443, nil), plain(80)},
-			wantScheme: false,
+			name:      "http listener pins http",
+			mode:      config.ListenerPortMatchModeOff,
+			listeners: []gatewayv1.Listener{plain(80)},
+			want:      "http",
 		},
 		{
-			name:       "plaintext only is left alone",
-			mode:       config.ListenerPortMatchModeOff,
-			listeners:  []gatewayv1.Listener{plain(80)},
-			wantScheme: false,
+			name:      "several listeners of the same protocol still pin it",
+			mode:      config.ListenerPortMatchModeOff,
+			listeners: []gatewayv1.Listener{https(443, nil), https(8443, ptr.To(gatewayv1.Hostname("secure.example")))},
+			want:      "https",
 		},
 		{
-			name:       "no listener means nothing to pin",
-			mode:       config.ListenerPortMatchModeOff,
-			listeners:  nil,
-			wantScheme: false,
+			name:      "a route attached to both protocols serves both",
+			mode:      config.ListenerPortMatchModeOff,
+			listeners: []gatewayv1.Listener{https(443, nil), plain(80)},
+			want:      "",
 		},
 		{
-			name:       "auto mode still pins the scheme",
-			mode:       config.ListenerPortMatchModeAuto,
-			listeners:  []gatewayv1.Listener{https(9443, nil)},
-			wantScheme: true,
+			name:      "no listener means nothing to pin",
+			mode:      config.ListenerPortMatchModeOff,
+			listeners: nil,
+			want:      "",
+		},
+		{
+			name:      "auto mode does not change the scheme predicate",
+			mode:      config.ListenerPortMatchModeAuto,
+			listeners: []gatewayv1.Listener{https(9443, nil)},
+			want:      "https",
 		},
 	}
 
@@ -130,13 +138,41 @@ func TestTranslateHTTPRouteSchemeVar(t *testing.T) {
 				return
 			}
 			vars := got.Services[0].Routes[0].Vars
-			if tt.wantScheme {
-				assert.Contains(t, vars, httpsSchemeVar,
-					"a route attached only to HTTPS listeners must be pinned to the https scheme")
+			if tt.want != "" {
+				assert.Contains(t, vars, schemeVar(tt.want),
+					"a route whose listeners agree on a scheme must be pinned to it")
 				return
 			}
-			assert.NotContains(t, vars, httpsSchemeVar,
-				"a route that can be reached over plaintext must not be pinned to https")
+			assert.NotContains(t, vars, schemeVar("http"))
+			assert.NotContains(t, vars, schemeVar("https"),
+				"a route whose listeners disagree must serve both schemes")
+		})
+	}
+}
+
+// The L4 protocols carry TLSRoute, TCPRoute and UDPRoute, which have no request
+// scheme. listenerScheme must refuse to pin those rather than guess, so that a
+// listener set containing one leaves the route alone.
+func TestListenerScheme(t *testing.T) {
+	listener := func(protocol gatewayv1.ProtocolType) gatewayv1.Listener {
+		return gatewayv1.Listener{Name: gatewayv1.SectionName(protocol), Protocol: protocol, Port: 443}
+	}
+
+	for name, tt := range map[string]struct {
+		listeners []gatewayv1.Listener
+		want      string
+	}{
+		"http":              {[]gatewayv1.Listener{listener(gatewayv1.HTTPProtocolType)}, "http"},
+		"https":             {[]gatewayv1.Listener{listener(gatewayv1.HTTPSProtocolType)}, "https"},
+		"tls":               {[]gatewayv1.Listener{listener(gatewayv1.TLSProtocolType)}, ""},
+		"tcp":               {[]gatewayv1.Listener{listener(gatewayv1.TCPProtocolType)}, ""},
+		"udp":               {[]gatewayv1.Listener{listener(gatewayv1.UDPProtocolType)}, ""},
+		"https beside tls":  {[]gatewayv1.Listener{listener(gatewayv1.HTTPSProtocolType), listener(gatewayv1.TLSProtocolType)}, ""},
+		"http beside https": {[]gatewayv1.Listener{listener(gatewayv1.HTTPProtocolType), listener(gatewayv1.HTTPSProtocolType)}, ""},
+		"none":              {nil, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, listenerScheme(tt.listeners))
 		})
 	}
 }

--- a/internal/adc/translator/httproute_scheme_test.go
+++ b/internal/adc/translator/httproute_scheme_test.go
@@ -47,19 +47,19 @@ func TestTranslateHTTPRouteSchemeVar(t *testing.T) {
 	pathMatchType := gatewayv1.PathMatchPathPrefix
 	pathValue := "/"
 
-	https := func(port int32, hostname *gatewayv1.Hostname) gatewayv1.Listener {
+	https := func(port gatewayv1.PortNumber, hostname *gatewayv1.Hostname) gatewayv1.Listener {
 		return gatewayv1.Listener{
 			Name:     "https",
 			Protocol: gatewayv1.HTTPSProtocolType,
-			Port:     gatewayv1.PortNumber(port),
+			Port:     port,
 			Hostname: hostname,
 		}
 	}
-	plain := func(port int32) gatewayv1.Listener {
+	plain := func(port gatewayv1.PortNumber) gatewayv1.Listener {
 		return gatewayv1.Listener{
 			Name:     "http",
 			Protocol: gatewayv1.HTTPProtocolType,
-			Port:     gatewayv1.PortNumber(port),
+			Port:     port,
 		}
 	}
 

--- a/internal/adc/translator/httproute_test.go
+++ b/internal/adc/translator/httproute_test.go
@@ -225,7 +225,14 @@ func TestTranslateHTTPRouteServerPortVarsByMode(t *testing.T) {
 			got, err := translator.TranslateHTTPRoute(tctx, httpRoute)
 			assert.NoError(t, err)
 			if assert.Len(t, got.Services, 1) && assert.Len(t, got.Services[0].Routes, 1) {
-				assert.Equal(t, tt.expected, got.Services[0].Routes[0].Vars)
+				// Every listener in this table is HTTP, so the route also carries the
+				// scheme predicate. TestTranslateHTTPRouteSchemeVar covers that on its own.
+				want := append(adctypes.Vars{{
+					{StrVal: "scheme"},
+					{StrVal: "=="},
+					{StrVal: "http"},
+				}}, tt.expected...)
+				assert.Equal(t, want, got.Services[0].Routes[0].Vars)
 			}
 		})
 	}

--- a/internal/adc/translator/translator.go
+++ b/internal/adc/translator/translator.go
@@ -22,6 +22,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 )
 
@@ -85,19 +86,32 @@ func allListenerPorts(listeners []gatewayv1.Listener) map[int32]struct{} {
 	return ports
 }
 
-// listenersAllTerminateTLS reports whether every listener the route attached to
-// terminates TLS. Only then can the route be pinned to the https scheme: a route
-// that also attaches to a plaintext listener must keep matching plaintext.
-func listenersAllTerminateTLS(listeners []gatewayv1.Listener) bool {
-	if len(listeners) == 0 {
-		return false
-	}
+// listenerScheme returns the request scheme shared by every listener the route
+// attached to, or "" when they disagree, when there are none, or when any of
+// them is a protocol that carries no request scheme.
+//
+// Only an unambiguous answer pins the route. A route attached to both an HTTP and
+// an HTTPS listener is meant to serve both, and a listener protocol that has no
+// scheme at all - TLS, TCP, UDP, which carry the L4 route kinds - leaves the
+// route alone rather than being guessed at.
+func listenerScheme(listeners []gatewayv1.Listener) string {
+	scheme := ""
 	for _, listener := range listeners {
-		if listener.Protocol != gatewayv1.HTTPSProtocolType {
-			return false
+		var current string
+		switch listener.Protocol {
+		case gatewayv1.HTTPProtocolType:
+			current = apiv2.SchemeHTTP
+		case gatewayv1.HTTPSProtocolType:
+			current = apiv2.SchemeHTTPS
+		default:
+			return ""
 		}
+		if scheme != "" && scheme != current {
+			return ""
+		}
+		scheme = current
 	}
-	return true
+	return scheme
 }
 
 // addSchemeVar pins a route to the scheme of the connection APISIX accepted.

--- a/internal/adc/translator/translator.go
+++ b/internal/adc/translator/translator.go
@@ -85,6 +85,36 @@ func allListenerPorts(listeners []gatewayv1.Listener) map[int32]struct{} {
 	return ports
 }
 
+// listenersAllTerminateTLS reports whether every listener the route attached to
+// terminates TLS. Only then can the route be pinned to the https scheme: a route
+// that also attaches to a plaintext listener must keep matching plaintext.
+func listenersAllTerminateTLS(listeners []gatewayv1.Listener) bool {
+	if len(listeners) == 0 {
+		return false
+	}
+	for _, listener := range listeners {
+		if listener.Protocol != gatewayv1.HTTPSProtocolType {
+			return false
+		}
+	}
+	return true
+}
+
+// addSchemeVar pins a route to the scheme of the connection APISIX accepted.
+//
+// Unlike server_port this holds whatever port mapping sits in front of the data
+// plane, because $scheme reflects the connection itself rather than a number the
+// Gateway declared. It is therefore independent of listener_port_match_mode,
+// which exists to pin a route to a listener port and cannot isolate protocols
+// unless the declared ports happen to match the ones APISIX listens on.
+func addSchemeVar(route *adctypes.Route, scheme string) {
+	route.Vars = append(route.Vars, []adctypes.StringOrSlice{
+		{StrVal: "scheme"},
+		{StrVal: "=="},
+		{StrVal: scheme},
+	})
+}
+
 // shouldInjectServerPortVars decides whether to pin the route to the matched
 // listener port(s) via a server_port predicate.
 //

--- a/internal/adc/translator/translator.go
+++ b/internal/adc/translator/translator.go
@@ -114,6 +114,18 @@ func listenerScheme(listeners []gatewayv1.Listener) string {
 	return scheme
 }
 
+// pinRoutesToListenerScheme pins the routes of one rule to the scheme their
+// listeners accept, when the listeners agree on one.
+func (t *Translator) pinRoutesToListenerScheme(listeners []gatewayv1.Listener, routes []*adctypes.Route) {
+	scheme := listenerScheme(listeners)
+	if scheme == "" {
+		return
+	}
+	for _, route := range routes {
+		addSchemeVar(route, scheme)
+	}
+}
+
 // addSchemeVar pins a route to the scheme of the connection APISIX accepted.
 //
 // Unlike server_port this holds whatever port mapping sits in front of the data

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -186,7 +186,10 @@ spec:
 			s.ResourceApplied("HTTPRoute", "httpbin", fmt.Sprintf(exactRouteByGet, gatewayName), 1)
 
 			By("access dataplane to check the HTTPRoute")
+			// The Gateway has only an HTTPS listener, so the route is pinned to the
+			// https scheme and is reached over TLS, not on the plaintext port.
 			s.RequestAssert(&scaffold.RequestAssert{
+				Client:   s.NewAPISIXHttpsClient("api6.com"),
 				Method:   "GET",
 				Path:     "/get",
 				Host:     "api6.com",
@@ -195,11 +198,20 @@ spec:
 				Interval: time.Second * 2,
 			})
 
+			By("the same request must not be served over plaintext")
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/get",
+				Host:   "api6.com",
+				Check:  scaffold.WithExpectedStatus(404),
+			})
+
 			By("delete HTTPRoute")
 			err := s.DeleteResourceFromString(fmt.Sprintf(exactRouteByGet, gatewayName))
 			Expect(err).NotTo(HaveOccurred(), "deleting HTTPRoute")
 
 			s.RequestAssert(&scaffold.RequestAssert{
+				Client: s.NewAPISIXHttpsClient("api6.com"),
 				Method: "GET",
 				Path:   "/get",
 				Host:   "api6.com",
@@ -2545,7 +2557,10 @@ spec:
 		})
 		It("HTTPS backend", func() {
 			s.ResourceApplied("HTTPRoute", "nginx", fmt.Sprintf(httproute, s.Namespace()), 1)
+			// beforeEachHTTPS builds a Gateway with only an HTTPS listener, so the
+			// route is reached over TLS rather than on the plaintext port.
 			s.RequestAssert(&scaffold.RequestAssert{
+				Client: s.NewAPISIXHttpsClient("api6.com"),
 				Method: "GET",
 				Path:   "/get",
 				Host:   "api6.com",

--- a/test/e2e/scaffold/adc.go
+++ b/test/e2e/scaffold/adc.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/api7/gopkg/pkg/log"
 	"go.uber.org/zap"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	"github.com/apache/apisix-ingress-controller/internal/adc/translator"
@@ -196,6 +196,9 @@ func (a *adcDataplaneResource) dumpResources(ctx context.Context) (*translator.T
 		return nil, err
 	}
 
+	// sigs.k8s.io/yaml converts to JSON first, so types with a custom
+	// UnmarshalJSON decode correctly. gopkg.in/yaml does not call it, and fails on
+	// adc.StringOrSlice, which every route var is built from.
 	var resources adctypes.Resources
 	if err := yaml.Unmarshal(yamlData, &resources); err != nil {
 		return nil, err


### PR DESCRIPTION
### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

An HTTPRoute attached only to an `HTTPS` listener, via `sectionName: https`, still answers plaintext requests for the same hostname and path. The TLS handshake succeeds on 443 and the same request succeeds unencrypted on 80, reaching the same backend. The reverse holds too: a route attached only to an `HTTP` listener is served on the TLS port.

Nothing in the translation prevents either. Hostname matching cannot tell the listeners apart, since the hostname is the same. The only existing mechanism is the `server_port` route variable behind `listener_port_match_mode`, and it does not fit this job:

- It is `off` by default, so out of the box there is no isolation at all.
- Turning it on is not enough. `server_port` is evaluated against the port APISIX accepted the connection on, not the port the Gateway declares. A Service mapping 443 to a data plane listening on 9443 is the normal deployment, and there the injected `server_port == 443` matches nothing, so the route stops serving on **both** protocols. Getting isolation requires renumbering the Gateway listeners to the data plane's physical ports, which contradicts what `spec.listeners[].port` means.
- `collectServerPortMatchPorts` skips listeners that set a `hostname`, so a route attached only to such a listener gets no predicate in any mode. That is deliberate and right for its own purpose, but it means the most common HTTPS listener shape, one with a hostname bound to its certificate, has no isolation available at all.

This PR derives the scheme from the listener set and pins the route to it:

```json
"vars": [["scheme", "==", "https"]]
```

`$scheme` reflects the connection APISIX accepted rather than a number the Gateway declared, so it holds whatever port mapping sits in front of the data plane, and it works with the default configuration. It is orthogonal to `listener_port_match_mode`, which keeps its own job of pinning a route to a listener port. The mechanism is the same one `addServerPortVars` already uses, so the data plane needs nothing new.

`listenerScheme` returns a scheme only when every listener the route attached to agrees:

| Listeners the route attached to | Predicate |
|---|---|
| all `HTTPS` | `scheme == https` |
| all `HTTP` | `scheme == http` |
| a mix of `HTTP` and `HTTPS` | none, the route is meant to serve both |
| any `TLS`, `TCP` or `UDP` | none |
| none | none |

The L4 protocols carry TLSRoute, TCPRoute and UDPRoute, which have no request scheme, so a listener set containing one leaves the route unpinned rather than guessed at. Those translators are untouched in any case: they build `StreamRoute`s with their own `server_port` field and never reach this code. `TestListenerScheme` asserts it directly.

Applies to HTTPRoute and GRPCRoute.

### Where this sits in the spec

Gateway API v1.6 calls this Listener Isolation and makes it **Extended**, at SHOULD strength:

> Note that, for all distinct Listeners, requests SHOULD match at most one Listener. [...] Implementations that do not support Listener Isolation MUST clearly document this, and MUST NOT claim support for the `GatewayHTTPListenerIsolation` feature.

So the current behavior is not a hard violation, and `GatewayHTTPListenerIsolation` is correctly absent from `SUPPORTED_EXTENDED_FEATURES`. This PR does not add it either: full Listener Isolation also covers hostname overlap between listeners on the same port, which `filterHostnames` does not implement. The documentation says so rather than overclaiming.

### The case this does not fit

TLS terminated in front of APISIX, where the connection APISIX accepts is plaintext even though the client used HTTPS. `$scheme` is then `http` and an HTTPS-pinned route would not match.

In that topology the Gateway is not terminating TLS, so the listener's `certificateRefs` are unused and the listener should be declared `HTTP` -- under which the route is pinned to `http` and matches. The documentation says so. It is worth a reviewer's attention because it is the one way this change can take traffic down rather than protect it.

### Blast radius, which is not symmetric

The two directions are not equally risky and a reviewer may want to treat them differently:

- Pinning `https` affects only routes deliberately bound to an HTTPS listener, and it closes a data exposure: an HTTPS-only route answering plaintext.
- Pinning `http` affects nearly every route, since an HTTP-only Gateway is the common case. It closes a stricter-isolation gap rather than an exposure: the traffic that stops matching was encrypted.

I implemented both because isolation reads both ways, but dropping the `http` direction is a two-line change if the risk is judged not worth it, and so is gating the whole thing behind a configuration field. Happy to do either.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible?

Not backward compatible, deliberately: a route stops answering the scheme its listeners do not accept. That is the fix.

Tests: `internal/adc/translator/httproute_scheme_test.go` covers each row of the table above through a full translation, plus `TestListenerScheme` on the protocol mapping itself. The two existing `server_port` tables now assert the scheme predicate alongside what they already checked, since every listener in them is HTTP.
