### PR TITLE
ci: cancel superseded runs for the remaining PR workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,9 @@ on:
       - 1.8.0
   schedule:
     - cron: '25 5 * * 5'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,9 @@ on:
     branches:
       - master
       - 1.8.0
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,6 +24,9 @@ on:
   pull_request:
     branches:
       - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   golangci:

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -26,6 +26,9 @@ on:
     branches:
       - master
       - 1.8.0
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-license:

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -26,6 +26,10 @@ on:
     branches:
       - master
       - 1.8.0
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -24,6 +24,10 @@ on:
   pull_request:
     branches:
       - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   misspell:
     name: runner / misspell

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,10 @@ on:
     branches:
       - master
       - 1.8.0
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/yamllint-checker.yml
+++ b/.github/workflows/yamllint-checker.yml
@@ -26,6 +26,10 @@ on:
     branches:
       - master
       - 1.8.0
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Twelve workflows run on every pull request push, but only four of them
(`apisix-e2e-test`, `apisix-conformance-test`, `benchmark-test`,
`kustomize-checker`) declare a concurrency group. The other eight keep every
superseded run alive, so a rebase or a follow-up commit leaves the previous
run's jobs queued and competing for the shared Apache Actions runner pool.

Queueing here is already the dominant cost. In a recent sample, a PR pushed at
23:17 UTC did not get a single job scheduled until 00:33 UTC. `spell-checker`,
which executes in seconds, took 76 minutes wall clock, all of it in the queue.
Every job in that batch started inside the same 40-second window, which is what
capacity being released in bulk looks like.

This PR adds the same concurrency group already used by the heavy workflows to:

- `codeql-analysis.yml`
- `dependency-review.yml`
- `golangci-lint.yml`
- `license-checker.yml`
- `lint-checker.yml`
- `spell-checker.yml`
- `unit-test.yml`
- `yamllint-checker.yml`

`push-docker.yaml`, `release-drafter.yml` and `stale.yml` are deliberately left
unchanged. They are not pull-request triggered, and cancelling them in progress
could drop an image push or a release draft update.

The group key is `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`,
identical to the existing four, so runs are only ever cancelled by a newer run
of the same workflow on the same PR or branch.

### Which issue(s) this PR fixes

Reduces runner contention on the shared Apache Actions pool. No functional
change to the controller.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
