### PR TITLE
ci: remove e2e on adc-node port

### DIFF
--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -30,16 +30,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ADC_VERSION: dev
   ADC_RUST_VERSION: "0.30.2"
 
 jobs:
   e2e-test:
     strategy:
       matrix:
-        adc_impl:
-        - node
-        - rust
         provider_type:
         - apisix-standalone
         - apisix
@@ -59,11 +55,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.26"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "*"
 
       - name: Install kind
         run: |
@@ -95,19 +86,7 @@ jobs:
         run: |
           make install
 
-      - name: Setup adc (node)
-        if: ${{ env.ADC_VERSION == 'dev' && matrix.adc_impl == 'node' }}
-        run: |
-          docker create --name adc-temp ghcr.io/api7/adc:dev
-          # main.cjs lives in the image's WORKDIR, not at the container root,
-          # and docker cp resolves a relative SRC_PATH against the root.
-          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
-          docker rm adc-temp
-          node $(pwd)/adc.js -v
-          echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV
-
       - name: Setup adc (rust)
-        if: ${{ matrix.adc_impl == 'rust' }}
         run: |
           curl -fsSL -o adc.tar.gz "https://github.com/api7/adc/releases/download/v${{ env.ADC_RUST_VERSION }}/adc_rust_${{ env.ADC_RUST_VERSION }}_linux_amd64.tar.gz"
           tar -xzf adc.tar.gz adc
@@ -142,12 +121,6 @@ jobs:
           fi
 
   disable-gateway-api:
-    strategy:
-      matrix:
-        adc_impl:
-        - node
-        - rust
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -159,11 +132,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.26"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "*"
 
       - name: Install kind
         run: |
@@ -191,19 +159,7 @@ jobs:
         run: |
           make kind-load-images
 
-      - name: Setup adc (node)
-        if: ${{ env.ADC_VERSION == 'dev' && matrix.adc_impl == 'node' }}
-        run: |
-          docker create --name adc-temp ghcr.io/api7/adc:dev
-          # main.cjs lives in the image's WORKDIR, not at the container root,
-          # and docker cp resolves a relative SRC_PATH against the root.
-          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
-          docker rm adc-temp
-          node $(pwd)/adc.js -v
-          echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV
-
       - name: Setup adc (rust)
-        if: ${{ matrix.adc_impl == 'rust' }}
         run: |
           curl -fsSL -o adc.tar.gz "https://github.com/api7/adc/releases/download/v${{ env.ADC_RUST_VERSION }}/adc_rust_${{ env.ADC_RUST_VERSION }}_linux_amd64.tar.gz"
           tar -xzf adc.tar.gz adc


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

Remove the E2E tests for the ADC Node.js version to reduce the backlog and queue of CI tasks.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
