### PR TITLE
feat: support HTTPRoute path redirects

### DIFF
--- a/api/adc/types.go
+++ b/api/adc/types.go
@@ -697,9 +697,11 @@ type RequestMirror struct {
 
 // RedirectConfig is the rule config for redirect plugin.
 type RedirectConfig struct {
-	HttpToHttps bool   `json:"http_to_https,omitempty" yaml:"http_to_https,omitempty"`
-	URI         string `json:"uri,omitempty" yaml:"uri,omitempty"`
-	RetCode     int    `json:"ret_code,omitempty" yaml:"ret_code,omitempty"`
+	HttpToHttps       bool     `json:"http_to_https,omitempty" yaml:"http_to_https,omitempty"`
+	URI               string   `json:"uri,omitempty" yaml:"uri,omitempty"`
+	RegexURI          []string `json:"regex_uri,omitempty" yaml:"regex_uri,omitempty"`
+	RetCode           int      `json:"ret_code,omitempty" yaml:"ret_code,omitempty"`
+	AppendQueryString bool     `json:"append_query_string,omitempty" yaml:"append_query_string,omitempty"`
 }
 
 const (

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -20,6 +20,7 @@ package translator
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -52,7 +53,7 @@ func (t *Translator) fillPluginsFromHTTPRouteFilters(
 		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
 			t.fillPluginFromHTTPRequestHeaderFilter(plugins, filter.RequestHeaderModifier)
 		case gatewayv1.HTTPRouteFilterRequestRedirect:
-			t.fillPluginFromHTTPRequestRedirectFilter(plugins, filter.RequestRedirect)
+			t.fillPluginFromHTTPRequestRedirectFilter(plugins, filter.RequestRedirect, matches)
 		case gatewayv1.HTTPRouteFilterRequestMirror:
 			t.fillPluginFromHTTPRequestMirrorFilter(plugins, namespace, filter.RequestMirror, apiv2.SchemeHTTP)
 		case gatewayv1.HTTPRouteFilterURLRewrite:
@@ -117,42 +118,34 @@ func (t *Translator) fillPluginFromURLRewriteFilter(plugins adctypes.Plugins, ur
 		case gatewayv1.FullPathHTTPPathModifier:
 			plugin.RewriteTarget = *urlRewrite.Path.ReplaceFullPath
 		case gatewayv1.PrefixMatchHTTPPathModifier:
-			prefixPaths := make([]string, 0, len(matches))
-			for _, match := range matches {
-				if match.Path == nil || match.Path.Type == nil || *match.Path.Type != gatewayv1.PathMatchPathPrefix {
-					continue
-				}
-				prefixPaths = append(prefixPaths, *match.Path.Value)
-			}
-			if len(prefixPaths) == 0 || urlRewrite.Path.ReplacePrefixMatch == nil {
-				break
-			}
-			prefixGroup := "(" + strings.Join(prefixPaths, "|") + ")"
-			replaceTarget := *urlRewrite.Path.ReplacePrefixMatch
-			// Handle ReplacePrefixMatch path rewrite
-			// If replaceTarget == "/", special handling is required to avoid
-			// producing double slashes or empty paths.
-			var regexPattern, regexTarget string
-			if replaceTarget == "/" {
-				// Match either "/prefix" or "/prefix/<remainder>"
-				// Pattern captures the remainder (if any) without a leading slash.
-				// Template reconstructs "/" + remainder, resulting in:
-				//   /prefix/three → /three
-				//   /prefix       → /
-				regexPattern = "^" + prefixGroup + "(?:/(.*))?$"
-				regexTarget = "/" + "$2"
-			} else {
-				// Match either "/prefix" or "/prefix/<remainder>"
-				// Pattern captures the remainder (including leading slash) as $2.
-				// Template appends it to replaceTarget:
-				//   /prefix/one/two → /one/two
-				//   /prefix/one     → /one
-				regexPattern = "^" + prefixGroup + "(/.*)?$"
-				regexTarget = replaceTarget + "$2"
-			}
-			plugin.RewriteTargetRegex = []string{regexPattern, regexTarget}
+			plugin.RewriteTargetRegex = buildPrefixMatchRegex(
+				*matches[0].Path.Value,
+				*urlRewrite.Path.ReplacePrefixMatch,
+			)
 		}
 	}
+}
+
+func buildPrefixMatchRegex(matchPrefix, replacePrefix string) []string {
+	matchPrefix = strings.TrimSuffix(matchPrefix, "/")
+	replacePrefix = strings.TrimSuffix(replacePrefix, "/")
+	if matchPrefix == "" {
+		matchPrefix = "/"
+	}
+
+	if matchPrefix == "/" {
+		regexTarget := "/$1"
+		if replacePrefix != "" {
+			regexTarget = replacePrefix + "/$1"
+		}
+		return []string{"^/(.*)$", regexTarget}
+	}
+
+	quotedPrefix := regexp.QuoteMeta(matchPrefix)
+	if replacePrefix == "" {
+		return []string{"^" + quotedPrefix + "(?:/(.*))?$", "/$1"}
+	}
+	return []string{"^" + quotedPrefix + "(/.*)?$", replacePrefix + "$1"}
 }
 
 func (t *Translator) fillPluginFromHTTPCORSFilter(plugins adctypes.Plugins, cors *gatewayv1.HTTPCORSFilter) {
@@ -287,7 +280,7 @@ func (t *Translator) fillPluginFromHTTPRequestMirrorFilter(plugins adctypes.Plug
 	plugin.Host = host
 }
 
-func (t *Translator) fillPluginFromHTTPRequestRedirectFilter(plugins adctypes.Plugins, reqRedirect *gatewayv1.HTTPRequestRedirectFilter) {
+func (t *Translator) fillPluginFromHTTPRequestRedirectFilter(plugins adctypes.Plugins, reqRedirect *gatewayv1.HTTPRequestRedirectFilter, matches []gatewayv1.HTTPRouteMatch) {
 	pluginName := adctypes.PluginRedirect
 	obj := plugins[pluginName]
 
@@ -316,12 +309,40 @@ func (t *Translator) fillPluginFromHTTPRequestRedirectFilter(plugins adctypes.Pl
 	}
 
 	if reqRedirect.Port != nil {
-		uri = fmt.Sprintf("%s://%s:%d$request_uri", scheme, hostname, int(*reqRedirect.Port))
+		uri = fmt.Sprintf("%s://%s:%d", scheme, hostname, int(*reqRedirect.Port))
 	} else {
-		uri = fmt.Sprintf("%s://%s$request_uri", scheme, hostname)
+		uri = fmt.Sprintf("%s://%s", scheme, hostname)
 	}
+
 	plugin.RetCode = code
-	plugin.URI = uri
+	if reqRedirect.Path == nil {
+		plugin.URI = uri + "$request_uri"
+		return
+	}
+
+	switch reqRedirect.Path.Type {
+	case gatewayv1.FullPathHTTPPathModifier:
+		if reqRedirect.Path.ReplaceFullPath != nil {
+			plugin.URI = uri + *reqRedirect.Path.ReplaceFullPath
+			plugin.AppendQueryString = true
+		}
+	case gatewayv1.PrefixMatchHTTPPathModifier:
+		plugin.RegexURI = buildPrefixMatchRegex(
+			*matches[0].Path.Value,
+			*reqRedirect.Path.ReplacePrefixMatch,
+		)
+		if reqRedirect.Hostname != nil {
+			locationPrefix := "//" + hostname
+			if reqRedirect.Scheme != nil {
+				locationPrefix = scheme + "://" + hostname
+			}
+			if reqRedirect.Port != nil {
+				locationPrefix += fmt.Sprintf(":%d", int(*reqRedirect.Port))
+			}
+			plugin.RegexURI[1] = locationPrefix + plugin.RegexURI[1]
+		}
+		plugin.AppendQueryString = true
+	}
 }
 
 func (t *Translator) fillHTTPRoutePoliciesForHTTPRoute(tctx *provider.TranslateContext, routes []*adctypes.Route, rule gatewayv1.HTTPRouteRule) {

--- a/internal/adc/translator/httproute_redirect_test.go
+++ b/internal/adc/translator/httproute_redirect_test.go
@@ -1,0 +1,247 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+func TestTranslateHTTPRouteRequestRedirectPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		match    gatewayv1.HTTPPathMatch
+		redirect gatewayv1.HTTPRequestRedirectFilter
+		expected *adctypes.RedirectConfig
+	}{
+		{
+			name: "redirect without path keeps request URI",
+			match: gatewayv1.HTTPPathMatch{
+				Type:  ptr.To(gatewayv1.PathMatchExact),
+				Value: ptr.To("/headers"),
+			},
+			redirect: gatewayv1.HTTPRequestRedirectFilter{
+				Scheme:     ptr.To("https"),
+				Hostname:   ptr.To(gatewayv1.PreciseHostname("example.org")),
+				Port:       ptr.To(gatewayv1.PortNumber(8443)),
+				StatusCode: ptr.To(301),
+			},
+			expected: &adctypes.RedirectConfig{
+				URI:     "https://example.org:8443$request_uri",
+				RetCode: 301,
+			},
+		},
+		{
+			name: "replace full path",
+			match: gatewayv1.HTTPPathMatch{
+				Type:  ptr.To(gatewayv1.PathMatchExact),
+				Value: ptr.To("/my-path"),
+			},
+			redirect: gatewayv1.HTTPRequestRedirectFilter{
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:            gatewayv1.FullPathHTTPPathModifier,
+					ReplaceFullPath: ptr.To("/my-path/"),
+				},
+				StatusCode: ptr.To(307),
+			},
+			expected: &adctypes.RedirectConfig{
+				URI:               "$scheme://$host/my-path/",
+				RetCode:           307,
+				AppendQueryString: true,
+			},
+		},
+		{
+			name: "replace path prefix",
+			match: gatewayv1.HTTPPathMatch{
+				Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+				Value: ptr.To("/original-prefix"),
+			},
+			redirect: gatewayv1.HTTPRequestRedirectFilter{
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: ptr.To("/replacement-prefix"),
+				},
+			},
+			expected: &adctypes.RedirectConfig{
+				RegexURI:          []string{"^/original-prefix(/.*)?$", "/replacement-prefix$1"},
+				RetCode:           302,
+				AppendQueryString: true,
+			},
+		},
+		{
+			name: "replace path prefix with root",
+			match: gatewayv1.HTTPPathMatch{
+				Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+				Value: ptr.To("/original-prefix"),
+			},
+			redirect: gatewayv1.HTTPRequestRedirectFilter{
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: ptr.To("/"),
+				},
+			},
+			expected: &adctypes.RedirectConfig{
+				RegexURI:          []string{"^/original-prefix(?:/(.*))?$", "/$1"},
+				RetCode:           302,
+				AppendQueryString: true,
+			},
+		},
+		{
+			name: "replace path prefix and hostname",
+			match: gatewayv1.HTTPPathMatch{
+				Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+				Value: ptr.To("/path-and-host"),
+			},
+			redirect: gatewayv1.HTTPRequestRedirectFilter{
+				Hostname: ptr.To(gatewayv1.PreciseHostname("example.org")),
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: ptr.To("/replacement-prefix"),
+				},
+			},
+			expected: &adctypes.RedirectConfig{
+				RegexURI:          []string{"^/path-and-host(/.*)?$", "//example.org/replacement-prefix$1"},
+				RetCode:           302,
+				AppendQueryString: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "redirect", Namespace: "default"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{{
+						Matches: []gatewayv1.HTTPRouteMatch{{Path: &tt.match}},
+						Filters: []gatewayv1.HTTPRouteFilter{{
+							Type:            gatewayv1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &tt.redirect,
+						}},
+					}},
+				},
+			}
+
+			result, err := NewTranslator(logr.Discard(), "").TranslateHTTPRoute(
+				provider.NewDefaultTranslateContext(context.Background()),
+				route,
+			)
+			require.NoError(t, err)
+			require.Len(t, result.Services, 1)
+
+			plugin, ok := result.Services[0].Plugins[adctypes.PluginRedirect].(*adctypes.RedirectConfig)
+			require.True(t, ok)
+			assert.Equal(t, tt.expected, plugin)
+		})
+	}
+}
+
+func TestRedirectConfigPathFieldsJSON(t *testing.T) {
+	data, err := json.Marshal(&adctypes.RedirectConfig{
+		RegexURI:          []string{"^/old(/.*)?$", "/new$1"},
+		RetCode:           302,
+		AppendQueryString: true,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"regex_uri": ["^/old(/.*)?$", "/new$1"],
+		"ret_code": 302,
+		"append_query_string": true
+	}`, string(data))
+}
+
+func TestBuildPrefixMatchRegex(t *testing.T) {
+	tests := []struct {
+		name          string
+		matchPrefix   string
+		replacePrefix string
+		requestPath   string
+		expectedPath  string
+	}{
+		{
+			name:          "replaces prefix and keeps remainder",
+			matchPrefix:   "/old",
+			replacePrefix: "/new",
+			requestPath:   "/old/child",
+			expectedPath:  "/new/child",
+		},
+		{
+			name:          "ignores trailing slashes in configured prefixes",
+			matchPrefix:   "/old/",
+			replacePrefix: "/new/",
+			requestPath:   "/old/child",
+			expectedPath:  "/new/child",
+		},
+		{
+			name:          "replaces an exact prefix without adding a slash",
+			matchPrefix:   "/old",
+			replacePrefix: "/new/",
+			requestPath:   "/old",
+			expectedPath:  "/new",
+		},
+		{
+			name:          "replaces prefix with root",
+			matchPrefix:   "/old",
+			replacePrefix: "/",
+			requestPath:   "/old/child",
+			expectedPath:  "/child",
+		},
+		{
+			name:          "empty replacement keeps a valid root path",
+			matchPrefix:   "/old",
+			replacePrefix: "",
+			requestPath:   "/old",
+			expectedPath:  "/",
+		},
+		{
+			name:          "replaces the root prefix",
+			matchPrefix:   "/",
+			replacePrefix: "/new",
+			requestPath:   "/child",
+			expectedPath:  "/new/child",
+		},
+		{
+			name:          "quotes regular expression characters in match prefix",
+			matchPrefix:   "/v1.0/(users)+",
+			replacePrefix: "/new",
+			requestPath:   "/v1.0/(users)+/child",
+			expectedPath:  "/new/child",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regexURI := buildPrefixMatchRegex(tt.matchPrefix, tt.replacePrefix)
+			require.Len(t, regexURI, 2)
+			re := regexp.MustCompile(regexURI[0])
+			assert.Equal(t, tt.expectedPath, re.ReplaceAllString(tt.requestPath, regexURI[1]))
+		})
+	}
+}

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -1918,6 +1918,56 @@ spec:
         statusCode: 301
 `
 
+		var fullPathRedirect = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: %s
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - httpbin.example
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /test
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /test/
+        statusCode: 307
+`
+
+		var prefixPathRedirect = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: %s
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - httpbin.example
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /old-path
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /new-path/
+        statusCode: 302
+`
+
 		var replacePrefixMatch = `
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -2257,6 +2307,38 @@ spec:
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(http.StatusMovedPermanently),
 					scaffold.WithExpectedHeader("Location", "http://httpbin.org/headers"),
+				},
+				Timeout:  time.Second * 30,
+				Interval: time.Second * 2,
+			})
+
+			By("update HTTPRoute with a full path redirect")
+			s.ResourceApplied("HTTPRoute", "httpbin", fmt.Sprintf(fullPathRedirect, s.Namespace(), s.Namespace()), 3)
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/test",
+				Host:   "httpbin.example",
+				Query:  map[string]any{"source": "gateway-api"},
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(http.StatusTemporaryRedirect),
+					scaffold.WithExpectedHeader("Location", "http://httpbin.example/test/?source=gateway-api"),
+				},
+				Timeout:  time.Second * 30,
+				Interval: time.Second * 2,
+			})
+
+			By("update HTTPRoute with a prefix path redirect")
+			s.ResourceApplied("HTTPRoute", "httpbin", fmt.Sprintf(prefixPathRedirect, s.Namespace(), s.Namespace()), 4)
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/old-path/child",
+				Host:   "httpbin.example",
+				Query:  map[string]any{"source": "gateway-api"},
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(http.StatusFound),
+					scaffold.WithExpectedHeader("Location", "/new-path/child?source=gateway-api"),
 				},
 				Timeout:  time.Second * 30,
 				Interval: time.Second * 2,


### PR DESCRIPTION
### Type of change:

- [x] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

This PR adds support for path redirects in Gateway API `HTTPRoute` `RequestRedirect` filters.

Previously, `requestRedirect.path` was ignored and the APISIX redirect plugin always used the original `$request_uri`. A redirect intended to change the path could therefore redirect the request back to itself, resulting in a "Too many redirects" error.

This change:

- Supports `ReplaceFullPath` using the APISIX redirect plugin's `uri` field.
- Supports `ReplacePrefixMatch` using the `regex_uri` field while preserving the unmatched path suffix.
- Preserves the original query string after replacing the path.
- Reuses the prefix replacement logic shared with `URLRewrite`.
- Preserves the existing behavior when no path replacement is configured.
- Adds unit and e2e coverage for full-path redirects, prefix redirects, hostname replacement, and query-string preservation.

No documentation was changed because this implements the existing Gateway API `RequestRedirect` contract and does not introduce controller-specific configuration.

Fixes #2857

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible?